### PR TITLE
feat: add pre-commit git hooks with make install-hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running pre-commit checks..."
+
+# Format check
+echo "  Checking formatting..."
+make format 2>/dev/null
+if ! git diff --exit-code --quiet; then
+    echo ""
+    echo "ERROR: Files were reformatted by gofumpt. The following files changed:"
+    git diff --name-only
+    echo ""
+    echo "Please stage the formatting changes and try again."
+    exit 1
+fi
+
+# Lint check
+echo "  Running linter..."
+if ! make lint 2>/dev/null; then
+    echo ""
+    echo "ERROR: Linting failed. Please fix the issues above and try again."
+    exit 1
+fi
+
+echo "Pre-commit checks passed!"

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,19 @@ security:
 		echo "$(YELLOW)govulncheck not found. Install with: go install golang.org/x/vuln/cmd/govulncheck@latest$(NC)"; \
 	fi
 
+# Git hooks
+.PHONY: install-hooks uninstall-hooks
+
+## Install git pre-commit hooks
+install-hooks:
+	git config core.hooksPath .githooks
+	@echo "$(GREEN)✓ Git hooks installed. Pre-commit hook is now active.$(NC)"
+
+## Uninstall git hooks
+uninstall-hooks:
+	git config --unset core.hooksPath
+	@echo "$(GREEN)✓ Git hooks uninstalled.$(NC)"
+
 # Help
 .PHONY: help
 help:
@@ -243,6 +256,8 @@ help:
 	@echo "  run             Build and run (use ARGS= for arguments)"
 	@echo "  completions     Generate shell completion scripts"
 	@echo "  dev             format + lint + test + build"
+	@echo "  install-hooks   Install git pre-commit hooks"
+	@echo "  uninstall-hooks Uninstall git hooks"
 	@echo "  help            Show this help"
 	@echo ""
 	@echo "$(BLUE)Environment:$(NC)"


### PR DESCRIPTION
Closes #35

## Summary
- Add `.githooks/pre-commit` script that runs `make format` (with diff check) and `make lint` before each commit
- Add `make install-hooks` target to configure git to use `.githooks/` as the hooks directory
- Add `make uninstall-hooks` target to revert to default git hooks behavior

## Test plan
- [ ] Run `make install-hooks` and verify `git config core.hooksPath` is set to `.githooks`
- [ ] Make a commit with properly formatted code and confirm it passes
- [ ] Introduce a formatting issue and confirm the hook blocks the commit
- [ ] Run `make uninstall-hooks` and verify hooks are deactivated

🤖 Generated with [Claude Code](https://claude.com/claude-code)