### PR TITLE
feat: add --video flag with YouTube URL validation to listings

### DIFF
--- a/internal/cli/listings/listings.go
+++ b/internal/cli/listings/listings.go
@@ -133,7 +133,7 @@ func UpdateCommand() *ffcli.Command {
 	title := fs.String("title", "", "Listing title")
 	fullDescription := fs.String("full-description", "", "Full description")
 	shortDescription := fs.String("short-description", "", "Short description")
-	video := fs.String("video", "", "Promo video URL")
+	video := fs.String("video", "", "YouTube promotional video URL (empty to clear)")
 	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
 	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
 
@@ -157,7 +157,7 @@ func PatchCommand() *ffcli.Command {
 	title := fs.String("title", "", "Listing title")
 	fullDescription := fs.String("full-description", "", "Full description")
 	shortDescription := fs.String("short-description", "", "Short description")
-	video := fs.String("video", "", "Promo video URL")
+	video := fs.String("video", "", "YouTube promotional video URL (empty to clear)")
 	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
 	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
 
@@ -280,6 +280,10 @@ func updateListing(ctx context.Context, packageName, editID, locale, title, full
 	}
 	if strings.TrimSpace(editID) == "" {
 		return fmt.Errorf("--edit is required")
+	}
+
+	if err := ValidateVideoURL(video); err != nil {
+		return err
 	}
 
 	listing := &androidpublisher.Listing{

--- a/internal/cli/listings/video.go
+++ b/internal/cli/listings/video.go
@@ -1,0 +1,19 @@
+package listings
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var youtubeRegexp = regexp.MustCompile(`^(https?://)?(www\.)?(youtube\.com/watch\?v=|youtu\.be/)[\w-]+`)
+
+// ValidateVideoURL validates a YouTube URL. Empty string is allowed (clears video).
+func ValidateVideoURL(url string) error {
+	if url == "" {
+		return nil
+	}
+	if !youtubeRegexp.MatchString(url) {
+		return fmt.Errorf("invalid YouTube URL: %s (expected youtube.com/watch?v=... or youtu.be/...)", url)
+	}
+	return nil
+}

--- a/internal/cli/listings/video_test.go
+++ b/internal/cli/listings/video_test.go
@@ -1,0 +1,26 @@
+package listings
+
+import "testing"
+
+func TestValidateVideoURL(t *testing.T) {
+	tests := []struct {
+		url   string
+		valid bool
+	}{
+		{"", true},
+		{"https://www.youtube.com/watch?v=dQw4w9WgXcQ", true},
+		{"https://youtu.be/dQw4w9WgXcQ", true},
+		{"https://youtube.com/watch?v=abc123", true},
+		{"https://vimeo.com/123", false},
+		{"not-a-url", false},
+	}
+	for _, tt := range tests {
+		err := ValidateVideoURL(tt.url)
+		if tt.valid && err != nil {
+			t.Errorf("ValidateVideoURL(%q) = %v, want nil", tt.url, err)
+		}
+		if !tt.valid && err == nil {
+			t.Errorf("ValidateVideoURL(%q) = nil, want error", tt.url)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add YouTube URL validation for the `--video` flag on `listings update` and `listings patch` commands
- Create `ValidateVideoURL` function that accepts `youtube.com/watch?v=...` and `youtu.be/...` formats (empty string allowed to clear)
- Update flag help text to clarify YouTube URL requirement
- Add unit tests for URL validation

Closes #22

## Test plan
- [x] `go test ./internal/cli/listings/...` passes (6 test cases for valid/invalid URLs)
- [x] `go build .` succeeds
- [ ] Manual test: `gplay listings update --video "https://www.youtube.com/watch?v=abc123" ...` accepted
- [ ] Manual test: `gplay listings update --video "https://vimeo.com/123" ...` rejected with error
- [ ] Manual test: `gplay listings update --video "" ...` accepted (clears video)

🤖 Generated with [Claude Code](https://claude.com/claude-code)