### PR TITLE
feat: add integration test build tags and test-all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,13 @@ test-coverage:
 .PHONY: test-integration
 test-integration:
 	@echo "$(BLUE)Running integration tests (requires GPLAY_* env vars)...$(NC)"
-	$(GO) test -tags=integration -v ./internal/playclient -run Integration
+	$(GO) test -tags=integration -v -race ./...
+
+## Run all tests (unit + integration)
+.PHONY: test-all
+test-all:
+	@echo "$(BLUE)Running all tests...$(NC)"
+	$(GO) test -tags=integration -v -race ./...
 
 # Lint the code
 .PHONY: lint
@@ -222,6 +228,7 @@ help:
 	@echo "  test            Run tests"
 	@echo "  test-coverage   Run tests with coverage report"
 	@echo "  test-integration Run integration tests (requires credentials)"
+	@echo "  test-all         Run all tests (unit + integration)"
 	@echo ""
 	@echo "$(BLUE)Quality:$(NC)"
 	@echo "  lint            Lint the code"

--- a/internal/cli/auth/auth_integration_test.go
+++ b/internal/cli/auth/auth_integration_test.go
@@ -1,0 +1,33 @@
+//go:build integration
+
+package auth
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+)
+
+func TestAuthDoctor_Integration(t *testing.T) {
+	// Skip unless integration env var is also set (safety net)
+	if v := os.Getenv("GPLAY_INTEGRATION_TEST"); v != "1" && v != "true" {
+		t.Skip("skipping integration test; set GPLAY_INTEGRATION_TEST=1 to run")
+	}
+
+	saPath := os.Getenv("GPLAY_SERVICE_ACCOUNT")
+	if saPath == "" {
+		t.Skip("skipping: GPLAY_SERVICE_ACCOUNT not set")
+	}
+
+	cmd := DoctorCommand()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOutput(&stdout)
+
+	err := cmd.ParseAndRun(context.Background(), []string{"--service-account", saPath})
+	if err != nil {
+		t.Fatalf("auth doctor failed: %v", err)
+	}
+
+	_ = stderr // available for future assertions
+}


### PR DESCRIPTION
Closes #39

## Summary
- Add example integration test `internal/cli/auth/auth_integration_test.go` with `//go:build integration` tag
- Update `test-integration` Makefile target to run all integration-tagged tests across the entire project (`./...`) with `-race`
- Add new `test-all` target to run both unit and integration tests together
- Add `test-all` to the Makefile help section

## Test plan
- [x] `make test` passes and excludes integration tests (auth package shows `[no test files]`)
- [x] Integration test file has the `//go:build integration` build tag
- [ ] `make test-integration` runs integration-tagged tests when credentials are available

🤖 Generated with [Claude Code](https://claude.com/claude-code)