### PR TITLE
feat: add JUnit CI report output for validation

### DIFF
--- a/internal/cli/shared/ci_flags.go
+++ b/internal/cli/shared/ci_flags.go
@@ -1,0 +1,47 @@
+package shared
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+)
+
+// validReportFormats lists the supported CI report formats.
+var validReportFormats = map[string]bool{
+	"junit": true,
+}
+
+// CIFlags holds CI report configuration.
+type CIFlags struct {
+	Report     string // "junit" or empty
+	ReportFile string // output file path (default: "results.xml")
+}
+
+// RegisterCIFlags adds --report and --report-file flags to a flag set.
+func RegisterCIFlags(fs *flag.FlagSet, cf *CIFlags) {
+	fs.StringVar(&cf.Report, "report", "", "CI report format (junit)")
+	fs.StringVar(&cf.ReportFile, "report-file", "results.xml", "CI report output file path")
+}
+
+// ValidateCIFlags checks that the flag values are valid.
+func ValidateCIFlags(cf *CIFlags) error {
+	report := strings.ToLower(strings.TrimSpace(cf.Report))
+
+	if report == "" {
+		return nil
+	}
+
+	if !validReportFormats[report] {
+		formats := make([]string, 0, len(validReportFormats))
+		for f := range validReportFormats {
+			formats = append(formats, f)
+		}
+		return fmt.Errorf("unsupported report format %q: valid values are: %s", cf.Report, strings.Join(formats, ", "))
+	}
+
+	if strings.TrimSpace(cf.ReportFile) == "" {
+		return fmt.Errorf("--report-file is required when --report is set")
+	}
+
+	return nil
+}

