### PR TITLE
feat: add SanitizeTerminal for safe table output

### DIFF
--- a/internal/output/sanitize.go
+++ b/internal/output/sanitize.go
@@ -1,0 +1,28 @@
+package output
+
+import "regexp"
+
+// ansiPattern matches ANSI CSI and OSC escape sequences.
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x07]*\x07|\x1b\[[0-9;]*m`)
+
+// SanitizeTerminal strips ANSI escape sequences and control characters
+// from s. Newlines (\n), carriage returns (\r), and tabs (\t) are preserved.
+func SanitizeTerminal(s string) string {
+	// Strip ANSI sequences first
+	s = ansiPattern.ReplaceAllString(s, "")
+
+	// Strip control chars (0x00-0x08, 0x0B-0x0C, 0x0E-0x1F, 0x7F)
+	// but preserve \n (0x0A), \r (0x0D), \t (0x09)
+	var result []rune
+	for _, r := range s {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			result = append(result, r)
+		case r < 0x20 || r == 0x7F:
+			// skip control characters
+		default:
+			result = append(result, r)
+		}
+	}
+	return string(result)
+}

--- a/internal/output/sanitize_test.go
+++ b/internal/output/sanitize_test.go
@@ -1,0 +1,101 @@
+package output
+
+import "testing"
+
+func TestSanitizeTerminal(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain text passthrough",
+			in:   "hello world",
+			want: "hello world",
+		},
+		{
+			name: "ANSI color codes stripped",
+			in:   "\x1b[31mred\x1b[0m",
+			want: "red",
+		},
+		{
+			name: "ANSI bold stripped",
+			in:   "\x1b[1mbold\x1b[22m",
+			want: "bold",
+		},
+		{
+			name: "ANSI CSI cursor movement stripped",
+			in:   "\x1b[2Aup two lines",
+			want: "up two lines",
+		},
+		{
+			name: "ANSI CSI erase display stripped",
+			in:   "\x1b[2Jcleared",
+			want: "cleared",
+		},
+		{
+			name: "ANSI SGR with multiple params stripped",
+			in:   "\x1b[38;5;196mred256\x1b[0m",
+			want: "red256",
+		},
+		{
+			name: "ANSI OSC sequence stripped",
+			in:   "\x1b]0;window title\x07rest",
+			want: "rest",
+		},
+		{
+			name: "control characters removed",
+			in:   "hello\x00\x01\x02\x7fworld",
+			want: "helloworld",
+		},
+		{
+			name: "newlines preserved",
+			in:   "line1\nline2\n",
+			want: "line1\nline2\n",
+		},
+		{
+			name: "tabs preserved",
+			in:   "col1\tcol2\tcol3",
+			want: "col1\tcol2\tcol3",
+		},
+		{
+			name: "carriage returns preserved",
+			in:   "hello\rworld",
+			want: "hello\rworld",
+		},
+		{
+			name: "unicode characters preserved",
+			in:   "emoji: \U0001F600 CJK: \u4E16\u754C",
+			want: "emoji: \U0001F600 CJK: \u4E16\u754C",
+		},
+		{
+			name: "empty string returns empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "only ANSI codes returns empty",
+			in:   "\x1b[31m\x1b[0m",
+			want: "",
+		},
+		{
+			name: "mixed ANSI and control characters",
+			in:   "\x1b[32mgreen\x00text\x1b[0m\x01end",
+			want: "greentextend",
+		},
+		{
+			name: "preserves whitespace within text",
+			in:   "  spaced  out  ",
+			want: "  spaced  out  ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeTerminal(tt.in)
+			if got != tt.want {
+				t.Errorf("SanitizeTerminal(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/output/table.go
+++ b/internal/output/table.go
@@ -27,6 +27,13 @@ func RenderTableTo(w io.Writer, headers []string, rows [][]string) {
 	}
 	fmt.Fprintln(tw, strings.Join(seps, "\t"))
 
+	// Sanitize row cell values
+	for i, row := range rows {
+		for j, cell := range row {
+			rows[i][j] = SanitizeTerminal(cell)
+		}
+	}
+
 	// Print rows
 	if len(rows) == 0 {
 		fmt.Fprintln(tw, "No results found.")


### PR DESCRIPTION
## Summary
- Add `SanitizeTerminal(s)` that strips ANSI escapes and control chars, preserving `\n`, `\r`, `\t`
- Integrate into table rendering to sanitize cell values before display
- Prevents terminal injection and garbled output from API responses

## Test plan
- [x] 16 table-driven unit tests covering plain text passthrough, ANSI stripping, control char removal, whitespace preservation, unicode, and edge cases
- [x] `go test ./internal/output/ -v` passes
- [x] `go vet ./...` clean

Closes #51