### PR TITLE
feat: add httptest-based API mocking for tests

### DIFF
--- a/internal/playclient/client.go
+++ b/internal/playclient/client.go
@@ -30,8 +30,9 @@ var scopes = []string{"https://www.googleapis.com/auth/androidpublisher"}
 
 // Service wraps the Android Publisher service and config.
 type Service struct {
-	API *androidpublisher.Service
-	Cfg *config.Config
+	API     *androidpublisher.Service
+	Cfg     *config.Config
+	BaseURL string // When set, overrides API.BasePath (used for testing).
 }
 
 // NewService creates an authenticated Android Publisher service.
@@ -53,6 +54,22 @@ func NewService(ctx context.Context) (*Service, error) {
 		return nil, err
 	}
 	return &Service{API: api, Cfg: cfg}, nil
+}
+
+// NewTestService creates a Service that targets the given base URL using a
+// plain (unauthenticated) HTTP client. This is intended for use with
+// httptest.Server in tests.
+func NewTestService(baseURL string) (*Service, error) {
+	ctx := context.Background()
+	api, err := androidpublisher.NewService(ctx,
+		option.WithHTTPClient(http.DefaultClient),
+		option.WithoutAuthentication(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	api.BasePath = baseURL
+	return &Service{API: api, BaseURL: baseURL}, nil
 }
 
 func newHTTPClient(ctx context.Context, cfg *config.Config) (*http.Client, error) {

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -1,0 +1,139 @@
+package testutil
+
+// ---------------------------------------------------------------------------
+// JSON fixture data for common Google Play Android Publisher API responses.
+// These are plain Go maps; tests marshal them as needed.
+// ---------------------------------------------------------------------------
+
+// EditFixture returns a sample Edits.insert / Edits.get response.
+func EditFixture() map[string]interface{} {
+	return map[string]interface{}{
+		"id":            "edit-123",
+		"expiryTimeSeconds": "1700000000",
+	}
+}
+
+// TrackFixture returns a sample Tracks.get response with a single release.
+func TrackFixture() map[string]interface{} {
+	return map[string]interface{}{
+		"track": "production",
+		"releases": []map[string]interface{}{
+			{
+				"name":            "1.0.0",
+				"versionCodes":    []string{"100"},
+				"status":          "completed",
+				"userFraction":    1.0,
+			},
+		},
+	}
+}
+
+// TracksListFixture returns a sample Tracks.list response.
+func TracksListFixture() map[string]interface{} {
+	return map[string]interface{}{
+		"kind":   "androidpublisher#tracksListResponse",
+		"tracks": []map[string]interface{}{
+			TrackFixture(),
+			{
+				"track": "beta",
+				"releases": []map[string]interface{}{
+					{
+						"name":         "1.1.0-beta",
+						"versionCodes": []string{"110"},
+						"status":       "completed",
+					},
+				},
+			},
+		},
+	}
+}
+
+// ReviewFixture returns a sample Reviews.get response.
+func ReviewFixture() map[string]interface{} {
+	return map[string]interface{}{
+		"reviewId": "review-abc",
+		"authorName": "Test User",
+		"comments": []map[string]interface{}{
+			{
+				"userComment": map[string]interface{}{
+					"text":            "Great app!",
+					"starRating":      5,
+					"lastModified":    map[string]interface{}{"seconds": "1700000000"},
+					"appVersionCode":  100,
+					"appVersionName":  "1.0.0",
+					"device":          "Pixel 6",
+				},
+			},
+		},
+	}
+}
+
+// ReviewsListFixture returns a sample Reviews.list response.
+func ReviewsListFixture() map[string]interface{} {
+	return map[string]interface{}{
+		"reviews": []map[string]interface{}{
+			ReviewFixture(),
+		},
+		"tokenPagination": map[string]interface{}{
+			"nextPageToken": "",
+		},
+	}
+}
+
+// ListingFixture returns a sample Listings.get response.
+func ListingFixture() map[string]interface{} {
+	return map[string]interface{}{
+		"language":         "en-US",
+		"title":            "My App",
+		"fullDescription":  "A great application.",
+		"shortDescription": "Great app",
+		"video":            "",
+	}
+}
+
+// ListingsListFixture returns a sample Listings.list response.
+func ListingsListFixture() map[string]interface{} {
+	return map[string]interface{}{
+		"kind": "androidpublisher#listingsListResponse",
+		"listings": []map[string]interface{}{
+			ListingFixture(),
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Error fixtures
+// ---------------------------------------------------------------------------
+
+// ErrorFixture404 returns a Google-style 404 error response body.
+func ErrorFixture404() map[string]interface{} {
+	return map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    404,
+			"message": "No application was found for the given package name.",
+			"status":  "NOT_FOUND",
+		},
+	}
+}
+
+// ErrorFixture403 returns a Google-style 403 error response body.
+func ErrorFixture403() map[string]interface{} {
+	return map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    403,
+			"message": "The caller does not have permission.",
+			"status":  "PERMISSION_DENIED",
+		},
+	}
+}
+
+// ErrorFixture409 returns a Google-style 409 error response body.
+func ErrorFixture409() map[string]interface{} {
+	return map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    409,
+			"message": "Another edit is already open for this application.",
+			"status":  "ALREADY_EXISTS",
+		},
+	}
+}

