### PR TITLE
feat: create docs/ directory with API, testing, and standards guides

### DIFF
--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -1,0 +1,40 @@
+# Google Play Android Publisher API Notes
+
+## API Reference
+
+- **REST Reference**: https://developers.google.com/android-publisher/api-ref/rest
+- **Overview**: https://developers.google.com/android-publisher
+
+## Edit Lifecycle
+
+All metadata changes go through an edit workflow:
+
+1. **Create edit** — `edits.insert()` returns an edit ID
+2. **Make changes** — listings, tracks, images, etc. within the edit
+3. **Validate** — `edits.validate()` checks for errors
+4. **Commit** — `edits.commit()` applies changes atomically
+5. **Delete** — `edits.delete()` discards uncommitted changes
+
+Edits expire after a period of inactivity. Always commit or delete when done.
+
+## Common Patterns
+
+- Package name (applicationId) is required for almost every API call
+- Track names: `internal`, `alpha`, `beta`, `production`, and custom tracks
+- Image types: `icon`, `featureGraphic`, `phoneScreenshots`, `sevenInchScreenshots`, `tenInchScreenshots`, `tvScreenshots`, `wearScreenshots`
+- Release status values: `draft`, `inProgress`, `halted`, `completed`
+
+## Rate Limits
+
+The API uses quota-based rate limiting. Default quotas are generous for typical usage. Use exponential backoff on 429 responses.
+
+## Common Error Codes
+
+| Code | Meaning |
+|------|---------|
+| 400 | Invalid request (check field values) |
+| 401 | Authentication failed (check service account) |
+| 403 | Insufficient permissions |
+| 404 | Resource not found (check package name, edit ID) |
+| 409 | Conflict (concurrent edit, stale data) |
+| 429 | Rate limited (back off and retry) |

--- a/docs/GO_STANDARDS.md
+++ b/docs/GO_STANDARDS.md
@@ -1,0 +1,49 @@
+# Go Standards
+
+## Error Handling
+
+Wrap errors with context:
+```go
+return fmt.Errorf("listing tracks: %w", err)
+```
+
+## CLI Conventions
+
+- **Explicit flags**: `--package`, `--output`, `--edit` (no single-letter aliases)
+- **JSON-first output**: minified JSON by default, `--output table` or `--output markdown` for humans
+- **No interactive prompts**: use `--confirm` for destructive operations
+- **Pagination**: `--paginate` fetches all pages automatically
+
+## Command Structure
+
+Commands use [ffcli](https://github.com/peterbourgon/ff):
+
+```go
+func MyCommand() *ffcli.Command {
+    fs := flag.NewFlagSet("mycommand", flag.ExitOnError)
+    // register flags...
+    return &ffcli.Command{
+        Name:       "mycommand",
+        ShortUsage: "gplay mycommand [flags]",
+        ShortHelp:  "Brief description.",
+        FlagSet:    fs,
+        UsageFunc:  shared.DefaultUsageFunc,
+        Exec:       execFunc,
+    }
+}
+```
+
+## Naming Conventions
+
+- Command packages: `internal/cli/<command>/`
+- Exported command constructor: `FooCommand() *ffcli.Command`
+- Test files: `<name>_test.go` in the same package
+- Integration tests: `<name>_integration_test.go` with build tag
+
+## Code Organization
+
+- `internal/cli/` — command implementations
+- `internal/cli/shared/` — shared utilities (flags, timeouts, output)
+- `internal/playclient/` — Google Play API client wrapper
+- `internal/output/` — output formatting (JSON, table, markdown)
+- `internal/config/` — configuration management

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,35 @@
+# Testing Guide
+
+## Running Tests
+
+```bash
+make test                  # Unit tests with race detector
+make test-integration      # Integration tests (requires credentials)
+make test-coverage         # Unit tests with coverage report
+```
+
+## Test Types
+
+### Unit Tests
+Standard `_test.go` files. Run offline, no credentials needed. Use table-driven tests.
+
+### Integration Tests
+Files with `//go:build integration` tag. Require real API credentials. Also call `testutil.SkipUnlessIntegration(t)` as a safety net.
+
+### CLI Tests
+Test command-line behavior by verifying flag parsing, output format, and error messages. Use `bytes.Buffer` for capturing stdout/stderr.
+
+## Test Helpers (`internal/testutil`)
+
+- `SkipUnlessIntegration(t)` — skip unless `GPLAY_INTEGRATION_TEST=1`
+- `IsolateConfig(t)` — isolated config directory for tests
+- `MockServiceAccount(t)` — fake service account JSON file
+- `RequireEnv(t, key)` — skip if env var not set
+
+## Writing New Tests
+
+1. Use `t.Helper()` in all helper functions
+2. Use `t.Cleanup()` instead of manual defer
+3. Use `t.Setenv()` for environment variable changes (auto-restored)
+4. Follow table-driven test pattern for multiple cases
+5. Test error messages written to stderr, not just error types


### PR DESCRIPTION
## Summary
- Add `docs/API_NOTES.md` with Google Play Android Publisher API reference, edit lifecycle, common patterns, rate limits, and error codes
- Add `docs/TESTING.md` with test running instructions, test types (unit/integration/CLI), test helpers, and conventions
- Add `docs/GO_STANDARDS.md` with error handling, CLI conventions, command structure, naming conventions, and code organization

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)