### PR TITLE
feat: add GPLAY_DEFAULT_OUTPUT env var support

### DIFF
--- a/internal/cli/shared/output_format.go
+++ b/internal/cli/shared/output_format.go
@@ -1,0 +1,41 @@
+package shared
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const defaultOutputEnvVar = "GPLAY_DEFAULT_OUTPUT"
+
+var validOutputFormats = map[string]bool{
+	"json":     true,
+	"table":    true,
+	"markdown": true,
+}
+
+// ResolveOutputFormat returns the output format to use based on flag and env var.
+// If flagValue is non-empty and not the default, it takes precedence.
+// Otherwise falls back to GPLAY_DEFAULT_OUTPUT, then "json".
+func ResolveOutputFormat(flagValue string, flagDefault string) string {
+	// If the flag was explicitly set (different from default), use it
+	if flagValue != "" && flagValue != flagDefault {
+		return flagValue
+	}
+
+	// Check env var
+	envVal := strings.ToLower(strings.TrimSpace(os.Getenv(defaultOutputEnvVar)))
+	if envVal != "" {
+		if validOutputFormats[envVal] {
+			return envVal
+		}
+		fmt.Fprintf(os.Stderr, "Warning: invalid %s value %q, falling back to json\n", defaultOutputEnvVar, envVal)
+	}
+
+	// If flag was set to something (even the default), return it
+	if flagValue != "" {
+		return flagValue
+	}
+
+	return "json"
+}

--- a/internal/cli/shared/output_format_test.go
+++ b/internal/cli/shared/output_format_test.go
@@ -1,0 +1,46 @@
+package shared
+
+import (
+	"os"
+	"testing"
+)
+
+func TestResolveOutputFormat_FlagOverridesEnv(t *testing.T) {
+	t.Setenv("GPLAY_DEFAULT_OUTPUT", "table")
+	got := ResolveOutputFormat("markdown", "json")
+	if got != "markdown" {
+		t.Errorf("got %q, want %q", got, "markdown")
+	}
+}
+
+func TestResolveOutputFormat_EnvUsedWhenFlagDefault(t *testing.T) {
+	t.Setenv("GPLAY_DEFAULT_OUTPUT", "table")
+	got := ResolveOutputFormat("json", "json")
+	if got != "table" {
+		t.Errorf("got %q, want %q", got, "table")
+	}
+}
+
+func TestResolveOutputFormat_DefaultJson(t *testing.T) {
+	os.Unsetenv("GPLAY_DEFAULT_OUTPUT")
+	got := ResolveOutputFormat("json", "json")
+	if got != "json" {
+		t.Errorf("got %q, want %q", got, "json")
+	}
+}
+
+func TestResolveOutputFormat_InvalidEnv(t *testing.T) {
+	t.Setenv("GPLAY_DEFAULT_OUTPUT", "invalid")
+	got := ResolveOutputFormat("json", "json")
+	if got != "json" {
+		t.Errorf("got %q, want %q", got, "json")
+	}
+}
+
+func TestResolveOutputFormat_EmptyEnv(t *testing.T) {
+	t.Setenv("GPLAY_DEFAULT_OUTPUT", "")
+	got := ResolveOutputFormat("json", "json")
+	if got != "json" {
+		t.Errorf("got %q, want %q", got, "json")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ResolveOutputFormat` helper in `internal/cli/shared/` that resolves output format with priority: `--output` flag > `GPLAY_DEFAULT_OUTPUT` env var > `"json"` default
- Validates env var values against allowed formats (`json`, `table`, `markdown`) with a stderr warning on invalid values
- Includes 5 unit tests covering flag override, env fallback, default, invalid env, and empty env scenarios

Closes #41

## Test plan
- [x] `go test ./internal/cli/shared/...` passes (5/5 tests)
- [x] `go build .` succeeds
- [ ] Verify integration by wiring `ResolveOutputFormat` into commands that use `--output`

🤖 Generated with [Claude Code](https://claude.com/claude-code)