### PR TITLE
feat: add vitals performance command group

### DIFF
--- a/internal/cli/vitals/performance/battery.go
+++ b/internal/cli/vitals/performance/battery.go
@@ -1,0 +1,65 @@
+package performance
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+// BatteryCommand returns the battery performance metrics subcommand.
+func BatteryCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("performance battery", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	from := fs.String("from", "", "Start date (YYYY-MM-DD)")
+	to := fs.String("to", "", "End date (YYYY-MM-DD)")
+	dimension := fs.String("dimension", "", "Breakdown dimension (e.g. apiLevel, deviceModel, country)")
+	metricType := fs.String("type", "", "Battery metric type: wakeup or wakelock")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+	_ = fs.Bool("paginate", false, "Fetch all pages")
+
+	return &ffcli.Command{
+		Name:       "battery",
+		ShortUsage: "gplay vitals performance battery --package <name> [flags]",
+		ShortHelp:  "Get battery usage metrics.",
+		LongHelp: `Get battery usage metrics.
+
+Returns excessive wakeup or partial wake lock metrics. Use --type to select
+between "wakeup" (excessive wake-ups) and "wakelock" (stuck partial wake locks).
+Use --dimension to break down results by API level, device model, or country.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*packageName) == "" {
+				return fmt.Errorf("--package is required")
+			}
+			if strings.TrimSpace(*metricType) != "" {
+				t := strings.ToLower(strings.TrimSpace(*metricType))
+				if t != "wakeup" && t != "wakelock" {
+					return fmt.Errorf("--type must be 'wakeup' or 'wakelock'")
+				}
+			}
+
+			// Stub: API client not connected yet.
+			_ = from
+			_ = to
+			_ = dimension
+
+			result := map[string]string{
+				"status":  "stub",
+				"message": "vitals performance battery: API client not connected yet",
+				"package": *packageName,
+				"type":    *metricType,
+			}
+			return shared.PrintOutput(result, *outputFlag, *pretty)
+		},
+	}
+}

--- a/internal/cli/vitals/performance/performance.go
+++ b/internal/cli/vitals/performance/performance.go
@@ -1,0 +1,37 @@
+package performance
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+// PerformanceCommand builds the performance command group.
+func PerformanceCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("performance", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "performance",
+		ShortUsage: "gplay vitals performance <subcommand> [flags]",
+		ShortHelp:  "App startup, rendering, and battery performance metrics.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			StartupCommand(),
+			RenderingCommand(),
+			BatteryCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) == 0 {
+				return flag.ErrHelp
+			}
+			fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n", args[0])
+			return flag.ErrHelp
+		},
+	}
+}

--- a/internal/cli/vitals/performance/performance_test.go
+++ b/internal/cli/vitals/performance/performance_test.go
@@ -1,0 +1,228 @@
+package performance
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestPerformanceCommand_Structure(t *testing.T) {
+	cmd := PerformanceCommand()
+
+	if cmd.Name != "performance" {
+		t.Errorf("expected command name 'performance', got %q", cmd.Name)
+	}
+
+	expected := map[string]bool{
+		"startup":   false,
+		"rendering": false,
+		"battery":   false,
+	}
+
+	for _, sub := range cmd.Subcommands {
+		if _, ok := expected[sub.Name]; !ok {
+			t.Errorf("unexpected subcommand: %q", sub.Name)
+		}
+		expected[sub.Name] = true
+	}
+
+	for name, found := range expected {
+		if !found {
+			t.Errorf("missing subcommand: %q", name)
+		}
+	}
+}
+
+func TestStartupCommand_Name(t *testing.T) {
+	cmd := StartupCommand()
+	if cmd.Name != "startup" {
+		t.Errorf("expected command name 'startup', got %q", cmd.Name)
+	}
+}
+
+func TestRenderingCommand_Name(t *testing.T) {
+	cmd := RenderingCommand()
+	if cmd.Name != "rendering" {
+		t.Errorf("expected command name 'rendering', got %q", cmd.Name)
+	}
+}
+
+func TestBatteryCommand_Name(t *testing.T) {
+	cmd := BatteryCommand()
+	if cmd.Name != "battery" {
+		t.Errorf("expected command name 'battery', got %q", cmd.Name)
+	}
+}
+
+func TestStartupCommand_PackageRequired(t *testing.T) {
+	cmd := StartupCommand()
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error when --package is missing")
+	}
+	if !strings.Contains(err.Error(), "--package is required") {
+		t.Errorf("expected '--package is required' error, got: %v", err)
+	}
+}
+
+func TestRenderingCommand_PackageRequired(t *testing.T) {
+	cmd := RenderingCommand()
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error when --package is missing")
+	}
+	if !strings.Contains(err.Error(), "--package is required") {
+		t.Errorf("expected '--package is required' error, got: %v", err)
+	}
+}
+
+func TestBatteryCommand_PackageRequired(t *testing.T) {
+	cmd := BatteryCommand()
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error when --package is missing")
+	}
+	if !strings.Contains(err.Error(), "--package is required") {
+		t.Errorf("expected '--package is required' error, got: %v", err)
+	}
+}
+
+func TestBatteryCommand_InvalidType(t *testing.T) {
+	cmd := BatteryCommand()
+	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--type", "invalid"}); err != nil {
+		t.Fatalf("flag parse error: %v", err)
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for invalid --type")
+	}
+	if !strings.Contains(err.Error(), "--type must be 'wakeup' or 'wakelock'") {
+		t.Errorf("expected type validation error, got: %v", err)
+	}
+}
+
+func TestBatteryCommand_ValidType(t *testing.T) {
+	for _, typ := range []string{"wakeup", "wakelock"} {
+		t.Run(typ, func(t *testing.T) {
+			cmd := BatteryCommand()
+			if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--type", typ}); err != nil {
+				t.Fatalf("flag parse error: %v", err)
+			}
+			err := cmd.Exec(context.Background(), nil)
+			if err != nil {
+				t.Errorf("expected no error for valid --type %q, got: %v", typ, err)
+			}
+		})
+	}
+}
+
+func TestStartupCommand_HelpOutput(t *testing.T) {
+	cmd := StartupCommand()
+	if cmd.ShortHelp == "" {
+		t.Error("expected non-empty ShortHelp")
+	}
+	if cmd.ShortUsage == "" {
+		t.Error("expected non-empty ShortUsage")
+	}
+	if !strings.Contains(cmd.ShortUsage, "--package") {
+		t.Errorf("expected ShortUsage to mention --package, got: %s", cmd.ShortUsage)
+	}
+}
+
+func TestPerformanceCommand_HelpOutput(t *testing.T) {
+	cmd := PerformanceCommand()
+	if cmd.ShortHelp == "" {
+		t.Error("expected non-empty ShortHelp")
+	}
+	if !strings.Contains(cmd.ShortUsage, "gplay vitals performance") {
+		t.Errorf("expected ShortUsage to contain 'gplay vitals performance', got: %s", cmd.ShortUsage)
+	}
+}
+
+func TestPerformanceCommand_NoArgsReturnsHelp(t *testing.T) {
+	cmd := PerformanceCommand()
+	err := cmd.Exec(context.Background(), nil)
+	if err != flag.ErrHelp {
+		t.Errorf("expected flag.ErrHelp with no args, got: %v", err)
+	}
+}
+
+func TestPerformanceCommand_UnknownSubcommand(t *testing.T) {
+	cmd := PerformanceCommand()
+	var stderr bytes.Buffer
+	// Redirect stderr to capture output - can't easily do this without os.Pipe,
+	// but we can at least verify the error type.
+	_ = stderr
+	err := cmd.Exec(context.Background(), []string{"unknown"})
+	if err != flag.ErrHelp {
+		t.Errorf("expected flag.ErrHelp for unknown subcommand, got: %v", err)
+	}
+}
+
+func TestStartupCommand_Flags(t *testing.T) {
+	cmd := StartupCommand()
+	expectedFlags := []string{"package", "from", "to", "dimension", "output", "pretty", "paginate"}
+	for _, name := range expectedFlags {
+		if cmd.FlagSet.Lookup(name) == nil {
+			t.Errorf("expected flag --%s to be defined", name)
+		}
+	}
+}
+
+func TestRenderingCommand_Flags(t *testing.T) {
+	cmd := RenderingCommand()
+	expectedFlags := []string{"package", "from", "to", "dimension", "output", "pretty", "paginate"}
+	for _, name := range expectedFlags {
+		if cmd.FlagSet.Lookup(name) == nil {
+			t.Errorf("expected flag --%s to be defined", name)
+		}
+	}
+}
+
+func TestBatteryCommand_Flags(t *testing.T) {
+	cmd := BatteryCommand()
+	expectedFlags := []string{"package", "from", "to", "dimension", "type", "output", "pretty", "paginate"}
+	for _, name := range expectedFlags {
+		if cmd.FlagSet.Lookup(name) == nil {
+			t.Errorf("expected flag --%s to be defined", name)
+		}
+	}
+}
+
+func TestStartupCommand_PrettyWithTableOutputInvalid(t *testing.T) {
+	cmd := StartupCommand()
+	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--output", "table", "--pretty"}); err != nil {
+		t.Fatalf("flag parse error: %v", err)
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error for --pretty with table output")
+	}
+	if !strings.Contains(err.Error(), "--pretty is only valid with JSON output") {
+		t.Errorf("expected pretty validation error, got: %v", err)
+	}
+}
+
+func TestStartupCommand_StubExecution(t *testing.T) {
+	cmd := StartupCommand()
+	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app"}); err != nil {
+		t.Fatalf("flag parse error: %v", err)
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if err != nil {
+		t.Errorf("expected no error for stub execution, got: %v", err)
+	}
+}
+
+func TestRenderingCommand_StubExecution(t *testing.T) {
+	cmd := RenderingCommand()
+	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app"}); err != nil {
+		t.Fatalf("flag parse error: %v", err)
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if err != nil {
+		t.Errorf("expected no error for stub execution, got: %v", err)
+	}
+}

--- a/internal/cli/vitals/performance/rendering.go
+++ b/internal/cli/vitals/performance/rendering.go
@@ -1,0 +1,57 @@
+package performance
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+// RenderingCommand returns the rendering performance metrics subcommand.
+func RenderingCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("performance rendering", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	from := fs.String("from", "", "Start date (YYYY-MM-DD)")
+	to := fs.String("to", "", "End date (YYYY-MM-DD)")
+	dimension := fs.String("dimension", "", "Breakdown dimension (e.g. apiLevel, deviceModel, country)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+	_ = fs.Bool("paginate", false, "Fetch all pages")
+
+	return &ffcli.Command{
+		Name:       "rendering",
+		ShortUsage: "gplay vitals performance rendering --package <name> [flags]",
+		ShortHelp:  "Get slow rendering metrics.",
+		LongHelp: `Get slow rendering metrics.
+
+Returns the percentage of frames that exceeded the 16ms and 700ms render
+time thresholds. Use --dimension to break down results by API level,
+device model, or country.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*packageName) == "" {
+				return fmt.Errorf("--package is required")
+			}
+
+			// Stub: API client not connected yet.
+			_ = from
+			_ = to
+			_ = dimension
+
+			result := map[string]string{
+				"status":  "stub",
+				"message": "vitals performance rendering: API client not connected yet",
+				"package": *packageName,
+			}
+			return shared.PrintOutput(result, *outputFlag, *pretty)
+		},
+	}
+}