--- a/internal/testutil/mockapi.go
+++ b/internal/testutil/mockapi.go
@@ -1,0 +1,109 @@
+// Package testutil provides httptest-based API mocking utilities for testing
+// commands that interact with the Google Play Android Publisher API.
+package testutil
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// RequestEntry records a single HTTP request received by the mock server.
+type RequestEntry struct {
+	Method string
+	Path   string
+	Body   string
+}
+
+// MockAPI wraps an httptest.Server with request logging and convenience helpers.
+type MockAPI struct {
+	Server *httptest.Server
+
+	mu  sync.Mutex
+	log []RequestEntry
+}
+
+// NewMockAPI creates a new test server routing requests through the given
+// handler map. Keys are "METHOD /path" (e.g. "GET /edits"). Unmatched
+// requests receive a 404 response. Every request is recorded in the log.
+// The server is automatically closed via t.Cleanup.
+func NewMockAPI(t *testing.T, handlers map[string]http.HandlerFunc) *MockAPI {
+	t.Helper()
+
+	m := &MockAPI{}
+
+	mux := http.NewServeMux()
+
+	// Register a catch-all handler that does routing + logging.
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		defer r.Body.Close()
+
+		m.mu.Lock()
+		m.log = append(m.log, RequestEntry{
+			Method: r.Method,
+			Path:   r.URL.Path,
+			Body:   string(body),
+		})
+		m.mu.Unlock()
+
+		key := r.Method + " " + r.URL.Path
+		if h, ok := handlers[key]; ok {
+			h(w, r)
+			return
+		}
+
+		// Fallback: 404
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"error": map[string]interface{}{
+				"code":    404,
+				"message": "no mock handler for " + key,
+			},
+		})
+	})
+
+	m.Server = httptest.NewServer(mux)
+	t.Cleanup(m.Server.Close)
+
+	return m
+}
+
+// BaseURL returns the test server's URL (e.g. "http://127.0.0.1:PORT").
+func (m *MockAPI) BaseURL() string {
+	return m.Server.URL
+}
+
+// RequestLog returns a copy of all recorded requests.
+func (m *MockAPI) RequestLog() []RequestEntry {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]RequestEntry, len(m.log))
+	copy(out, m.log)
+	return out
+}
+
+// HandleJSON returns an http.HandlerFunc that responds with the given status
+// code and JSON-encodes body into the response.
+func HandleJSON(statusCode int, body interface{}) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_ = json.NewEncoder(w).Encode(body)
+	}
+}
+
+// HandleError returns an http.HandlerFunc that responds with a Google-style
+// JSON error body.
+func HandleError(statusCode int, message string) http.HandlerFunc {
+	return HandleJSON(statusCode, map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    statusCode,
+			"message": message,
+		},
+	})
+}

