### PR TITLE
feat: add error classification with actionable hints

### DIFF
--- a/internal/cli/shared/errfmt/errfmt.go
+++ b/internal/cli/shared/errfmt/errfmt.go
@@ -1,0 +1,118 @@
+package errfmt
+
+import (
+	"errors"
+	"net"
+	"os"
+	"strings"
+
+	"google.golang.org/api/googleapi"
+)
+
+// Category represents the type of error.
+type Category string
+
+const (
+	CategoryAuth        Category = "auth"
+	CategoryPermission  Category = "permission"
+	CategoryNotFound    Category = "not_found"
+	CategoryTimeout     Category = "timeout"
+	CategoryMissingAuth Category = "missing_auth"
+	CategoryGeneric     Category = "generic"
+)
+
+// ClassifiedError holds a classified error with an actionable hint.
+type ClassifiedError struct {
+	Original error
+	Category Category
+	Hint     string
+}
+
+func (c *ClassifiedError) Error() string {
+	return c.Original.Error()
+}
+
+func (c *ClassifiedError) Unwrap() error {
+	return c.Original
+}
+
+// Classify auto-detects the error category and adds an actionable hint.
+func Classify(err error) *ClassifiedError {
+	if err == nil {
+		return nil
+	}
+
+	// Check for Google API errors (401, 403, 404).
+	var gerr *googleapi.Error
+	if errors.As(err, &gerr) {
+		switch gerr.Code {
+		case 401:
+			return &ClassifiedError{
+				Original: err,
+				Category: CategoryAuth,
+				Hint:     "Your credentials are invalid or expired. Run `gplay auth login` to re-authenticate.",
+			}
+		case 403:
+			return &ClassifiedError{
+				Original: err,
+				Category: CategoryPermission,
+				Hint:     "The service account lacks required permissions. Check Play Console access settings.",
+			}
+		case 404:
+			return &ClassifiedError{
+				Original: err,
+				Category: CategoryNotFound,
+				Hint:     "Resource not found. Verify the package name and resource IDs are correct.",
+			}
+		}
+	}
+
+	// Check for timeout errors.
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return &ClassifiedError{
+			Original: err,
+			Category: CategoryTimeout,
+			Hint:     "Request timed out. Try increasing GPLAY_TIMEOUT or check your network connection.",
+		}
+	}
+
+	// Check for missing auth (file not found for service account).
+	if os.IsNotExist(err) {
+		return &ClassifiedError{
+			Original: err,
+			Category: CategoryMissingAuth,
+			Hint:     "Service account file not found. Run `gplay auth doctor` to diagnose.",
+		}
+	}
+
+	// Check for context deadline exceeded.
+	if strings.Contains(err.Error(), "context deadline exceeded") {
+		return &ClassifiedError{
+			Original: err,
+			Category: CategoryTimeout,
+			Hint:     "Request timed out. Try increasing GPLAY_TIMEOUT or check your network connection.",
+		}
+	}
+
+	return &ClassifiedError{Original: err, Category: CategoryGeneric, Hint: ""}
+}
+
+// FormatStderr returns a formatted error string for stderr output.
+func FormatStderr(err error) string {
+	classified := Classify(err)
+	if classified == nil {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("Error: ")
+	sb.WriteString(classified.Original.Error())
+
+	if classified.Hint != "" {
+		sb.WriteString("\n\nHint: ")
+		sb.WriteString(classified.Hint)
+	}
+
+	return sb.String()
+}

--- a/internal/cli/shared/errfmt/errfmt_test.go
+++ b/internal/cli/shared/errfmt/errfmt_test.go
@@ -1,0 +1,179 @@
+package errfmt
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/googleapi"
+)
+
+// fakeTimeoutErr implements net.Error with Timeout() returning true.
+type fakeTimeoutErr struct{ msg string }
+
+func (e *fakeTimeoutErr) Error() string   { return e.msg }
+func (e *fakeTimeoutErr) Timeout() bool   { return true }
+func (e *fakeTimeoutErr) Temporary() bool { return false }
+
+func TestClassify_NilError(t *testing.T) {
+	if got := Classify(nil); got != nil {
+		t.Fatalf("Classify(nil) = %v; want nil", got)
+	}
+}
+
+func TestClassify_GoogleAPI401(t *testing.T) {
+	err := &googleapi.Error{Code: 401, Message: "unauthorized"}
+	c := Classify(err)
+	if c == nil {
+		t.Fatal("Classify returned nil for 401")
+	}
+	if c.Category != CategoryAuth {
+		t.Errorf("Category = %q; want %q", c.Category, CategoryAuth)
+	}
+	if !strings.Contains(c.Hint, "gplay auth login") {
+		t.Errorf("Hint = %q; want it to contain 'gplay auth login'", c.Hint)
+	}
+}
+
+func TestClassify_GoogleAPI403(t *testing.T) {
+	err := &googleapi.Error{Code: 403, Message: "forbidden"}
+	c := Classify(err)
+	if c == nil {
+		t.Fatal("Classify returned nil for 403")
+	}
+	if c.Category != CategoryPermission {
+		t.Errorf("Category = %q; want %q", c.Category, CategoryPermission)
+	}
+	if !strings.Contains(c.Hint, "permissions") {
+		t.Errorf("Hint = %q; want it to contain 'permissions'", c.Hint)
+	}
+}
+
+func TestClassify_GoogleAPI404(t *testing.T) {
+	err := &googleapi.Error{Code: 404, Message: "not found"}
+	c := Classify(err)
+	if c == nil {
+		t.Fatal("Classify returned nil for 404")
+	}
+	if c.Category != CategoryNotFound {
+		t.Errorf("Category = %q; want %q", c.Category, CategoryNotFound)
+	}
+	if !strings.Contains(c.Hint, "package name") {
+		t.Errorf("Hint = %q; want it to contain 'package name'", c.Hint)
+	}
+}
+
+func TestClassify_TimeoutError(t *testing.T) {
+	err := &fakeTimeoutErr{msg: "i/o timeout"}
+	c := Classify(err)
+	if c == nil {
+		t.Fatal("Classify returned nil for timeout error")
+	}
+	if c.Category != CategoryTimeout {
+		t.Errorf("Category = %q; want %q", c.Category, CategoryTimeout)
+	}
+	if !strings.Contains(c.Hint, "GPLAY_TIMEOUT") {
+		t.Errorf("Hint = %q; want it to contain 'GPLAY_TIMEOUT'", c.Hint)
+	}
+}
+
+func TestClassify_OsNotExist(t *testing.T) {
+	err := &os.PathError{Op: "open", Path: "/missing/key.json", Err: os.ErrNotExist}
+	c := Classify(err)
+	if c == nil {
+		t.Fatal("Classify returned nil for os.ErrNotExist")
+	}
+	if c.Category != CategoryMissingAuth {
+		t.Errorf("Category = %q; want %q", c.Category, CategoryMissingAuth)
+	}
+	if !strings.Contains(c.Hint, "gplay auth doctor") {
+		t.Errorf("Hint = %q; want it to contain 'gplay auth doctor'", c.Hint)
+	}
+}
+
+func TestClassify_ContextDeadlineExceeded(t *testing.T) {
+	err := fmt.Errorf("request failed: context deadline exceeded")
+	c := Classify(err)
+	if c == nil {
+		t.Fatal("Classify returned nil for context deadline exceeded")
+	}
+	if c.Category != CategoryTimeout {
+		t.Errorf("Category = %q; want %q", c.Category, CategoryTimeout)
+	}
+	if !strings.Contains(c.Hint, "GPLAY_TIMEOUT") {
+		t.Errorf("Hint = %q; want it to contain 'GPLAY_TIMEOUT'", c.Hint)
+	}
+}
+
+func TestClassify_GenericError(t *testing.T) {
+	err := fmt.Errorf("something went wrong")
+	c := Classify(err)
+	if c == nil {
+		t.Fatal("Classify returned nil for generic error")
+	}
+	if c.Category != CategoryGeneric {
+		t.Errorf("Category = %q; want %q", c.Category, CategoryGeneric)
+	}
+	if c.Hint != "" {
+		t.Errorf("Hint = %q; want empty", c.Hint)
+	}
+}
+
+func TestClassifiedError_Unwrap(t *testing.T) {
+	orig := fmt.Errorf("original")
+	c := Classify(orig)
+	if !errors.Is(c, orig) {
+		t.Error("Unwrap chain does not reach original error")
+	}
+}
+
+func TestClassifiedError_ErrorReturnsOriginalMessage(t *testing.T) {
+	orig := fmt.Errorf("original message")
+	c := Classify(orig)
+	if c.Error() != orig.Error() {
+		t.Errorf("Error() = %q; want %q", c.Error(), orig.Error())
+	}
+}
+
+func TestFormatStderr_WithHint(t *testing.T) {
+	err := &googleapi.Error{Code: 401, Message: "unauthorized"}
+	out := FormatStderr(err)
+	if !strings.HasPrefix(out, "Error: ") {
+		t.Errorf("output should start with 'Error: '; got %q", out)
+	}
+	if !strings.Contains(out, "\n\nHint: ") {
+		t.Errorf("output should contain '\\n\\nHint: '; got %q", out)
+	}
+}
+
+func TestFormatStderr_GenericNoHint(t *testing.T) {
+	err := fmt.Errorf("generic failure")
+	out := FormatStderr(err)
+	if !strings.HasPrefix(out, "Error: ") {
+		t.Errorf("output should start with 'Error: '; got %q", out)
+	}
+	if strings.Contains(out, "Hint:") {
+		t.Errorf("output should not contain 'Hint:'; got %q", out)
+	}
+}
+
+func TestFormatStderr_NilReturnsEmpty(t *testing.T) {
+	out := FormatStderr(nil)
+	if out != "" {
+		t.Errorf("FormatStderr(nil) = %q; want empty", out)
+	}
+}
+
+func TestClassify_WrappedGoogleAPIError(t *testing.T) {
+	inner := &googleapi.Error{Code: 403, Message: "forbidden"}
+	wrapped := fmt.Errorf("API call failed: %w", inner)
+	c := Classify(wrapped)
+	if c == nil {
+		t.Fatal("Classify returned nil for wrapped 403")
+	}
+	if c.Category != CategoryPermission {
+		t.Errorf("Category = %q; want %q", c.Category, CategoryPermission)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `errfmt` package with `Classify(err)` for auto-detecting error categories (auth, permission, not-found, timeout, missing auth)
- Add `FormatStderr(err)` for user-friendly error output with actionable hints
- Complements existing `WrapGoogleAPIError` with richer classification

Closes #101