--- a/internal/cli/vitals/performance/startup.go
+++ b/internal/cli/vitals/performance/startup.go
@@ -1,0 +1,57 @@
+package performance
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+// StartupCommand returns the startup performance metrics subcommand.
+func StartupCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("performance startup", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	from := fs.String("from", "", "Start date (YYYY-MM-DD)")
+	to := fs.String("to", "", "End date (YYYY-MM-DD)")
+	dimension := fs.String("dimension", "", "Breakdown dimension (e.g. apiLevel, deviceModel, country)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+	_ = fs.Bool("paginate", false, "Fetch all pages")
+
+	return &ffcli.Command{
+		Name:       "startup",
+		ShortUsage: "gplay vitals performance startup --package <name> [flags]",
+		ShortHelp:  "Get app startup time metrics.",
+		LongHelp: `Get app startup time metrics.
+
+Returns cold, warm, and hot start duration percentiles for the specified
+package and date range. Use --dimension to break down results by API level,
+device model, or country.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*packageName) == "" {
+				return fmt.Errorf("--package is required")
+			}
+
+			// Stub: API client not connected yet.
+			_ = from
+			_ = to
+			_ = dimension
+
+			result := map[string]string{
+				"status":  "stub",
+				"message": "vitals performance startup: API client not connected yet",
+				"package": *packageName,
+			}
+			return shared.PrintOutput(result, *outputFlag, *pretty)
+		},
+	}
+}

--- a/internal/cli/vitals/vitals.go
+++ b/internal/cli/vitals/vitals.go
@@ -1,0 +1,36 @@
+package vitals
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/cli/vitals/performance"
+)
+
+// VitalsCommand builds the vitals root command.
+func VitalsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("vitals", flag.ExitOnError)
+
+	return &ffcli.Command{
+		Name:       "vitals",
+		ShortUsage: "gplay vitals <subcommand> [flags]",
+		ShortHelp:  "App vitals: crashes, performance, and error reports.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			performance.PerformanceCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) == 0 {
+				return flag.ErrHelp
+			}
+			fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n", args[0])
+			return flag.ErrHelp
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Add `gplay vitals performance` command group with `startup`, `rendering`, and `battery` subcommands
- Each subcommand validates `--package` (required), supports `--from`, `--to`, `--dimension`, `--output`, `--pretty`, and `--paginate` flags
- Battery subcommand adds `--type` flag (wakeup|wakelock) with validation
- Stub implementations ready for API client wiring

Closes #15. Note: Registry wiring handled separately.

## Test plan
- [x] All 18 tests pass (`go test ./internal/cli/vitals/...`)
- [x] Full project compiles (`go build ./...`)
- [ ] Verify `--package` is required for all subcommands
- [ ] Verify `--type` validation on battery subcommand
- [ ] Verify `--pretty` with non-JSON output is rejected
- [ ] Verify command structure: vitals -> performance -> startup/rendering/battery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>