--- a/internal/testutil/mockapi_test.go
+++ b/internal/testutil/mockapi_test.go
@@ -1,0 +1,215 @@
+package testutil_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/testutil"
+)
+
+func TestNewMockAPI_BaseURL(t *testing.T) {
+	mock := testutil.NewMockAPI(t, nil)
+	url := mock.BaseURL()
+	if url == "" {
+		t.Fatal("BaseURL() returned empty string")
+	}
+	if url[:4] != "http" {
+		t.Fatalf("BaseURL() should start with http, got %q", url)
+	}
+}
+
+func TestMockAPI_HandlerRouting(t *testing.T) {
+	handlers := map[string]http.HandlerFunc{
+		"GET /hello": testutil.HandleJSON(http.StatusOK, map[string]string{"msg": "hi"}),
+	}
+	mock := testutil.NewMockAPI(t, handlers)
+
+	resp, err := http.Get(mock.BaseURL() + "/hello")
+	if err != nil {
+		t.Fatalf("GET /hello failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var body map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if body["msg"] != "hi" {
+		t.Fatalf("expected msg=hi, got %q", body["msg"])
+	}
+}
+
+func TestMockAPI_UnmatchedRoute_Returns404(t *testing.T) {
+	mock := testutil.NewMockAPI(t, nil)
+
+	resp, err := http.Get(mock.BaseURL() + "/nonexistent")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestMockAPI_RequestLog(t *testing.T) {
+	handlers := map[string]http.HandlerFunc{
+		"POST /submit": testutil.HandleJSON(http.StatusCreated, map[string]string{"ok": "true"}),
+	}
+	mock := testutil.NewMockAPI(t, handlers)
+
+	// Make a request with a body.
+	resp, err := http.Post(mock.BaseURL()+"/submit", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /submit failed: %v", err)
+	}
+	resp.Body.Close()
+
+	log := mock.RequestLog()
+	if len(log) != 1 {
+		t.Fatalf("expected 1 log entry, got %d", len(log))
+	}
+	if log[0].Method != "POST" {
+		t.Fatalf("expected POST, got %s", log[0].Method)
+	}
+	if log[0].Path != "/submit" {
+		t.Fatalf("expected /submit, got %s", log[0].Path)
+	}
+}
+
+func TestMockAPI_MultipleRequests(t *testing.T) {
+	handlers := map[string]http.HandlerFunc{
+		"GET /a": testutil.HandleJSON(http.StatusOK, "a"),
+		"GET /b": testutil.HandleJSON(http.StatusOK, "b"),
+	}
+	mock := testutil.NewMockAPI(t, handlers)
+
+	for _, path := range []string{"/a", "/b", "/a"} {
+		resp, err := http.Get(mock.BaseURL() + path)
+		if err != nil {
+			t.Fatalf("GET %s failed: %v", path, err)
+		}
+		resp.Body.Close()
+	}
+
+	log := mock.RequestLog()
+	if len(log) != 3 {
+		t.Fatalf("expected 3 log entries, got %d", len(log))
+	}
+	if log[0].Path != "/a" || log[1].Path != "/b" || log[2].Path != "/a" {
+		t.Fatalf("unexpected log paths: %v", log)
+	}
+}
+
+func TestHandleError(t *testing.T) {
+	handlers := map[string]http.HandlerFunc{
+		"GET /fail": testutil.HandleError(http.StatusForbidden, "access denied"),
+	}
+	mock := testutil.NewMockAPI(t, handlers)
+
+	resp, err := http.Get(mock.BaseURL() + "/fail")
+	if err != nil {
+		t.Fatalf("GET /fail failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+
+	data, _ := io.ReadAll(resp.Body)
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to parse error JSON: %v", err)
+	}
+	errObj, ok := parsed["error"].(map[string]interface{})
+	if !ok {
+		t.Fatal("expected error object in response")
+	}
+	if errObj["message"] != "access denied" {
+		t.Fatalf("expected message 'access denied', got %q", errObj["message"])
+	}
+}
+
+func TestFixtures_NotNil(t *testing.T) {
+	fixtures := []struct {
+		name string
+		fn   func() map[string]interface{}
+	}{
+		{"EditFixture", testutil.EditFixture},
+		{"TrackFixture", testutil.TrackFixture},
+		{"TracksListFixture", testutil.TracksListFixture},
+		{"ReviewFixture", testutil.ReviewFixture},
+		{"ReviewsListFixture", testutil.ReviewsListFixture},
+		{"ListingFixture", testutil.ListingFixture},
+		{"ListingsListFixture", testutil.ListingsListFixture},
+		{"ErrorFixture404", testutil.ErrorFixture404},
+		{"ErrorFixture403", testutil.ErrorFixture403},
+		{"ErrorFixture409", testutil.ErrorFixture409},
+	}
+	for _, f := range fixtures {
+		t.Run(f.name, func(t *testing.T) {
+			result := f.fn()
+			if result == nil {
+				t.Fatalf("%s returned nil", f.name)
+			}
+			// Ensure it marshals to valid JSON.
+			data, err := json.Marshal(result)
+			if err != nil {
+				t.Fatalf("%s failed to marshal: %v", f.name, err)
+			}
+			if len(data) < 2 {
+				t.Fatalf("%s produced empty JSON", f.name)
+			}
+		})
+	}
+}
+
+func TestFixtures_WithHandleJSON(t *testing.T) {
+	// Verify that fixtures integrate cleanly with HandleJSON in a MockAPI.
+	handlers := map[string]http.HandlerFunc{
+		"GET /edit":    testutil.HandleJSON(http.StatusOK, testutil.EditFixture()),
+		"GET /tracks":  testutil.HandleJSON(http.StatusOK, testutil.TracksListFixture()),
+		"GET /reviews": testutil.HandleJSON(http.StatusOK, testutil.ReviewsListFixture()),
+		"GET /listing": testutil.HandleJSON(http.StatusOK, testutil.ListingFixture()),
+		"GET /err404":  testutil.HandleJSON(http.StatusNotFound, testutil.ErrorFixture404()),
+		"GET /err403":  testutil.HandleJSON(http.StatusForbidden, testutil.ErrorFixture403()),
+		"GET /err409":  testutil.HandleJSON(http.StatusConflict, testutil.ErrorFixture409()),
+	}
+	mock := testutil.NewMockAPI(t, handlers)
+
+	paths := []struct {
+		path   string
+		status int
+	}{
+		{"/edit", 200},
+		{"/tracks", 200},
+		{"/reviews", 200},
+		{"/listing", 200},
+		{"/err404", 404},
+		{"/err403", 403},
+		{"/err409", 409},
+	}
+	for _, p := range paths {
+		resp, err := http.Get(mock.BaseURL() + p.path)
+		if err != nil {
+			t.Fatalf("GET %s failed: %v", p.path, err)
+		}
+		if resp.StatusCode != p.status {
+			t.Fatalf("GET %s: expected %d, got %d", p.path, p.status, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+
+	log := mock.RequestLog()
+	if len(log) != len(paths) {
+		t.Fatalf("expected %d log entries, got %d", len(paths), len(log))
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/testutil` package with `MockAPI` struct wrapping `httptest.Server`, providing method+path routing, request logging, and `HandleJSON`/`HandleError` helpers
- Add JSON fixture functions for common Play API responses (edits, tracks, reviews, listings) and error responses (404, 403, 409)
- Add `playclient.NewTestService(baseURL)` to create unauthenticated services pointing at a test server, enabling httptest-based integration tests

Closes #37

## Test plan
- [x] `go test ./internal/testutil/...` -- all 8 tests pass (including subtests for all fixtures)
- [x] `go build ./...` -- full project compiles with no errors
- [ ] Verify CI passes on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)