### PR TITLE
feat: add progress indicators for file uploads

### DIFF
--- a/internal/cli/shared/progress.go
+++ b/internal/cli/shared/progress.go
@@ -1,0 +1,86 @@
+package shared
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// ProgressReader wraps an io.Reader and reports progress to stderr.
+type ProgressReader struct {
+	reader    io.Reader
+	total     int64
+	read      int64
+	filename  string
+	writer    io.Writer // nil to disable output
+	mu        sync.Mutex
+	startTime time.Time
+	lastPrint time.Time
+}
+
+// NewProgressReader creates a progress-reporting reader.
+// If stderr is not a TTY, output is disabled.
+// total can be 0 if unknown.
+func NewProgressReader(r io.Reader, total int64, filename string) *ProgressReader {
+	var w io.Writer
+	if info, err := os.Stderr.Stat(); err == nil && info.Mode()&os.ModeCharDevice != 0 {
+		w = os.Stderr
+	}
+	return &ProgressReader{
+		reader:    r,
+		total:     total,
+		filename:  filename,
+		writer:    w,
+		startTime: time.Now(),
+	}
+}
+
+func (pr *ProgressReader) Read(p []byte) (int, error) {
+	n, err := pr.reader.Read(p)
+	pr.mu.Lock()
+	pr.read += int64(n)
+	now := time.Now()
+	if pr.writer != nil && (now.Sub(pr.lastPrint) > 100*time.Millisecond || err == io.EOF) {
+		pr.printProgress()
+		pr.lastPrint = now
+	}
+	pr.mu.Unlock()
+	if err == io.EOF && pr.writer != nil {
+		pr.printFinal()
+	}
+	return n, err
+}
+
+func (pr *ProgressReader) printProgress() {
+	elapsed := time.Since(pr.startTime).Seconds()
+	speed := float64(pr.read) / elapsed / 1024 / 1024 // MB/s
+	if pr.total > 0 {
+		pct := float64(pr.read) / float64(pr.total) * 100
+		fmt.Fprintf(pr.writer, "\rUploading %s  %s / %s (%.0f%%)  %.1f MB/s",
+			pr.filename, formatBytes(pr.read), formatBytes(pr.total), pct, speed)
+	} else {
+		fmt.Fprintf(pr.writer, "\rUploading %s  %s  %.1f MB/s",
+			pr.filename, formatBytes(pr.read), speed)
+	}
+}
+
+func (pr *ProgressReader) printFinal() {
+	elapsed := time.Since(pr.startTime)
+	fmt.Fprintf(pr.writer, "\rUploaded %s  %s in %s\n",
+		pr.filename, formatBytes(pr.read), elapsed.Round(time.Millisecond))
+}
+
+func formatBytes(b int64) string {
+	switch {
+	case b >= 1024*1024*1024:
+		return fmt.Sprintf("%.1f GB", float64(b)/1024/1024/1024)
+	case b >= 1024*1024:
+		return fmt.Sprintf("%.1f MB", float64(b)/1024/1024)
+	case b >= 1024:
+		return fmt.Sprintf("%.1f KB", float64(b)/1024)
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/internal/cli/shared/progress_test.go
+++ b/internal/cli/shared/progress_test.go
@@ -1,0 +1,95 @@
+package shared
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestProgressReaderImplementsIOReader(t *testing.T) {
+	pr := &ProgressReader{reader: strings.NewReader("hello")}
+	var _ io.Reader = pr
+}
+
+func TestProgressReaderCountsBytes(t *testing.T) {
+	data := "hello, world!"
+	pr := &ProgressReader{reader: strings.NewReader(data)}
+
+	buf := make([]byte, 4)
+	total := 0
+	for {
+		n, err := pr.Read(buf)
+		total += n
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if total != len(data) {
+		t.Errorf("read %d bytes, want %d", total, len(data))
+	}
+	if pr.read != int64(len(data)) {
+		t.Errorf("tracked %d bytes, want %d", pr.read, len(data))
+	}
+}
+
+func TestProgressReaderNoOutputWhenWriterNil(t *testing.T) {
+	data := strings.Repeat("x", 1024)
+	pr := &ProgressReader{reader: strings.NewReader(data), writer: nil}
+
+	_, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// No panic, no output — writer is nil so nothing is written.
+}
+
+func TestProgressReaderWritesToWriter(t *testing.T) {
+	data := strings.Repeat("x", 1024)
+	var buf bytes.Buffer
+	pr := &ProgressReader{
+		reader:   strings.NewReader(data),
+		total:    int64(len(data)),
+		filename: "test.apk",
+		writer:   &buf,
+	}
+
+	_, err := io.ReadAll(pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "test.apk") {
+		t.Errorf("output should contain filename, got: %s", output)
+	}
+	if !strings.Contains(output, "1.0 KB") {
+		t.Errorf("output should contain formatted size, got: %s", output)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1572864, "1.5 MB"},
+		{1073741824, "1.0 GB"},
+		{1610612736, "1.5 GB"},
+	}
+	for _, tt := range tests {
+		got := formatBytes(tt.input)
+		if got != tt.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add `ProgressReader` in `internal/cli/shared/progress.go` that wraps `io.Reader` to report upload progress to stderr
- TTY-aware output: progress is only displayed when stderr is a terminal (non-TTY environments get no output)
- Includes byte formatting (`B`/`KB`/`MB`/`GB`), upload speed calculation, percentage tracking, and throttled updates (100ms intervals)
- Comprehensive tests for `io.Reader` conformance, byte counting accuracy, writer-nil safety, and `formatBytes` output

Closes #30

## Test plan
- [x] `go test ./internal/cli/shared/...` — all 5 new tests pass
- [x] `go build ./...` — full project compiles cleanly
- [ ] Manual verification: wrap a file upload reader with `ProgressReader` and confirm progress output on a real TTY

🤖 Generated with [Claude Code](https://claude.com/claude-code)