### PR TITLE
feat: add "Did you mean?" command suggestions

### DIFF
--- a/internal/cli/shared/suggest.go
+++ b/internal/cli/shared/suggest.go
@@ -1,0 +1,61 @@
+package shared
+
+import (
+	"fmt"
+	"strings"
+)
+
+// LevenshteinDistance computes the edit distance between two strings.
+func LevenshteinDistance(a, b string) int {
+	a = strings.ToLower(a)
+	b = strings.ToLower(b)
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(curr[j-1]+1, min(prev[j]+1, prev[j-1]+cost))
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+// SuggestCommand finds the closest command name within maxDistance.
+func SuggestCommand(input string, commands []string, maxDistance int) string {
+	best := ""
+	bestDist := maxDistance + 1
+	for _, cmd := range commands {
+		d := LevenshteinDistance(input, cmd)
+		if d < bestDist {
+			bestDist = d
+			best = cmd
+		}
+	}
+	if bestDist <= maxDistance {
+		return best
+	}
+	return ""
+}
+
+// FormatUnknownCommand returns an error message with an optional suggestion.
+func FormatUnknownCommand(input string, commands []string) string {
+	suggestion := SuggestCommand(input, commands, 3)
+	if suggestion != "" {
+		return fmt.Sprintf("Unknown command %q. Did you mean %q?\n\nRun 'gplay --help' for a list of commands.", input, suggestion)
+	}
+	return fmt.Sprintf("Unknown command %q.\n\nRun 'gplay --help' for a list of commands.", input)
+}

--- a/internal/cli/shared/suggest_test.go
+++ b/internal/cli/shared/suggest_test.go
@@ -1,0 +1,49 @@
+package shared
+
+import "testing"
+
+func TestLevenshteinDistance(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want int
+	}{
+		{"tracks", "trakcs", 2},
+		{"auth", "auth", 0},
+		{"", "abc", 3},
+		{"abc", "", 3},
+		{"kitten", "sitting", 3},
+	}
+	for _, tt := range tests {
+		got := LevenshteinDistance(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("LevenshteinDistance(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestSuggestCommand(t *testing.T) {
+	commands := []string{"auth", "tracks", "listings", "reviews", "bundles", "images"}
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"trakcs", "tracks"},
+		{"atuh", "auth"},
+		{"listing", "listings"},
+		{"xyzabc123", ""},
+	}
+	for _, tt := range tests {
+		got := SuggestCommand(tt.input, commands, 3)
+		if got != tt.want {
+			t.Errorf("SuggestCommand(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestFormatUnknownCommand(t *testing.T) {
+	commands := []string{"auth", "tracks"}
+	msg := FormatUnknownCommand("trakcs", commands)
+	if msg == "" {
+		t.Error("expected non-empty message")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -8,24 +8,29 @@ import (
 
 	"github.com/peterbourgon/ff/v3/ffcli"
 
-	"github.com/tamtom/play-console-cli/internal/cli/shared"
 	"github.com/tamtom/play-console-cli/internal/cli/registry"
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
 )
 
 var version = "dev"
 
 func main() {
-	root := &ffcli.Command{
-		Name:       "gplay",
-		ShortUsage: "gplay <command> [flags]",
-		ShortHelp:  "A CLI for Google Play Console.",
-		FlagSet:    flag.NewFlagSet("gplay", flag.ExitOnError),
+	var root *ffcli.Command
+	root = &ffcli.Command{
+		Name:        "gplay",
+		ShortUsage:  "gplay <command> [flags]",
+		ShortHelp:   "A CLI for Google Play Console.",
+		FlagSet:     flag.NewFlagSet("gplay", flag.ExitOnError),
 		Subcommands: registry.Subcommands(version),
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) == 0 {
 				return flag.ErrHelp
 			}
-			fmt.Fprintf(os.Stderr, "Unknown command: %s\n\n", args[0])
+			var names []string
+			for _, sub := range root.Subcommands {
+				names = append(names, sub.Name)
+			}
+			fmt.Fprintln(os.Stderr, shared.FormatUnknownCommand(args[0], names))
 			return flag.ErrHelp
 		},
 	}


### PR DESCRIPTION
## Summary
- Add `LevenshteinDistance` function and `SuggestCommand` helper in `internal/cli/shared/suggest.go`
- Hook `FormatUnknownCommand` into the root command's Exec so typos like `gplay trakcs` produce `Did you mean "tracks"?`
- Include comprehensive unit tests for distance calculation, suggestion matching, and message formatting

## Test plan
- [x] `go test ./internal/cli/shared/...` passes (Levenshtein distance, suggestion, and formatting tests)
- [x] `go test ./...` passes (no regressions)
- [x] `go build .` succeeds
- [ ] Manual: run `gplay trakcs` and verify "Did you mean" message appears on stderr
- [ ] Manual: run `gplay xyzabc123` and verify no suggestion is shown (distance too large)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)