### PR TITLE
feat: add dry-run support (#40)

### DIFF
--- a/internal/cli/shared/dryrun.go
+++ b/internal/cli/shared/dryrun.go
@@ -1,0 +1,84 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// dryRunKey is the context key for the dry-run flag.
+type dryRunKey struct{}
+
+// ContextWithDryRun returns a context with the dry-run flag set.
+func ContextWithDryRun(ctx context.Context, dryRun bool) context.Context {
+	return context.WithValue(ctx, dryRunKey{}, dryRun)
+}
+
+// IsDryRun returns true if the context has dry-run enabled.
+func IsDryRun(ctx context.Context) bool {
+	v, ok := ctx.Value(dryRunKey{}).(bool)
+	return ok && v
+}
+
+// writeMethods are HTTP methods that mutate state.
+var writeMethods = map[string]bool{
+	http.MethodPost:   true,
+	http.MethodPut:    true,
+	http.MethodPatch:  true,
+	http.MethodDelete: true,
+}
+
+// DryRunTransport wraps an http.RoundTripper and intercepts write requests
+// when dry-run mode is active. GET/HEAD requests pass through normally.
+// Write requests (POST, PUT, PATCH, DELETE) are logged to stderr and return
+// a synthetic 200 OK response without making any actual API call.
+type DryRunTransport struct {
+	Base   http.RoundTripper
+	Writer io.Writer // output destination (typically os.Stderr)
+}
+
+// RoundTrip implements http.RoundTripper.
+func (t *DryRunTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if !writeMethods[req.Method] {
+		return t.Base.RoundTrip(req)
+	}
+
+	w := t.Writer
+	if w == nil {
+		return t.Base.RoundTrip(req)
+	}
+
+	// Log the intercepted request.
+	fmt.Fprintf(w, "[DRY RUN] %s %s\n", req.Method, req.URL.String())
+
+	if req.Body != nil && req.Body != http.NoBody {
+		body, err := io.ReadAll(req.Body)
+		req.Body.Close()
+		if err == nil && len(body) > 0 {
+			// Truncate very large bodies (e.g., binary uploads) for readability.
+			const maxBody = 2048
+			display := string(body)
+			if len(display) > maxBody {
+				display = display[:maxBody] + "... (truncated)"
+			}
+			fmt.Fprintf(w, "[DRY RUN] Body: %s\n", strings.TrimSpace(display))
+		}
+	}
+
+	fmt.Fprintf(w, "[DRY RUN] No changes were made.\n")
+
+	// Return a synthetic successful response.
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(bytes.NewBufferString("{}")),
+		Request:    req,
+	}, nil
+}

