### PR TITLE
feat: add braille spinner for API calls

### DIFF
--- a/internal/cli/shared/spinner.go
+++ b/internal/cli/shared/spinner.go
@@ -27,14 +27,15 @@ type spinner struct {
 	active bool
 }
 
-// newSpinner creates a spinner. If the env var GPLAY_SPINNER_DISABLED is set,
-// the writer is forced to nil (no output).
+// newSpinner creates a spinner. If the env var GPLAY_SPINNER_DISABLED is set
+// or GPLAY_DEBUG is set (debug/retry logs would collide), the writer is forced
+// to nil (no output).
 func newSpinner(label string, w io.Writer, delay time.Duration) *spinner {
-	if os.Getenv(spinnerEnvVar) != "" {
+	if os.Getenv(spinnerEnvVar) != "" || os.Getenv("GPLAY_DEBUG") != "" {
 		w = nil
 	}
 	return &spinner{
-		label: label,
+		label:  label,
 		writer: w,
 		tick:   spinnerTickRate,
 		delay:  delay,

--- a/internal/cli/shared/spinner_test.go
+++ b/internal/cli/shared/spinner_test.go
@@ -129,6 +129,16 @@ func TestSpinner_EnvVarDisabled(t *testing.T) {
 	}
 }
 
+func TestSpinner_DebugModeDisabled(t *testing.T) {
+	t.Setenv("GPLAY_DEBUG", "api")
+
+	var buf bytes.Buffer
+	s := newSpinner("loading", &buf, 0)
+	if s.writer != nil {
+		t.Error("spinner writer should be nil when GPLAY_DEBUG is set")
+	}
+}
+
 func TestSpinner_EnvVarNotSet(t *testing.T) {
 	os.Unsetenv("GPLAY_SPINNER_DISABLED")
 


### PR DESCRIPTION
## Summary
- Add `WithSpinner` and `WithSpinnerDelayed` helpers that display a braille spinner on stderr during long API calls
- TTY-gated (no output in pipes/CI), opt-out via `GPLAY_SPINNER_DISABLED`
- 120ms tick rate, thread-safe, handles panics and errors

Closes #98