--- a/internal/cli/shared/ci_flags_test.go
+++ b/internal/cli/shared/ci_flags_test.go
@@ -1,0 +1,137 @@
+package shared
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestRegisterCIFlags(t *testing.T) {
+	t.Run("registers both flags with defaults", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		var cf CIFlags
+		RegisterCIFlags(fs, &cf)
+
+		reportFlag := fs.Lookup("report")
+		if reportFlag == nil {
+			t.Fatal("expected --report flag to be registered")
+		}
+		if reportFlag.DefValue != "" {
+			t.Fatalf("expected default value empty, got %q", reportFlag.DefValue)
+		}
+
+		reportFileFlag := fs.Lookup("report-file")
+		if reportFileFlag == nil {
+			t.Fatal("expected --report-file flag to be registered")
+		}
+		if reportFileFlag.DefValue != "results.xml" {
+			t.Fatalf("expected default value %q, got %q", "results.xml", reportFileFlag.DefValue)
+		}
+	})
+
+	t.Run("parses junit report flag", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		var cf CIFlags
+		RegisterCIFlags(fs, &cf)
+
+		err := fs.Parse([]string{"--report", "junit"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cf.Report != "junit" {
+			t.Fatalf("expected report %q, got %q", "junit", cf.Report)
+		}
+		if cf.ReportFile != "results.xml" {
+			t.Fatalf("expected report-file %q, got %q", "results.xml", cf.ReportFile)
+		}
+	})
+
+	t.Run("parses custom report file", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		var cf CIFlags
+		RegisterCIFlags(fs, &cf)
+
+		err := fs.Parse([]string{"--report", "junit", "--report-file", "custom.xml"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cf.Report != "junit" {
+			t.Fatalf("expected report %q, got %q", "junit", cf.Report)
+		}
+		if cf.ReportFile != "custom.xml" {
+			t.Fatalf("expected report-file %q, got %q", "custom.xml", cf.ReportFile)
+		}
+	})
+
+	t.Run("empty report is valid", func(t *testing.T) {
+		fs := flag.NewFlagSet("test", flag.ContinueOnError)
+		var cf CIFlags
+		RegisterCIFlags(fs, &cf)
+
+		err := fs.Parse([]string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cf.Report != "" {
+			t.Fatalf("expected empty report, got %q", cf.Report)
+		}
+	})
+}
+
+func TestValidateCIFlags(t *testing.T) {
+	t.Run("valid junit report", func(t *testing.T) {
+		cf := &CIFlags{Report: "junit", ReportFile: "results.xml"}
+		if err := ValidateCIFlags(cf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty report is valid", func(t *testing.T) {
+		cf := &CIFlags{Report: "", ReportFile: "results.xml"}
+		if err := ValidateCIFlags(cf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("invalid report format", func(t *testing.T) {
+		cf := &CIFlags{Report: "html", ReportFile: "results.xml"}
+		err := ValidateCIFlags(cf)
+		if err == nil {
+			t.Fatal("expected error for invalid report format")
+		}
+		expected := `unsupported report format "html": valid values are: junit`
+		if err.Error() != expected {
+			t.Fatalf("expected error %q, got %q", expected, err.Error())
+		}
+	})
+
+	t.Run("empty report file when report set", func(t *testing.T) {
+		cf := &CIFlags{Report: "junit", ReportFile: ""}
+		err := ValidateCIFlags(cf)
+		if err == nil {
+			t.Fatal("expected error for empty report file")
+		}
+		expected := "--report-file is required when --report is set"
+		if err.Error() != expected {
+			t.Fatalf("expected error %q, got %q", expected, err.Error())
+		}
+	})
+
+	t.Run("whitespace-only report file when report set", func(t *testing.T) {
+		cf := &CIFlags{Report: "junit", ReportFile: "   "}
+		err := ValidateCIFlags(cf)
+		if err == nil {
+			t.Fatal("expected error for whitespace report file")
+		}
+		expected := "--report-file is required when --report is set"
+		if err.Error() != expected {
+			t.Fatalf("expected error %q, got %q", expected, err.Error())
+		}
+	})
+
+	t.Run("case insensitive report format", func(t *testing.T) {
+		cf := &CIFlags{Report: "JUnit", ReportFile: "results.xml"}
+		if err := ValidateCIFlags(cf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}

--- a/internal/cli/shared/junit_report.go
+++ b/internal/cli/shared/junit_report.go
@@ -1,0 +1,105 @@
+package shared
+
+import (
+	"encoding/xml"
+	"fmt"
+	"os"
+)
+
+// JUnitTestSuites is the top-level XML element.
+type JUnitTestSuites struct {
+	XMLName xml.Name         `xml:"testsuites"`
+	Suites  []JUnitTestSuite `xml:"testsuite"`
+}
+
+// JUnitTestSuite represents a single test suite.
+type JUnitTestSuite struct {
+	XMLName  xml.Name        `xml:"testsuite"`
+	Name     string          `xml:"name,attr"`
+	Tests    int             `xml:"tests,attr"`
+	Failures int             `xml:"failures,attr"`
+	Errors   int             `xml:"errors,attr"`
+	Time     float64         `xml:"time,attr"`
+	Cases    []JUnitTestCase `xml:"testcase"`
+}
+
+// JUnitTestCase represents a single test case.
+type JUnitTestCase struct {
+	XMLName   xml.Name      `xml:"testcase"`
+	Name      string        `xml:"name,attr"`
+	ClassName string        `xml:"classname,attr"`
+	Time      float64       `xml:"time,attr"`
+	Failure   *JUnitFailure `xml:"failure,omitempty"`
+}
+
+// JUnitFailure represents a test failure.
+type JUnitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Body    string `xml:",chardata"`
+}
+
+// WriteJUnitReport writes JUnit XML to the specified file.
+func WriteJUnitReport(suites *JUnitTestSuites, filePath string) error {
+	data, err := xml.MarshalIndent(suites, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal JUnit XML: %w", err)
+	}
+
+	content := xml.Header + string(data) + "\n"
+
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		return fmt.Errorf("write JUnit report: %w", err)
+	}
+
+	return nil
+}
+
+// NewJUnitFromValidation converts validation results into JUnit format.
+// validationName is the suite name (e.g., "bundle", "listing", "screenshots").
+// errors are test failures, warnings are passed-with-warnings.
+func NewJUnitFromValidation(validationName string, errors []string, warnings []string, durationSecs float64) *JUnitTestSuites {
+	var cases []JUnitTestCase
+	failures := 0
+
+	for _, e := range errors {
+		cases = append(cases, JUnitTestCase{
+			Name:      e,
+			ClassName: validationName,
+			Failure: &JUnitFailure{
+				Message: e,
+				Type:    "validation-error",
+				Body:    e,
+			},
+		})
+		failures++
+	}
+
+	for _, w := range warnings {
+		cases = append(cases, JUnitTestCase{
+			Name:      w,
+			ClassName: validationName,
+		})
+	}
+
+	// If no errors and no warnings, create a single passing test case.
+	if len(cases) == 0 {
+		cases = append(cases, JUnitTestCase{
+			Name:      validationName + "-validation",
+			ClassName: validationName,
+		})
+	}
+
+	suite := JUnitTestSuite{
+		Name:     validationName,
+		Tests:    len(cases),
+		Failures: failures,
+		Errors:   0,
+		Time:     durationSecs,
+		Cases:    cases,
+	}
+
+	return &JUnitTestSuites{
+		Suites: []JUnitTestSuite{suite},
+	}
+}

--- a/internal/cli/shared/junit_report_test.go
+++ b/internal/cli/shared/junit_report_test.go
@@ -1,0 +1,348 @@
+package shared
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestJUnitXMLGeneration(t *testing.T) {
+	t.Run("produces valid JUnit XML with header", func(t *testing.T) {
+		suites := &JUnitTestSuites{
+			Suites: []JUnitTestSuite{
+				{
+					Name:     "validation",
+					Tests:    1,
+					Failures: 0,
+					Errors:   0,
+					Time:     0.5,
+					Cases: []JUnitTestCase{
+						{
+							Name:      "check-passed",
+							ClassName: "validation",
+							Time:      0.5,
+						},
+					},
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "results.xml")
+		if err := WriteJUnitReport(suites, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+
+		content := string(data)
+
+		// Must have XML header
+		if !strings.HasPrefix(content, `<?xml version="1.0" encoding="UTF-8"?>`) {
+			t.Fatalf("expected XML header, got: %s", content[:80])
+		}
+
+		// Must contain testsuites element
+		if !strings.Contains(content, "<testsuites>") {
+			t.Fatal("expected <testsuites> element")
+		}
+
+		// Must be valid XML
+		var parsed JUnitTestSuites
+		if err := xml.Unmarshal([]byte(strings.TrimPrefix(content, `<?xml version="1.0" encoding="UTF-8"?>`+"\n")), &parsed); err != nil {
+			t.Fatalf("invalid XML: %v", err)
+		}
+
+		if len(parsed.Suites) != 1 {
+			t.Fatalf("expected 1 suite, got %d", len(parsed.Suites))
+		}
+		if parsed.Suites[0].Name != "validation" {
+			t.Fatalf("expected suite name %q, got %q", "validation", parsed.Suites[0].Name)
+		}
+	})
+
+	t.Run("includes failure details", func(t *testing.T) {
+		suites := &JUnitTestSuites{
+			Suites: []JUnitTestSuite{
+				{
+					Name:     "bundle",
+					Tests:    2,
+					Failures: 1,
+					Errors:   0,
+					Time:     1.2,
+					Cases: []JUnitTestCase{
+						{
+							Name:      "valid-package",
+							ClassName: "bundle",
+							Time:      0.6,
+						},
+						{
+							Name:      "valid-signing-key",
+							ClassName: "bundle",
+							Time:      0.6,
+							Failure: &JUnitFailure{
+								Message: "signing key mismatch",
+								Type:    "validation-error",
+								Body:    "Expected SHA-256 fingerprint to match upload key",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "results.xml")
+		if err := WriteJUnitReport(suites, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+
+		content := string(data)
+
+		if !strings.Contains(content, `message="signing key mismatch"`) {
+			t.Fatal("expected failure message in XML")
+		}
+		if !strings.Contains(content, `type="validation-error"`) {
+			t.Fatal("expected failure type in XML")
+		}
+		if !strings.Contains(content, "Expected SHA-256 fingerprint to match upload key") {
+			t.Fatal("expected failure body in XML")
+		}
+	})
+
+	t.Run("uses indented output", func(t *testing.T) {
+		suites := &JUnitTestSuites{
+			Suites: []JUnitTestSuite{
+				{
+					Name:  "test",
+					Tests: 1,
+					Cases: []JUnitTestCase{
+						{Name: "case1", ClassName: "test"},
+					},
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "results.xml")
+		if err := WriteJUnitReport(suites, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+
+		// Indented output should have lines starting with spaces
+		lines := strings.Split(string(data), "\n")
+		foundIndented := false
+		for _, line := range lines {
+			if strings.HasPrefix(line, "  ") {
+				foundIndented = true
+				break
+			}
+		}
+		if !foundIndented {
+			t.Fatal("expected indented XML output")
+		}
+	})
+
+	t.Run("file has 0644 permissions", func(t *testing.T) {
+		suites := &JUnitTestSuites{}
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "results.xml")
+		if err := WriteJUnitReport(suites, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("failed to stat file: %v", err)
+		}
+		perm := info.Mode().Perm()
+		if perm != 0644 {
+			t.Fatalf("expected permissions 0644, got %o", perm)
+		}
+	})
+}
+
+func TestWriteJUnitReport_Errors(t *testing.T) {
+	t.Run("returns error for invalid path", func(t *testing.T) {
+		suites := &JUnitTestSuites{}
+		err := WriteJUnitReport(suites, "/nonexistent/dir/results.xml")
+		if err == nil {
+			t.Fatal("expected error for invalid path")
+		}
+	})
+}
+
+func TestNewJUnitFromValidation(t *testing.T) {
+	t.Run("errors become failures", func(t *testing.T) {
+		errors := []string{"missing icon", "invalid package name"}
+		warnings := []string{"large APK size"}
+		result := NewJUnitFromValidation("bundle", errors, warnings, 1.5)
+
+		if len(result.Suites) != 1 {
+			t.Fatalf("expected 1 suite, got %d", len(result.Suites))
+		}
+
+		suite := result.Suites[0]
+		if suite.Name != "bundle" {
+			t.Fatalf("expected suite name %q, got %q", "bundle", suite.Name)
+		}
+		if suite.Tests != 3 {
+			t.Fatalf("expected 3 tests, got %d", suite.Tests)
+		}
+		if suite.Failures != 2 {
+			t.Fatalf("expected 2 failures, got %d", suite.Failures)
+		}
+		if suite.Errors != 0 {
+			t.Fatalf("expected 0 errors, got %d", suite.Errors)
+		}
+		if suite.Time != 1.5 {
+			t.Fatalf("expected time 1.5, got %f", suite.Time)
+		}
+
+		// Check error test cases
+		if suite.Cases[0].Name != "missing icon" {
+			t.Fatalf("expected case name %q, got %q", "missing icon", suite.Cases[0].Name)
+		}
+		if suite.Cases[0].ClassName != "bundle" {
+			t.Fatalf("expected classname %q, got %q", "bundle", suite.Cases[0].ClassName)
+		}
+		if suite.Cases[0].Failure == nil {
+			t.Fatal("expected failure for error case")
+		}
+		if suite.Cases[0].Failure.Message != "missing icon" {
+			t.Fatalf("expected failure message %q, got %q", "missing icon", suite.Cases[0].Failure.Message)
+		}
+		if suite.Cases[0].Failure.Type != "validation-error" {
+			t.Fatalf("expected failure type %q, got %q", "validation-error", suite.Cases[0].Failure.Type)
+		}
+
+		if suite.Cases[1].Name != "invalid package name" {
+			t.Fatalf("expected case name %q, got %q", "invalid package name", suite.Cases[1].Name)
+		}
+		if suite.Cases[1].Failure == nil {
+			t.Fatal("expected failure for second error case")
+		}
+
+		// Check warning test case (should pass, no failure)
+		if suite.Cases[2].Name != "large APK size" {
+			t.Fatalf("expected case name %q, got %q", "large APK size", suite.Cases[2].Name)
+		}
+		if suite.Cases[2].ClassName != "bundle" {
+			t.Fatalf("expected classname %q, got %q", "bundle", suite.Cases[2].ClassName)
+		}
+		if suite.Cases[2].Failure != nil {
+			t.Fatal("expected no failure for warning case")
+		}
+	})
+
+	t.Run("empty errors and warnings produce passing suite", func(t *testing.T) {
+		result := NewJUnitFromValidation("listing", nil, nil, 0.3)
+
+		if len(result.Suites) != 1 {
+			t.Fatalf("expected 1 suite, got %d", len(result.Suites))
+		}
+
+		suite := result.Suites[0]
+		if suite.Name != "listing" {
+			t.Fatalf("expected suite name %q, got %q", "listing", suite.Name)
+		}
+		if suite.Tests != 1 {
+			t.Fatalf("expected 1 test, got %d", suite.Tests)
+		}
+		if suite.Failures != 0 {
+			t.Fatalf("expected 0 failures, got %d", suite.Failures)
+		}
+		if suite.Cases[0].Name != "listing-validation" {
+			t.Fatalf("expected case name %q, got %q", "listing-validation", suite.Cases[0].Name)
+		}
+		if suite.Cases[0].Failure != nil {
+			t.Fatal("expected no failure for passing suite")
+		}
+	})
+
+	t.Run("only warnings produce passing cases", func(t *testing.T) {
+		warnings := []string{"warning1", "warning2"}
+		result := NewJUnitFromValidation("screenshots", nil, warnings, 2.0)
+
+		suite := result.Suites[0]
+		if suite.Tests != 2 {
+			t.Fatalf("expected 2 tests, got %d", suite.Tests)
+		}
+		if suite.Failures != 0 {
+			t.Fatalf("expected 0 failures, got %d", suite.Failures)
+		}
+		for i, c := range suite.Cases {
+			if c.Failure != nil {
+				t.Fatalf("expected no failure for warning case %d", i)
+			}
+		}
+	})
+
+	t.Run("only errors produce all failures", func(t *testing.T) {
+		errors := []string{"error1", "error2", "error3"}
+		result := NewJUnitFromValidation("bundle", errors, nil, 0.8)
+
+		suite := result.Suites[0]
+		if suite.Tests != 3 {
+			t.Fatalf("expected 3 tests, got %d", suite.Tests)
+		}
+		if suite.Failures != 3 {
+			t.Fatalf("expected 3 failures, got %d", suite.Failures)
+		}
+		for i, c := range suite.Cases {
+			if c.Failure == nil {
+				t.Fatalf("expected failure for error case %d", i)
+			}
+		}
+	})
+
+	t.Run("XML roundtrip of validation result", func(t *testing.T) {
+		errors := []string{"bad version code"}
+		warnings := []string{"missing translation"}
+		result := NewJUnitFromValidation("release", errors, warnings, 0.5)
+
+		dir := t.TempDir()
+		path := filepath.Join(dir, "test.xml")
+		if err := WriteJUnitReport(result, path); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("failed to read file: %v", err)
+		}
+
+		content := string(data)
+		if !strings.Contains(content, `name="release"`) {
+			t.Fatal("expected suite name in XML")
+		}
+		if !strings.Contains(content, `tests="2"`) {
+			t.Fatal("expected tests count in XML")
+		}
+		if !strings.Contains(content, `failures="1"`) {
+			t.Fatal("expected failures count in XML")
+		}
+		if !strings.Contains(content, `message="bad version code"`) {
+			t.Fatal("expected failure message in XML")
+		}
+		if !strings.Contains(content, `name="missing translation"`) {
+			t.Fatal("expected warning case in XML")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `--report junit --report-file results.xml` flags for CI integration
- Generate JUnit XML test suites from validation command results
- Supports conversion of validation errors/warnings to JUnit test cases

Closes #100