--- a/internal/cli/shared/dryrun_test.go
+++ b/internal/cli/shared/dryrun_test.go
@@ -1,0 +1,271 @@
+package shared
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestContextDryRun(t *testing.T) {
+	t.Run("default context is not dry-run", func(t *testing.T) {
+		ctx := context.Background()
+		if IsDryRun(ctx) {
+			t.Fatal("expected IsDryRun to be false on background context")
+		}
+	})
+
+	t.Run("context with dry-run true", func(t *testing.T) {
+		ctx := ContextWithDryRun(context.Background(), true)
+		if !IsDryRun(ctx) {
+			t.Fatal("expected IsDryRun to be true")
+		}
+	})
+
+	t.Run("context with dry-run false", func(t *testing.T) {
+		ctx := ContextWithDryRun(context.Background(), false)
+		if IsDryRun(ctx) {
+			t.Fatal("expected IsDryRun to be false when explicitly set to false")
+		}
+	})
+}
+
+// fakeTransport records whether RoundTrip was called.
+type fakeTransport struct {
+	called  bool
+	lastReq *http.Request
+}
+
+func (f *fakeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.called = true
+	f.lastReq = req
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Status:     "200 OK",
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader(`{"real":"response"}`)),
+		Request:    req,
+	}, nil
+}
+
+func TestDryRunTransport_InterceptsWriteMethods(t *testing.T) {
+	methods := []string{http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete}
+
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			base := &fakeTransport{}
+			var buf bytes.Buffer
+			transport := &DryRunTransport{Base: base, Writer: &buf}
+
+			body := `{"track":"production"}`
+			req, err := http.NewRequest(method, "https://androidpublisher.googleapis.com/v3/test", strings.NewReader(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			resp, err := transport.RoundTrip(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if base.called {
+				t.Fatal("expected base transport NOT to be called for write method")
+			}
+
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+			}
+
+			output := buf.String()
+			if !strings.Contains(output, "[DRY RUN]") {
+				t.Fatalf("expected [DRY RUN] prefix in output, got: %s", output)
+			}
+			if !strings.Contains(output, method) {
+				t.Fatalf("expected method %s in output, got: %s", method, output)
+			}
+			if !strings.Contains(output, "https://androidpublisher.googleapis.com/v3/test") {
+				t.Fatalf("expected URL in output, got: %s", output)
+			}
+			if !strings.Contains(output, `"track":"production"`) {
+				t.Fatalf("expected body in output, got: %s", output)
+			}
+			if !strings.Contains(output, "No changes were made.") {
+				t.Fatalf("expected 'No changes were made.' in output, got: %s", output)
+			}
+		})
+	}
+}
+
+func TestDryRunTransport_PassesThroughGET(t *testing.T) {
+	base := &fakeTransport{}
+	var buf bytes.Buffer
+	transport := &DryRunTransport{Base: base, Writer: &buf}
+
+	req, err := http.NewRequest(http.MethodGet, "https://androidpublisher.googleapis.com/v3/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !base.called {
+		t.Fatal("expected base transport to be called for GET")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+	}
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no dry-run output for GET, got: %s", buf.String())
+	}
+}
+
+func TestDryRunTransport_PassesThroughHEAD(t *testing.T) {
+	base := &fakeTransport{}
+	var buf bytes.Buffer
+	transport := &DryRunTransport{Base: base, Writer: &buf}
+
+	req, err := http.NewRequest(http.MethodHead, "https://example.com/test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !base.called {
+		t.Fatal("expected base transport to be called for HEAD")
+	}
+
+	if buf.Len() != 0 {
+		t.Fatalf("expected no dry-run output for HEAD, got: %s", buf.String())
+	}
+}
+
+func TestDryRunTransport_NoBody(t *testing.T) {
+	base := &fakeTransport{}
+	var buf bytes.Buffer
+	transport := &DryRunTransport{Base: base, Writer: &buf}
+
+	req, err := http.NewRequest(http.MethodDelete, "https://androidpublisher.googleapis.com/v3/resource/123", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if base.called {
+		t.Fatal("expected base transport NOT to be called")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 OK, got %d", resp.StatusCode)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "[DRY RUN] DELETE") {
+		t.Fatalf("expected DELETE in output, got: %s", output)
+	}
+	// Should not contain "Body:" since there was no body
+	if strings.Contains(output, "Body:") {
+		t.Fatalf("unexpected Body line in output for bodyless request: %s", output)
+	}
+	if !strings.Contains(output, "No changes were made.") {
+		t.Fatalf("expected 'No changes were made.' in output, got: %s", output)
+	}
+}
+
+func TestDryRunTransport_LargeBodyTruncated(t *testing.T) {
+	base := &fakeTransport{}
+	var buf bytes.Buffer
+	transport := &DryRunTransport{Base: base, Writer: &buf}
+
+	// Create a body larger than 2048 bytes.
+	largeBody := strings.Repeat("x", 3000)
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/upload", strings.NewReader(largeBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "... (truncated)") {
+		t.Fatalf("expected truncation marker in output, got: %s", output)
+	}
+}
+
+func TestDryRunTransport_SyntheticResponseBody(t *testing.T) {
+	base := &fakeTransport{}
+	var buf bytes.Buffer
+	transport := &DryRunTransport{Base: base, Writer: &buf}
+
+	req, err := http.NewRequest(http.MethodPost, "https://example.com/test", strings.NewReader(`{}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	if string(body) != "{}" {
+		t.Fatalf("expected empty JSON body '{}', got: %s", string(body))
+	}
+
+	if resp.Header.Get("Content-Type") != "application/json" {
+		t.Fatalf("expected application/json content type, got: %s", resp.Header.Get("Content-Type"))
+	}
+}
+
+func TestDryRunTransport_OutputFormat(t *testing.T) {
+	base := &fakeTransport{}
+	var buf bytes.Buffer
+	transport := &DryRunTransport{Base: base, Writer: &buf}
+
+	body := `{"releases":[{"status":"completed","versionCodes":["42"]}]}`
+	req, err := http.NewRequest(http.MethodPut, "https://androidpublisher.googleapis.com/androidpublisher/v3/applications/com.example.app/edits/123/tracks/production", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = transport.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := buf.String()
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines of output, got %d: %s", len(lines), output)
+	}
+
+	if !strings.HasPrefix(lines[0], "[DRY RUN] PUT ") {
+		t.Fatalf("line 0 should start with '[DRY RUN] PUT ', got: %s", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "[DRY RUN] Body: ") {
+		t.Fatalf("line 1 should start with '[DRY RUN] Body: ', got: %s", lines[1])
+	}
+	if lines[2] != "[DRY RUN] No changes were made." {
+		t.Fatalf("line 2 should be '[DRY RUN] No changes were made.', got: %s", lines[2])
+	}
+}

--- a/internal/playclient/client.go
+++ b/internal/playclient/client.go
@@ -48,6 +48,15 @@ func NewService(ctx context.Context) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Wrap transport with DryRunTransport when dry-run is active.
+	if shared.IsDryRun(ctx) {
+		client.Transport = &shared.DryRunTransport{
+			Base:   client.Transport,
+			Writer: os.Stderr,
+		}
+	}
+
 	api, err := androidpublisher.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Add `--dry-run` global flag to the root command that previews write operations without executing them
- Create `DryRunTransport` (wraps `http.RoundTripper`) that intercepts POST/PUT/PATCH/DELETE requests, logs them to stderr with `[DRY RUN]` prefix, and returns synthetic 200 OK responses
- Wire dry-run flag via `context.Context` so all commands automatically get dry-run support at the HTTP transport layer -- no per-command changes needed

## How it works

1. `--dry-run` flag on root command sets a boolean in context via `shared.ContextWithDryRun()`
2. `playclient.NewService()` checks context and wraps the OAuth HTTP client's transport with `DryRunTransport`
3. GET/HEAD requests pass through normally (reads are safe)
4. POST/PUT/PATCH/DELETE requests are intercepted: method + URL + body logged to stderr, synthetic `{}` response returned

Example output:
```
[DRY RUN] PUT https://androidpublisher.googleapis.com/.../tracks/production
[DRY RUN] Body: {"track":"production","releases":[...]}
[DRY RUN] No changes were made.
```

## Files changed

- **Created**: `internal/cli/shared/dryrun.go` -- `DryRunTransport`, context helpers (`ContextWithDryRun`, `IsDryRun`)
- **Created**: `internal/cli/shared/dryrun_test.go` -- 8 test cases covering intercept, passthrough, truncation, format
- **Modified**: `main.go` -- Add `--dry-run` flag, propagate via context
- **Modified**: `internal/playclient/client.go` -- Wrap HTTP transport when dry-run active

## Test plan

- [x] Unit test: `DryRunTransport` intercepts POST/PUT/PATCH/DELETE and returns synthetic response
- [x] Unit test: `DryRunTransport` passes through GET/HEAD requests unmodified
- [x] Unit test: dry-run output format matches `[DRY RUN]` prefix pattern
- [x] Unit test: context propagation of dry-run flag (true, false, unset)
- [x] Unit test: large body truncation at 2048 chars
- [x] Unit test: no-body requests (DELETE without body)
- [x] Unit test: synthetic response has `{}` body and `application/json` content type
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)