### PR TITLE
feat: add make deps target for dependency management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,14 @@ tidy:
 	@echo "$(BLUE)Tidying dependencies...$(NC)"
 	$(GO) mod tidy
 
+## Download and verify dependencies
+.PHONY: deps
+deps:
+	@echo "$(BLUE)Downloading dependencies...$(NC)"
+	$(GO) mod download
+	$(GO) mod verify
+	@echo "$(GREEN)✓ Dependencies downloaded and verified.$(NC)"
+
 # Update dependencies
 .PHONY: update-deps
 update-deps:
@@ -230,6 +238,7 @@ help:
 	@echo ""
 	@echo "$(BLUE)Dependencies:$(NC)"
 	@echo "  tidy            Tidy go.mod dependencies"
+	@echo "  deps            Download and verify dependencies"
 	@echo "  update-deps     Update all dependencies"
 	@echo "  tools           Install dev tools (gofumpt, golangci-lint)"
 	@echo ""


### PR DESCRIPTION
## Summary
- Add `deps` Makefile target that runs `go mod download` and `go mod verify` to download and verify all module dependencies
- Add `deps` entry to the `make help` output under the Dependencies section

Closes #44

## Test plan
- [x] `make deps` runs successfully, downloading and verifying all modules
- [x] `make help` shows the new `deps` target under Dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)