### PR TITLE
feat: add migrate fastlane command

### DIFF
--- a/internal/cli/migrate/fastlane.go
+++ b/internal/cli/migrate/fastlane.go
@@ -1,0 +1,307 @@
+package migrate
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+// Known Fastlane text files that map to store listing fields.
+var fastlaneTextFiles = []string{
+	"title.txt",
+	"short_description.txt",
+	"full_description.txt",
+	"video.txt",
+}
+
+// Known Fastlane image directories.
+var fastlaneImageDirs = []string{
+	"phoneScreenshots",
+	"sevenInchScreenshots",
+	"tenInchScreenshots",
+	"tvScreenshots",
+	"wearScreenshots",
+}
+
+// Known Fastlane single-image files.
+var fastlaneSingleImages = []string{
+	"featureGraphic.png",
+	"icon.png",
+	"promoGraphic.png",
+	"tvBanner.png",
+}
+
+// FastlaneSummary is the JSON-serialisable result of a migration.
+type FastlaneSummary struct {
+	Source      string           `json:"source"`
+	OutputDir   string           `json:"outputDir,omitempty"`
+	DryRun      bool             `json:"dryRun"`
+	Locales     []LocaleSummary  `json:"locales"`
+	TotalFiles  int              `json:"totalFiles"`
+	TotalImages int              `json:"totalImages"`
+	Warnings    []string         `json:"warnings,omitempty"`
+}
+
+// LocaleSummary describes what was found/imported for one locale.
+type LocaleSummary struct {
+	Locale     string   `json:"locale"`
+	TextFiles  []string `json:"textFiles,omitempty"`
+	Changelogs []string `json:"changelogs,omitempty"`
+	Images     []string `json:"images,omitempty"`
+}
+
+// FastlaneCommand returns the "migrate fastlane" subcommand.
+func FastlaneCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("migrate fastlane", flag.ExitOnError)
+	source := fs.String("source", "", "Path to Fastlane metadata/android/ directory (required)")
+	outputDir := fs.String("output-dir", ".gplay/metadata/", "Output directory for imported metadata")
+	dryRun := fs.Bool("dry-run", false, "Preview what would be imported without writing files")
+	locales := fs.String("locales", "", "Comma-separated list of locales to import (default: all)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "fastlane",
+		ShortUsage: "gplay migrate fastlane --source <path> [--output-dir <path>] [--dry-run] [--locales <list>]",
+		ShortHelp:  "Import metadata from Fastlane directory structure.",
+		LongHelp: `Import metadata from a Fastlane metadata/android/ directory.
+
+Reads the standard Fastlane directory layout and copies text files,
+changelogs, and images into the gplay metadata directory.
+
+Fastlane directory structure:
+  metadata/android/
+    en-US/
+      title.txt
+      short_description.txt
+      full_description.txt
+      video.txt
+      changelogs/
+        100.txt
+      images/
+        phoneScreenshots/
+        featureGraphic.png
+    de-DE/
+      ...`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*source) == "" {
+				return fmt.Errorf("--source is required")
+			}
+
+			var localeFilter map[string]bool
+			if strings.TrimSpace(*locales) != "" {
+				localeFilter = make(map[string]bool)
+				for _, l := range strings.Split(*locales, ",") {
+					l = strings.TrimSpace(l)
+					if l != "" {
+						localeFilter[l] = true
+					}
+				}
+			}
+
+			summary, err := runFastlaneMigration(*source, *outputDir, *dryRun, localeFilter)
+			if err != nil {
+				return err
+			}
+
+			return shared.PrintOutput(summary, *outputFlag, *pretty)
+		},
+	}
+}
+
+// runFastlaneMigration scans the Fastlane source directory and optionally
+// copies files to the output directory. It returns a summary of what was
+// found or imported.
+func runFastlaneMigration(source, outputDir string, dryRun bool, localeFilter map[string]bool) (*FastlaneSummary, error) {
+	// Validate source exists and is a directory.
+	info, err := os.Stat(source)
+	if err != nil {
+		return nil, fmt.Errorf("cannot access source directory: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("source is not a directory: %s", source)
+	}
+
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read source directory: %w", err)
+	}
+
+	summary := &FastlaneSummary{
+		Source:  source,
+		DryRun:  dryRun,
+	}
+	if !dryRun {
+		summary.OutputDir = outputDir
+	}
+
+	// Collect locale dirs, sorted for deterministic output.
+	var localeDirs []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if localeFilter != nil && !localeFilter[name] {
+			continue
+		}
+		localeDirs = append(localeDirs, name)
+	}
+	sort.Strings(localeDirs)
+
+	if len(localeDirs) == 0 {
+		summary.Warnings = append(summary.Warnings, "no locale directories found in source")
+		return summary, nil
+	}
+
+	for _, locale := range localeDirs {
+		localeSrc := filepath.Join(source, locale)
+		localeDst := filepath.Join(outputDir, locale)
+
+		ls := LocaleSummary{Locale: locale}
+
+		// --- Text files ---
+		for _, tf := range fastlaneTextFiles {
+			srcPath := filepath.Join(localeSrc, tf)
+			if _, err := os.Stat(srcPath); err != nil {
+				continue
+			}
+			ls.TextFiles = append(ls.TextFiles, tf)
+			summary.TotalFiles++
+
+			if !dryRun {
+				if err := copyFile(srcPath, filepath.Join(localeDst, tf)); err != nil {
+					summary.Warnings = append(summary.Warnings,
+						fmt.Sprintf("[%s] failed to copy %s: %v", locale, tf, err))
+				}
+			}
+		}
+
+		// --- Changelogs ---
+		changelogSrc := filepath.Join(localeSrc, "changelogs")
+		if clEntries, err := os.ReadDir(changelogSrc); err == nil {
+			for _, cl := range clEntries {
+				if cl.IsDir() || !strings.HasSuffix(cl.Name(), ".txt") {
+					continue
+				}
+				ls.Changelogs = append(ls.Changelogs, cl.Name())
+				summary.TotalFiles++
+
+				if !dryRun {
+					src := filepath.Join(changelogSrc, cl.Name())
+					dst := filepath.Join(localeDst, "changelogs", cl.Name())
+					if err := copyFile(src, dst); err != nil {
+						summary.Warnings = append(summary.Warnings,
+							fmt.Sprintf("[%s] failed to copy changelog %s: %v", locale, cl.Name(), err))
+					}
+				}
+			}
+			sort.Strings(ls.Changelogs)
+		}
+
+		// --- Images ---
+		imagesSrc := filepath.Join(localeSrc, "images")
+		if _, err := os.Stat(imagesSrc); err == nil {
+			// Screenshot directories
+			for _, imgDir := range fastlaneImageDirs {
+				dirPath := filepath.Join(imagesSrc, imgDir)
+				imgEntries, err := os.ReadDir(dirPath)
+				if err != nil {
+					continue
+				}
+				for _, img := range imgEntries {
+					if img.IsDir() {
+						continue
+					}
+					if !isImageFile(img.Name()) {
+						continue
+					}
+					rel := filepath.Join("images", imgDir, img.Name())
+					ls.Images = append(ls.Images, rel)
+					summary.TotalImages++
+
+					if !dryRun {
+						src := filepath.Join(dirPath, img.Name())
+						dst := filepath.Join(localeDst, rel)
+						if err := copyFile(src, dst); err != nil {
+							summary.Warnings = append(summary.Warnings,
+								fmt.Sprintf("[%s] failed to copy %s: %v", locale, rel, err))
+						}
+					}
+				}
+			}
+
+			// Single image files (featureGraphic.png, etc.)
+			for _, singleImg := range fastlaneSingleImages {
+				srcPath := filepath.Join(imagesSrc, singleImg)
+				if _, err := os.Stat(srcPath); err != nil {
+					continue
+				}
+				rel := filepath.Join("images", singleImg)
+				ls.Images = append(ls.Images, rel)
+				summary.TotalImages++
+
+				if !dryRun {
+					dst := filepath.Join(localeDst, rel)
+					if err := copyFile(srcPath, dst); err != nil {
+						summary.Warnings = append(summary.Warnings,
+							fmt.Sprintf("[%s] failed to copy %s: %v", locale, rel, err))
+					}
+				}
+			}
+			sort.Strings(ls.Images)
+		}
+
+		summary.Locales = append(summary.Locales, ls)
+	}
+
+	return summary, nil
+}
+
+// copyFile copies a single file, creating parent directories as needed.
+func copyFile(src, dst string) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+	return out.Close()
+}
+
+// isImageFile checks if a filename has a common image extension.
+func isImageFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	switch ext {
+	case ".png", ".jpg", ".jpeg", ".webp":
+		return true
+	}
+	return false
+}

