### PR TITLE
feat: real table output using text/tabwriter

### DIFF
--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -1,0 +1,51 @@
+package output
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+)
+
+// RenderTable writes a formatted table to stdout with the given headers and rows.
+func RenderTable(headers []string, rows [][]string) {
+	RenderTableTo(os.Stdout, headers, rows)
+}
+
+// RenderTableTo writes a formatted table to the given writer.
+func RenderTableTo(w io.Writer, headers []string, rows [][]string) {
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+
+	// Print headers
+	fmt.Fprintln(tw, strings.Join(headers, "\t"))
+
+	// Print separator
+	seps := make([]string, len(headers))
+	for i, h := range headers {
+		seps[i] = strings.Repeat("-", len(h))
+	}
+	fmt.Fprintln(tw, strings.Join(seps, "\t"))
+
+	// Print rows
+	if len(rows) == 0 {
+		fmt.Fprintln(tw, "No results found.")
+	} else {
+		for _, row := range rows {
+			fmt.Fprintln(tw, strings.Join(row, "\t"))
+		}
+	}
+
+	tw.Flush()
+}
+
+// Truncate truncates a string to maxLen characters, adding "..." if truncated.
+func Truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 3 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-3] + "..."
+}

--- a/internal/output/table_test.go
+++ b/internal/output/table_test.go
@@ -1,0 +1,54 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRenderTableTo(t *testing.T) {
+	var buf bytes.Buffer
+	headers := []string{"Name", "Value"}
+	rows := [][]string{
+		{"alpha", "1"},
+		{"beta", "2"},
+	}
+	RenderTableTo(&buf, headers, rows)
+	out := buf.String()
+	if !strings.Contains(out, "Name") {
+		t.Error("expected headers in output")
+	}
+	if !strings.Contains(out, "alpha") {
+		t.Error("expected row data in output")
+	}
+	if !strings.Contains(out, "---") {
+		t.Error("expected separator in output")
+	}
+}
+
+func TestRenderTableTo_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	RenderTableTo(&buf, []string{"Col"}, nil)
+	if !strings.Contains(buf.String(), "No results found") {
+		t.Error("expected empty message")
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	tests := []struct {
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"hello", 10, "hello"},
+		{"hello world", 8, "hello..."},
+		{"hi", 2, "hi"},
+		{"hello", 3, "hel"},
+	}
+	for _, tt := range tests {
+		got := Truncate(tt.input, tt.maxLen)
+		if got != tt.want {
+			t.Errorf("Truncate(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `RenderTable` / `RenderTableTo` functions in `internal/output/table.go` that produce aligned column output via `text/tabwriter`
- Add `Truncate` helper for safely shortening long cell values
- Include tests for table rendering (with data, empty rows) and truncation edge cases

Closes #20

## Test plan
- [x] `go test ./internal/output/...` passes (3 new tests)
- [ ] Verify table output visually by wiring a command to use `RenderTable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)