### PR TITLE
feat: add ANSI color utilities with NO_COLOR support

### DIFF
--- a/internal/output/color.go
+++ b/internal/output/color.go
@@ -1,0 +1,91 @@
+package output
+
+import (
+	"fmt"
+	"os"
+)
+
+// ANSI escape codes.
+const (
+	ansiReset  = "\033[0m"
+	ansiRed    = "\033[31m"
+	ansiGreen  = "\033[32m"
+	ansiYellow = "\033[33m"
+	ansiCyan   = "\033[36m"
+	ansiBold   = "\033[1m"
+	ansiDim    = "\033[2m"
+)
+
+// colorEnabled tracks whether ANSI color output is active.
+var colorEnabled bool
+
+func init() {
+	initColors()
+}
+
+// initColors determines whether colors should be enabled based on the NO_COLOR
+// environment variable (https://no-color.org) and whether stderr is a TTY.
+func initColors() {
+	// NO_COLOR spec: when the variable is present (regardless of value),
+	// disable color output.
+	if _, present := os.LookupEnv("NO_COLOR"); present {
+		colorEnabled = false
+		return
+	}
+
+	// Check if stderr is a terminal (character device).
+	fi, err := os.Stderr.Stat()
+	if err != nil {
+		colorEnabled = false
+		return
+	}
+	colorEnabled = fi.Mode()&os.ModeCharDevice != 0
+}
+
+// ColorsEnabled reports whether ANSI color output is currently active.
+func ColorsEnabled() bool {
+	return colorEnabled
+}
+
+// wrap returns s wrapped in the given ANSI code if colors are enabled,
+// otherwise returns s unchanged.
+func wrap(code, s string) string {
+	if !colorEnabled {
+		return s
+	}
+	return fmt.Sprintf("%s%s%s", code, s, ansiReset)
+}
+
+// Green wraps s in green ANSI color.
+func Green(s string) string { return wrap(ansiGreen, s) }
+
+// Yellow wraps s in yellow ANSI color.
+func Yellow(s string) string { return wrap(ansiYellow, s) }
+
+// Red wraps s in red ANSI color.
+func Red(s string) string { return wrap(ansiRed, s) }
+
+// Bold wraps s in bold ANSI style.
+func Bold(s string) string { return wrap(ansiBold, s) }
+
+// Cyan wraps s in cyan ANSI color.
+func Cyan(s string) string { return wrap(ansiCyan, s) }
+
+// Dim wraps s in dim ANSI style.
+func Dim(s string) string { return wrap(ansiDim, s) }
+
+// StatusColor returns the status string wrapped in a color appropriate to its
+// meaning: green for completed/active, yellow for draft/inProgress, red for
+// halted/failed. Unknown statuses are returned unmodified.
+func StatusColor(status string) string {
+	switch status {
+	case "completed", "active":
+		return Green(status)
+	case "draft", "inProgress":
+		return Yellow(status)
+	case "halted", "failed":
+		return Red(status)
+	default:
+		return status
+	}
+}

