### PR TITLE
feat: add main-branch.yml CI workflow for post-merge checks

### DIFF
--- a/.github/workflows/main-branch.yml
+++ b/.github/workflows/main-branch.yml
@@ -1,0 +1,51 @@
+name: Main Branch
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  format:
+    name: Format Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: go install mvdan.cc/gofumpt@latest
+      - run: make format
+      - run: git diff --exit-code
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: make test
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - run: make build


### PR DESCRIPTION
Closes #26

## Summary
- Adds `.github/workflows/main-branch.yml` that runs on every push to `main`
- Runs four parallel jobs: format check, lint, unit tests, and build
- Acts as a post-merge safety net to catch issues early

## Test plan
- [ ] Verify workflow triggers on push to main
- [ ] Confirm all four jobs (format, lint, test, build) run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)