### PR TITLE
feat: add apps list command stub

### DIFF
--- a/internal/cli/apps/apps.go
+++ b/internal/cli/apps/apps.go
@@ -1,0 +1,33 @@
+package apps
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+// AppsCommand returns the apps command group.
+func AppsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "apps",
+		ShortUsage: "gplay apps <subcommand> [flags]",
+		ShortHelp:  "List and manage apps accessible by the service account.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			ListCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) == 0 {
+				return flag.ErrHelp
+			}
+			fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n", args[0])
+			return flag.ErrHelp
+		},
+	}
+}

--- a/internal/cli/apps/apps_test.go
+++ b/internal/cli/apps/apps_test.go
@@ -1,0 +1,34 @@
+package apps
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+func TestAppsCommand_Help(t *testing.T) {
+	cmd := AppsCommand()
+	if cmd.Name != "apps" {
+		t.Errorf("Name = %q, want %q", cmd.Name, "apps")
+	}
+	if len(cmd.Subcommands) == 0 {
+		t.Error("expected at least one subcommand")
+	}
+}
+
+func TestListCommand_Flags(t *testing.T) {
+	cmd := ListCommand()
+	if cmd.Name != "list" {
+		t.Errorf("Name = %q, want %q", cmd.Name, "list")
+	}
+	var buf bytes.Buffer
+	_ = buf
+}
+
+func TestAppsCommand_UnknownSubcommand(t *testing.T) {
+	cmd := AppsCommand()
+	err := cmd.ParseAndRun(context.Background(), []string{"nonexistent"})
+	if err == nil {
+		t.Error("expected error for unknown subcommand")
+	}
+}

--- a/internal/cli/apps/list.go
+++ b/internal/cli/apps/list.go
@@ -1,0 +1,46 @@
+package apps
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/playclient"
+)
+
+// ListCommand returns the apps list subcommand.
+func ListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("apps list", flag.ExitOnError)
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "gplay apps list [flags]",
+		ShortHelp:  "List all apps accessible by the service account.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+
+			service, err := playclient.NewService(ctx)
+			if err != nil {
+				return fmt.Errorf("creating service: %w", err)
+			}
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			// Use the androidpublisher API to list apps
+			// The API doesn't have a direct "list apps" endpoint,
+			// but we can validate access by checking the service
+			_ = ctx
+
+			return fmt.Errorf("apps list requires the Play Developer Reporting API which is not yet configured. Use gplay tracks list --package <name> to verify access to a specific app")
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `apps` command group with `list` subcommand in `internal/cli/apps/`
- Implements stub that returns an informative error about the Play Developer Reporting API not being configured yet
- Follows existing CLI patterns (DefaultUsageFunc, ValidateOutputFlags, ContextWithTimeout)
- Does **not** modify `registry.go` -- wiring will be handled separately

## Test plan
- [x] `go test ./internal/cli/apps/...` passes (3 tests)
- [x] `go build .` succeeds
- [ ] Wire into registry and verify `gplay apps --help` shows subcommands
- [ ] Connect to real Play Developer Reporting API when available

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)