--- a/internal/output/color_test.go
+++ b/internal/output/color_test.go
@@ -1,0 +1,177 @@
+package output
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestColorsEnabledRespectsNO_COLOR(t *testing.T) {
+	// Save and restore original value.
+	orig, hadOrig := os.LookupEnv("NO_COLOR")
+	defer func() {
+		if hadOrig {
+			os.Setenv("NO_COLOR", orig)
+		} else {
+			os.Unsetenv("NO_COLOR")
+		}
+	}()
+
+	os.Setenv("NO_COLOR", "1")
+	initColors()
+	if ColorsEnabled() {
+		t.Error("expected colors disabled when NO_COLOR is set")
+	}
+
+	os.Unsetenv("NO_COLOR")
+	// Force re-init; in a non-TTY test env colors will still be off due to
+	// TTY detection, so we test the NO_COLOR path explicitly above.
+	initColors()
+}
+
+func TestColorsEnabledWhenNO_COLOREmpty(t *testing.T) {
+	orig, hadOrig := os.LookupEnv("NO_COLOR")
+	defer func() {
+		if hadOrig {
+			os.Setenv("NO_COLOR", orig)
+		} else {
+			os.Unsetenv("NO_COLOR")
+		}
+	}()
+
+	// NO_COLOR spec: any non-empty value disables colors. Empty string means
+	// the variable is set but empty -- spec says "when set", so we treat empty
+	// as NOT disabling colors to match the most common interpretation.
+	// However, the spec at no-color.org says "command-line software which
+	// outputs text with ANSI color added should check for the presence of a
+	// NO_COLOR environment variable that, when present, prevents ANSI color."
+	// "present" means os.LookupEnv returns true, regardless of value.
+	os.Setenv("NO_COLOR", "")
+	initColors()
+	if ColorsEnabled() {
+		// Even an empty NO_COLOR disables colors per the spec ("when present").
+		t.Error("expected colors disabled when NO_COLOR is set (even empty)")
+	}
+}
+
+func TestColorFunctionsWithColorsEnabled(t *testing.T) {
+	// Force colors on for this test.
+	colorEnabled = true
+	defer func() { initColors() }()
+
+	tests := []struct {
+		name     string
+		fn       func(string) string
+		input    string
+		contains string
+	}{
+		{"Green", Green, "ok", "\033[32mok\033[0m"},
+		{"Yellow", Yellow, "warn", "\033[33mwarn\033[0m"},
+		{"Red", Red, "err", "\033[31merr\033[0m"},
+		{"Bold", Bold, "title", "\033[1mtitle\033[0m"},
+		{"Cyan", Cyan, "info", "\033[36minfo\033[0m"},
+		{"Dim", Dim, "faint", "\033[2mfaint\033[0m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn(tt.input)
+			if got != tt.contains {
+				t.Errorf("%s(%q) = %q, want %q", tt.name, tt.input, got, tt.contains)
+			}
+		})
+	}
+}
+
+func TestColorFunctionsWithColorsDisabled(t *testing.T) {
+	colorEnabled = false
+	defer func() { initColors() }()
+
+	tests := []struct {
+		name  string
+		fn    func(string) string
+		input string
+	}{
+		{"Green", Green, "ok"},
+		{"Yellow", Yellow, "warn"},
+		{"Red", Red, "err"},
+		{"Bold", Bold, "title"},
+		{"Cyan", Cyan, "info"},
+		{"Dim", Dim, "faint"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.fn(tt.input)
+			if got != tt.input {
+				t.Errorf("%s(%q) = %q, want plain %q", tt.name, tt.input, got, tt.input)
+			}
+			if strings.Contains(got, "\033[") {
+				t.Errorf("%s(%q) contains ANSI codes when colors are disabled", tt.name, tt.input)
+			}
+		})
+	}
+}
+
+func TestStatusColor(t *testing.T) {
+	colorEnabled = true
+	defer func() { initColors() }()
+
+	tests := []struct {
+		status    string
+		wantCode  string
+		wantPlain string
+	}{
+		{"completed", "\033[32m", "completed"},
+		{"active", "\033[32m", "active"},
+		{"draft", "\033[33m", "draft"},
+		{"inProgress", "\033[33m", "inProgress"},
+		{"halted", "\033[31m", "halted"},
+		{"failed", "\033[31m", "failed"},
+		{"unknown", "", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			got := StatusColor(tt.status)
+			if tt.wantCode != "" {
+				if !strings.HasPrefix(got, tt.wantCode) {
+					t.Errorf("StatusColor(%q) = %q, want prefix %q", tt.status, got, tt.wantCode)
+				}
+				if !strings.HasSuffix(got, "\033[0m") {
+					t.Errorf("StatusColor(%q) = %q, want suffix \\033[0m", tt.status, got)
+				}
+			} else {
+				// Unknown status returns plain string.
+				if got != tt.wantPlain {
+					t.Errorf("StatusColor(%q) = %q, want %q", tt.status, got, tt.wantPlain)
+				}
+			}
+		})
+	}
+}
+
+func TestStatusColorDisabled(t *testing.T) {
+	colorEnabled = false
+	defer func() { initColors() }()
+
+	statuses := []string{"completed", "active", "draft", "inProgress", "halted", "failed", "unknown"}
+	for _, s := range statuses {
+		t.Run(s, func(t *testing.T) {
+			got := StatusColor(s)
+			if got != s {
+				t.Errorf("StatusColor(%q) = %q, want plain %q when disabled", s, got, s)
+			}
+		})
+	}
+}
+
+func TestEmptyStringColorFunctions(t *testing.T) {
+	colorEnabled = true
+	defer func() { initColors() }()
+
+	// Even empty strings get wrapped.
+	if got := Green(""); got != "\033[32m\033[0m" {
+		t.Errorf("Green(\"\") = %q, want wrapped empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #25

- Add `internal/output/color.go` with color wrapping functions: `Green()`, `Yellow()`, `Red()`, `Bold()`, `Cyan()`, `Dim()`
- Automatic color disabling via `NO_COLOR` env var (per [no-color.org](https://no-color.org)) and non-TTY stderr detection
- `StatusColor(status)` maps semantic statuses to colors: green for completed/active, yellow for draft/inProgress, red for halted/failed
- `ColorsEnabled()` function to query current color state
- No external dependencies; no changes to existing files

## Test plan

- [x] `TestColorsEnabledRespectsNO_COLOR` — colors disabled when `NO_COLOR` is set
- [x] `TestColorsEnabledWhenNO_COLOREmpty` — colors disabled even with empty `NO_COLOR` (spec compliance)
- [x] `TestColorFunctionsWithColorsEnabled` — all 6 functions produce correct ANSI escape sequences
- [x] `TestColorFunctionsWithColorsDisabled` — all functions return plain strings, no ANSI codes
- [x] `TestStatusColor` — correct color mapping for all known statuses + passthrough for unknown
- [x] `TestStatusColorDisabled` — all statuses return plain when colors off
- [x] `TestEmptyStringColorFunctions` — edge case: empty string input
- [x] Full test suite passes with `-race` flag
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)