--- a/internal/cli/migrate/fastlane_test.go
+++ b/internal/cli/migrate/fastlane_test.go
@@ -1,0 +1,356 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupFastlaneFixture creates a realistic Fastlane metadata/android/ tree
+// inside a temp directory and returns the path to the root locale directory.
+func setupFastlaneFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+
+	// en-US locale with all file types
+	enUS := filepath.Join(root, "en-US")
+	mkFile(t, filepath.Join(enUS, "title.txt"), "My App")
+	mkFile(t, filepath.Join(enUS, "short_description.txt"), "A short description")
+	mkFile(t, filepath.Join(enUS, "full_description.txt"), "A full description of the app.")
+	mkFile(t, filepath.Join(enUS, "video.txt"), "https://youtu.be/abc123")
+	mkFile(t, filepath.Join(enUS, "changelogs", "100.txt"), "Bug fixes")
+	mkFile(t, filepath.Join(enUS, "changelogs", "200.txt"), "New feature")
+	mkFile(t, filepath.Join(enUS, "images", "phoneScreenshots", "1.png"), "png-data")
+	mkFile(t, filepath.Join(enUS, "images", "phoneScreenshots", "2.png"), "png-data")
+	mkFile(t, filepath.Join(enUS, "images", "featureGraphic.png"), "feature-data")
+
+	// de-DE locale with partial files
+	deDE := filepath.Join(root, "de-DE")
+	mkFile(t, filepath.Join(deDE, "title.txt"), "Meine App")
+	mkFile(t, filepath.Join(deDE, "short_description.txt"), "Eine kurze Beschreibung")
+
+	return root
+}
+
+// mkFile creates a file with the given content, creating parent dirs.
+func mkFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// ─── CLI-level tests ───────────────────────────────────────────────────────
+
+func TestFastlaneCommand_SourceRequired(t *testing.T) {
+	cmd := FastlaneCommand()
+	err := cmd.ParseAndRun(context.Background(), []string{})
+	if err == nil {
+		t.Fatal("expected error when --source is missing")
+	}
+	if got := err.Error(); got != "--source is required" {
+		t.Fatalf("unexpected error: %s", got)
+	}
+}
+
+func TestFastlaneCommand_InvalidOutputFlags(t *testing.T) {
+	cmd := FastlaneCommand()
+	err := cmd.ParseAndRun(context.Background(), []string{
+		"--source", "/tmp/does-not-matter",
+		"--output", "table",
+		"--pretty",
+	})
+	if err == nil {
+		t.Fatal("expected error for --pretty with table output")
+	}
+}
+
+func TestFastlaneCommand_SourceNotFound(t *testing.T) {
+	cmd := FastlaneCommand()
+	err := cmd.ParseAndRun(context.Background(), []string{
+		"--source", "/tmp/nonexistent-dir-xyz",
+	})
+	if err == nil {
+		t.Fatal("expected error for missing source directory")
+	}
+}
+
+func TestFastlaneCommand_DryRunProducesJSON(t *testing.T) {
+	src := setupFastlaneFixture(t)
+
+	// Capture stdout.
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := FastlaneCommand()
+	err := cmd.ParseAndRun(context.Background(), []string{
+		"--source", src,
+		"--dry-run",
+	})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf [8192]byte
+	n, _ := r.Read(buf[:])
+	output := string(buf[:n])
+
+	var summary FastlaneSummary
+	if err := json.Unmarshal([]byte(output), &summary); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, output)
+	}
+
+	if !summary.DryRun {
+		t.Error("expected dryRun=true")
+	}
+	if len(summary.Locales) != 2 {
+		t.Fatalf("expected 2 locales, got %d", len(summary.Locales))
+	}
+}
+
+func TestFastlaneCommand_LocaleFilter(t *testing.T) {
+	src := setupFastlaneFixture(t)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	cmd := FastlaneCommand()
+	err := cmd.ParseAndRun(context.Background(), []string{
+		"--source", src,
+		"--dry-run",
+		"--locales", "de-DE",
+	})
+
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var buf [8192]byte
+	n, _ := r.Read(buf[:])
+
+	var summary FastlaneSummary
+	if err := json.Unmarshal(buf[:n], &summary); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	if len(summary.Locales) != 1 {
+		t.Fatalf("expected 1 locale, got %d", len(summary.Locales))
+	}
+	if summary.Locales[0].Locale != "de-DE" {
+		t.Errorf("expected de-DE, got %s", summary.Locales[0].Locale)
+	}
+}
+
+// ─── Unit tests for core migration logic ───────────────────────────────────
+
+func TestRunFastlaneMigration_DryRun(t *testing.T) {
+	src := setupFastlaneFixture(t)
+
+	summary, err := runFastlaneMigration(src, "/unused", true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !summary.DryRun {
+		t.Error("expected dryRun=true")
+	}
+	if summary.OutputDir != "" {
+		t.Errorf("expected empty outputDir in dry-run, got %q", summary.OutputDir)
+	}
+	if len(summary.Locales) != 2 {
+		t.Fatalf("expected 2 locales, got %d", len(summary.Locales))
+	}
+
+	// en-US assertions
+	en := findLocale(t, summary, "en-US")
+	assertContains(t, en.TextFiles, "title.txt")
+	assertContains(t, en.TextFiles, "short_description.txt")
+	assertContains(t, en.TextFiles, "full_description.txt")
+	assertContains(t, en.TextFiles, "video.txt")
+	if len(en.Changelogs) != 2 {
+		t.Errorf("expected 2 changelogs, got %d", len(en.Changelogs))
+	}
+	if len(en.Images) != 3 {
+		t.Errorf("expected 3 images, got %d: %v", len(en.Images), en.Images)
+	}
+
+	// de-DE assertions
+	de := findLocale(t, summary, "de-DE")
+	if len(de.TextFiles) != 2 {
+		t.Errorf("expected 2 text files, got %d", len(de.TextFiles))
+	}
+	if len(de.Changelogs) != 0 {
+		t.Errorf("expected 0 changelogs, got %d", len(de.Changelogs))
+	}
+
+	// Totals
+	if summary.TotalFiles != 8 { // 4 text + 2 changelog (en) + 2 text (de)
+		t.Errorf("expected 8 total files, got %d", summary.TotalFiles)
+	}
+	if summary.TotalImages != 3 { // 2 phone + 1 feature
+		t.Errorf("expected 3 total images, got %d", summary.TotalImages)
+	}
+}
+
+func TestRunFastlaneMigration_CopiesFiles(t *testing.T) {
+	src := setupFastlaneFixture(t)
+	dst := filepath.Join(t.TempDir(), "output")
+
+	summary, err := runFastlaneMigration(src, dst, false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if summary.DryRun {
+		t.Error("expected dryRun=false")
+	}
+	if summary.OutputDir != dst {
+		t.Errorf("expected outputDir=%q, got %q", dst, summary.OutputDir)
+	}
+
+	// Verify files were actually written.
+	assertFileContent(t, filepath.Join(dst, "en-US", "title.txt"), "My App")
+	assertFileContent(t, filepath.Join(dst, "en-US", "short_description.txt"), "A short description")
+	assertFileContent(t, filepath.Join(dst, "en-US", "changelogs", "100.txt"), "Bug fixes")
+	assertFileContent(t, filepath.Join(dst, "en-US", "changelogs", "200.txt"), "New feature")
+	assertFileExists(t, filepath.Join(dst, "en-US", "images", "phoneScreenshots", "1.png"))
+	assertFileExists(t, filepath.Join(dst, "en-US", "images", "phoneScreenshots", "2.png"))
+	assertFileExists(t, filepath.Join(dst, "en-US", "images", "featureGraphic.png"))
+	assertFileContent(t, filepath.Join(dst, "de-DE", "title.txt"), "Meine App")
+}
+
+func TestRunFastlaneMigration_LocaleFilter(t *testing.T) {
+	src := setupFastlaneFixture(t)
+
+	filter := map[string]bool{"en-US": true}
+	summary, err := runFastlaneMigration(src, "/unused", true, filter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(summary.Locales) != 1 {
+		t.Fatalf("expected 1 locale, got %d", len(summary.Locales))
+	}
+	if summary.Locales[0].Locale != "en-US" {
+		t.Errorf("expected en-US, got %s", summary.Locales[0].Locale)
+	}
+}
+
+func TestRunFastlaneMigration_EmptySource(t *testing.T) {
+	src := t.TempDir() // empty directory
+
+	summary, err := runFastlaneMigration(src, "/unused", true, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(summary.Locales) != 0 {
+		t.Errorf("expected 0 locales, got %d", len(summary.Locales))
+	}
+	if len(summary.Warnings) == 0 {
+		t.Error("expected warning about no locale directories")
+	}
+}
+
+func TestRunFastlaneMigration_SourceNotDir(t *testing.T) {
+	tmp := t.TempDir()
+	file := filepath.Join(tmp, "notadir.txt")
+	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := runFastlaneMigration(file, "/unused", true, nil)
+	if err == nil {
+		t.Fatal("expected error for non-directory source")
+	}
+}
+
+func TestRunFastlaneMigration_SourceMissing(t *testing.T) {
+	_, err := runFastlaneMigration("/tmp/nonexistent-migrate-test", "/unused", true, nil)
+	if err == nil {
+		t.Fatal("expected error for missing source")
+	}
+}
+
+func TestMigrateCommand_ShowsHelp(t *testing.T) {
+	cmd := MigrateCommand()
+	err := cmd.ParseAndRun(context.Background(), []string{})
+	if err == nil {
+		t.Fatal("expected ErrHelp from parent command")
+	}
+}
+
+func TestIsImageFile(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"photo.png", true},
+		{"photo.PNG", true},
+		{"photo.jpg", true},
+		{"photo.jpeg", true},
+		{"photo.webp", true},
+		{"readme.txt", false},
+		{"data.json", false},
+		{".gitkeep", false},
+	}
+	for _, tt := range tests {
+		if got := isImageFile(tt.name); got != tt.want {
+			t.Errorf("isImageFile(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+// ─── Test helpers ──────────────────────────────────────────────────────────
+
+func findLocale(t *testing.T, s *FastlaneSummary, locale string) LocaleSummary {
+	t.Helper()
+	for _, ls := range s.Locales {
+		if ls.Locale == locale {
+			return ls
+		}
+	}
+	t.Fatalf("locale %q not found in summary", locale)
+	return LocaleSummary{}
+}
+
+func assertContains(t *testing.T, slice []string, item string) {
+	t.Helper()
+	for _, s := range slice {
+		if s == item {
+			return
+		}
+	}
+	t.Errorf("expected %v to contain %q", slice, item)
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("cannot read %s: %v", path, err)
+	}
+	if got := string(data); got != want {
+		t.Errorf("%s: got %q, want %q", path, got, want)
+	}
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file to exist: %s", path)
+	}
+}

--- a/internal/cli/migrate/migrate.go
+++ b/internal/cli/migrate/migrate.go
@@ -1,0 +1,32 @@
+package migrate
+
+import (
+	"context"
+	"flag"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+// MigrateCommand returns the parent migrate command.
+func MigrateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("migrate", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "migrate",
+		ShortUsage: "gplay migrate <subcommand> [flags]",
+		ShortHelp:  "Migrate metadata from other tools.",
+		LongHelp: `Import metadata from other store management tools.
+
+Supported sources:
+  fastlane    Import from Fastlane metadata/android/ directory structure`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			FastlaneCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Add `gplay migrate fastlane` command that imports Fastlane `metadata/android/` directory structure into gplay format
- Supports `--source` (required), `--output-dir`, `--dry-run`, `--locales` filter, and standard `--output`/`--pretty` flags
- File-operations-only feature (no API calls) -- reads text files, changelogs, and images from the standard Fastlane layout

## Implementation
- `internal/cli/migrate/migrate.go` -- parent `migrate` command group
- `internal/cli/migrate/fastlane.go` -- `fastlane` subcommand with scanning and file copying logic
- `internal/cli/migrate/fastlane_test.go` -- 13 tests covering CLI flags, dry-run, file copying, locale filtering, edge cases

## Test plan
- [x] `go test ./internal/cli/migrate/...` passes (13/13 tests)
- [x] `go build ./...` succeeds
- [ ] Manual test: `gplay migrate fastlane --source ./metadata/android --dry-run`
- [ ] Manual test: `gplay migrate fastlane --source ./metadata/android --output-dir /tmp/out --locales en-US`

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)