### PR TITLE
feat: add release-notes generate command

### DIFF
--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -38,6 +38,7 @@ import (
 	"github.com/tamtom/play-console-cli/internal/cli/purchases"
 	"github.com/tamtom/play-console-cli/internal/cli/recovery"
 	"github.com/tamtom/play-console-cli/internal/cli/release"
+	releasenotes "github.com/tamtom/play-console-cli/internal/cli/releasenotes"
 	"github.com/tamtom/play-console-cli/internal/cli/reports"
 	"github.com/tamtom/play-console-cli/internal/cli/reviews"
 	"github.com/tamtom/play-console-cli/internal/cli/rollout"
@@ -110,6 +111,7 @@ func Subcommands(version string) []*ffcli.Command {
 		devicetiers.DeviceTiersCommand(),
 		notify.NotifyCommand(),
 		migrate.MigrateCommand(),
+		releasenotes.ReleaseNotesCommand(),
 		reports.ReportsCommand(),
 		docs.DocsCommand(),
 		updatecmd.UpdateCommand(),

--- a/internal/cli/releasenotes/release_notes.go
+++ b/internal/cli/releasenotes/release_notes.go
@@ -1,0 +1,112 @@
+package releasenotes
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	rn "github.com/tamtom/play-console-cli/internal/releasenotes"
+)
+
+// ReleaseNotesCommand returns the parent "release-notes" command group.
+func ReleaseNotesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("release-notes", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "release-notes",
+		ShortUsage: "gplay release-notes <subcommand> [flags]",
+		ShortHelp:  "Generate release notes from git history.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			GenerateCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+// GenerateCommand returns the "release-notes generate" subcommand.
+func GenerateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("release-notes generate", flag.ExitOnError)
+	sinceTag := fs.String("since-tag", "", "Start from this git tag (exclusive)")
+	sinceRef := fs.String("since-ref", "", "Start from this git ref (exclusive, alternative to --since-tag)")
+	untilRef := fs.String("until-ref", "HEAD", "End at this ref (inclusive, default: HEAD)")
+	maxChars := fs.Int("max-chars", 500, "Maximum character count (Google Play limit: 500)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+
+	return &ffcli.Command{
+		Name:       "generate",
+		ShortUsage: "gplay release-notes generate --since-tag <tag> [flags]",
+		ShortHelp:  "Generate release notes from git commit history.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			return runGenerate(ctx, generateOpts{
+				sinceTag:   *sinceTag,
+				sinceRef:   *sinceRef,
+				untilRef:   *untilRef,
+				maxChars:   *maxChars,
+				outputFlag: *outputFlag,
+			})
+		},
+	}
+}
+
+type generateOpts struct {
+	sinceTag   string
+	sinceRef   string
+	untilRef   string
+	maxChars   int
+	outputFlag string
+}
+
+// generateResult is the JSON-serializable output.
+type generateResult struct {
+	ReleaseNotes string          `json:"release_notes"`
+	CommitCount  int             `json:"commit_count"`
+	Truncated    bool            `json:"truncated"`
+	Commits      []rn.GitCommit  `json:"commits"`
+}
+
+func runGenerate(ctx context.Context, opts generateOpts) error {
+	// Validate flags
+	sinceTag := strings.TrimSpace(opts.sinceTag)
+	sinceRef := strings.TrimSpace(opts.sinceRef)
+
+	if sinceTag != "" && sinceRef != "" {
+		fmt.Fprintln(os.Stderr, "Error: --since-tag and --since-ref are mutually exclusive")
+		return flag.ErrHelp
+	}
+	if sinceTag == "" && sinceRef == "" {
+		fmt.Fprintln(os.Stderr, "Error: one of --since-tag or --since-ref is required")
+		return flag.ErrHelp
+	}
+
+	ref := sinceRef
+	if sinceTag != "" {
+		ref = sinceTag
+	}
+
+	commits, err := rn.GitLog(ctx, ref, opts.untilRef)
+	if err != nil {
+		return fmt.Errorf("generating release notes: %w", err)
+	}
+
+	notes := rn.Format(commits, opts.maxChars)
+	fullNotes := rn.Format(commits, 0)
+
+	result := generateResult{
+		ReleaseNotes: notes,
+		CommitCount:  len(commits),
+		Truncated:    len(notes) < len(fullNotes),
+		Commits:      commits,
+	}
+
+	return shared.PrintOutput(result, opts.outputFlag, false)
+}

--- a/internal/cli/releasenotes/release_notes_test.go
+++ b/internal/cli/releasenotes/release_notes_test.go
@@ -1,0 +1,144 @@
+package releasenotes
+
+import (
+	"context"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestReleaseNotesCommand_Name(t *testing.T) {
+	cmd := ReleaseNotesCommand()
+	if cmd.Name != "release-notes" {
+		t.Errorf("Name = %q, want %q", cmd.Name, "release-notes")
+	}
+}
+
+func TestReleaseNotesCommand_HasSubcommands(t *testing.T) {
+	cmd := ReleaseNotesCommand()
+	if len(cmd.Subcommands) == 0 {
+		t.Fatal("expected subcommands")
+	}
+	found := false
+	for _, sub := range cmd.Subcommands {
+		if sub.Name == "generate" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'generate' subcommand")
+	}
+}
+
+func TestReleaseNotesCommand_NoArgsReturnsHelp(t *testing.T) {
+	cmd := ReleaseNotesCommand()
+	err := cmd.Exec(context.Background(), nil)
+	if err != flag.ErrHelp {
+		t.Errorf("expected flag.ErrHelp, got %v", err)
+	}
+}
+
+func TestGenerateCommand_Flags(t *testing.T) {
+	cmd := GenerateCommand()
+	if cmd.FlagSet == nil {
+		t.Fatal("expected FlagSet")
+	}
+
+	tests := []struct {
+		name     string
+		defValue string
+	}{
+		{"since-tag", ""},
+		{"since-ref", ""},
+		{"until-ref", "HEAD"},
+		{"max-chars", "500"},
+		{"output", "json"},
+	}
+
+	for _, tt := range tests {
+		f := cmd.FlagSet.Lookup(tt.name)
+		if f == nil {
+			t.Errorf("flag --%s not found", tt.name)
+			continue
+		}
+		if f.DefValue != tt.defValue {
+			t.Errorf("flag --%s default = %q, want %q", tt.name, f.DefValue, tt.defValue)
+		}
+	}
+}
+
+func TestRunGenerate_MutuallyExclusiveFlags(t *testing.T) {
+	err := runGenerate(context.Background(), generateOpts{
+		sinceTag:   "v1.0.0",
+		sinceRef:   "abc1234",
+		untilRef:   "HEAD",
+		maxChars:   500,
+		outputFlag: "json",
+	})
+	if err != flag.ErrHelp {
+		t.Errorf("expected flag.ErrHelp for mutually exclusive flags, got %v", err)
+	}
+}
+
+func TestRunGenerate_NeitherFlagProvided(t *testing.T) {
+	err := runGenerate(context.Background(), generateOpts{
+		sinceTag:   "",
+		sinceRef:   "",
+		untilRef:   "HEAD",
+		maxChars:   500,
+		outputFlag: "json",
+	})
+	if err != flag.ErrHelp {
+		t.Errorf("expected flag.ErrHelp when neither flag provided, got %v", err)
+	}
+}
+
+func TestRunGenerate_WhitespaceOnlyFlags(t *testing.T) {
+	err := runGenerate(context.Background(), generateOpts{
+		sinceTag:   "  ",
+		sinceRef:   "  ",
+		untilRef:   "HEAD",
+		maxChars:   500,
+		outputFlag: "json",
+	})
+	if err != flag.ErrHelp {
+		t.Errorf("expected flag.ErrHelp for whitespace-only flags, got %v", err)
+	}
+}
+
+func TestRunGenerate_SinceTagOnly(t *testing.T) {
+	// This will fail with a git error since we're not in a real repo context
+	// with the specified tag, but it should NOT fail with flag validation errors.
+	err := runGenerate(context.Background(), generateOpts{
+		sinceTag:   "v1.0.0",
+		sinceRef:   "",
+		untilRef:   "HEAD",
+		maxChars:   500,
+		outputFlag: "json",
+	})
+	// Should get a git error, not a flag validation error
+	if err == flag.ErrHelp {
+		t.Error("did not expect flag.ErrHelp when --since-tag is provided")
+	}
+	if err != nil && !strings.Contains(err.Error(), "git") {
+		t.Errorf("expected git-related error, got: %v", err)
+	}
+}
+
+func TestRunGenerate_SinceRefOnly(t *testing.T) {
+	err := runGenerate(context.Background(), generateOpts{
+		sinceTag:   "",
+		sinceRef:   "abc1234",
+		untilRef:   "HEAD",
+		maxChars:   500,
+		outputFlag: "json",
+	})
+	// Should get a git error, not a flag validation error
+	if err == flag.ErrHelp {
+		t.Error("did not expect flag.ErrHelp when --since-ref is provided")
+	}
+	if err != nil && !strings.Contains(err.Error(), "git") {
+		t.Errorf("expected git-related error, got: %v", err)
+	}
+}

--- a/internal/releasenotes/git.go
+++ b/internal/releasenotes/git.go
@@ -1,0 +1,50 @@
+package releasenotes
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// GitCommit represents a single git commit.
+type GitCommit struct {
+	Hash    string `json:"hash"`
+	Subject string `json:"subject"`
+}
+
+// GitLog runs `git log --no-merges --format="%h%x00%s"` between refs and returns commits.
+// sinceRef is the starting ref (exclusive), untilRef is the ending ref (inclusive).
+func GitLog(ctx context.Context, sinceRef, untilRef string) ([]GitCommit, error) {
+	refRange := untilRef
+	if sinceRef != "" {
+		refRange = sinceRef + ".." + untilRef
+	}
+
+	cmd := exec.CommandContext(ctx, "git", "log", "--no-merges", "--format=%h%x00%s", refRange)
+	out, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("git log failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, fmt.Errorf("git log failed: %w", err)
+	}
+
+	text := strings.TrimSpace(string(out))
+	if text == "" {
+		return nil, nil
+	}
+
+	var commits []GitCommit
+	for _, line := range strings.Split(text, "\n") {
+		parts := strings.SplitN(line, "\x00", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		commits = append(commits, GitCommit{
+			Hash:    parts[0],
+			Subject: parts[1],
+		})
+	}
+	return commits, nil
+}

--- a/internal/releasenotes/releasenotes.go
+++ b/internal/releasenotes/releasenotes.go
@@ -1,0 +1,54 @@
+package releasenotes
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Format converts commits into a bullet-point release notes string.
+// Truncates to maxChars (Google Play limit is 500 chars).
+// Truncation removes whole lines to avoid cutting mid-sentence,
+// and appends "..." if any lines were dropped.
+func Format(commits []GitCommit, maxChars int) string {
+	if len(commits) == 0 {
+		return ""
+	}
+
+	var lines []string
+	for _, c := range commits {
+		lines = append(lines, fmt.Sprintf("- %s", c.Subject))
+	}
+
+	result := strings.Join(lines, "\n")
+	if maxChars <= 0 || len(result) <= maxChars {
+		return result
+	}
+
+	// Truncate at line boundary
+	const ellipsis = "\n..."
+	budget := maxChars - len(ellipsis)
+	if budget <= 0 {
+		return "..."
+	}
+
+	var kept []string
+	total := 0
+	for i, line := range lines {
+		lineLen := len(line)
+		if i > 0 {
+			lineLen++ // account for newline separator
+		}
+		if total+lineLen > budget {
+			break
+		}
+		kept = append(kept, line)
+		total += lineLen
+	}
+
+	if len(kept) == 0 {
+		// Even a single line is too long; truncate it
+		return lines[0][:budget] + ellipsis
+	}
+
+	return strings.Join(kept, "\n") + ellipsis
+}

--- a/internal/releasenotes/releasenotes_test.go
+++ b/internal/releasenotes/releasenotes_test.go
@@ -1,0 +1,138 @@
+package releasenotes
+
+import (
+	"testing"
+)
+
+func TestFormat_EmptyCommits(t *testing.T) {
+	result := Format(nil, 500)
+	if result != "" {
+		t.Errorf("Format(nil, 500) = %q, want empty string", result)
+	}
+}
+
+func TestFormat_SingleCommit(t *testing.T) {
+	commits := []GitCommit{
+		{Hash: "abc1234", Subject: "Fix login crash"},
+	}
+	result := Format(commits, 500)
+	want := "- Fix login crash"
+	if result != want {
+		t.Errorf("Format() = %q, want %q", result, want)
+	}
+}
+
+func TestFormat_MultipleCommits(t *testing.T) {
+	commits := []GitCommit{
+		{Hash: "abc1234", Subject: "Fix login crash"},
+		{Hash: "def5678", Subject: "Add dark mode"},
+		{Hash: "ghi9012", Subject: "Update translations"},
+	}
+	result := Format(commits, 500)
+	want := "- Fix login crash\n- Add dark mode\n- Update translations"
+	if result != want {
+		t.Errorf("Format() = %q, want %q", result, want)
+	}
+}
+
+func TestFormat_NoTruncationWhenUnderLimit(t *testing.T) {
+	commits := []GitCommit{
+		{Hash: "abc1234", Subject: "Short"},
+	}
+	result := Format(commits, 500)
+	if len(result) > 500 {
+		t.Errorf("result length %d exceeds maxChars 500", len(result))
+	}
+}
+
+func TestFormat_TruncationAtLineBoundary(t *testing.T) {
+	commits := []GitCommit{
+		{Hash: "a", Subject: "First commit message"},    // "- First commit message" = 22 chars
+		{Hash: "b", Subject: "Second commit message"},   // "- Second commit message" = 23 chars
+		{Hash: "c", Subject: "Third commit message"},    // "- Third commit message" = 22 chars
+		{Hash: "d", Subject: "Fourth commit message"},   // "- Fourth commit message" = 23 chars
+	}
+
+	// "- First commit message\n- Second commit message" = 46 chars
+	// + "\n..." = 50 chars
+	// "- Third commit message" would make it 69 + "\n..." = 73 chars
+	result := Format(commits, 55)
+
+	// Should contain first two lines and ellipsis
+	want := "- First commit message\n- Second commit message\n..."
+	if result != want {
+		t.Errorf("Format() = %q, want %q", result, want)
+	}
+}
+
+func TestFormat_TruncationDoesNotCutMidLine(t *testing.T) {
+	commits := []GitCommit{
+		{Hash: "a", Subject: "First commit"},
+		{Hash: "b", Subject: "Second commit that is longer"},
+		{Hash: "c", Subject: "Third commit"},
+	}
+
+	// Set limit so that cutting mid-line of the second commit would be needed
+	// "- First commit" = 14 chars
+	// "\n- Second commit that is longer" = 31 chars more = 45 total
+	// "\n..." = 4 more = 49
+	// Let's set limit to 30 so only first line fits
+	result := Format(commits, 30)
+	want := "- First commit\n..."
+	if result != want {
+		t.Errorf("Format() = %q, want %q", result, want)
+	}
+}
+
+func TestFormat_ResultWithinMaxChars(t *testing.T) {
+	commits := []GitCommit{
+		{Hash: "a", Subject: "Alpha"},
+		{Hash: "b", Subject: "Beta"},
+		{Hash: "c", Subject: "Gamma"},
+		{Hash: "d", Subject: "Delta"},
+		{Hash: "e", Subject: "Epsilon"},
+	}
+	maxChars := 40
+	result := Format(commits, maxChars)
+	if len(result) > maxChars {
+		t.Errorf("result length %d exceeds maxChars %d: %q", len(result), maxChars, result)
+	}
+}
+
+func TestFormat_ZeroMaxCharsNoTruncation(t *testing.T) {
+	commits := []GitCommit{
+		{Hash: "a", Subject: "First"},
+		{Hash: "b", Subject: "Second"},
+	}
+	result := Format(commits, 0)
+	want := "- First\n- Second"
+	if result != want {
+		t.Errorf("Format() = %q, want %q", result, want)
+	}
+}
+
+func TestFormat_ExactFitNoEllipsis(t *testing.T) {
+	commits := []GitCommit{
+		{Hash: "a", Subject: "Hello"},
+	}
+	// "- Hello" = 7 chars
+	result := Format(commits, 7)
+	want := "- Hello"
+	if result != want {
+		t.Errorf("Format() = %q, want %q", result, want)
+	}
+}
+
+func TestFormat_VerySmallLimit(t *testing.T) {
+	commits := []GitCommit{
+		{Hash: "a", Subject: "A long commit message that exceeds the limit"},
+	}
+	result := Format(commits, 10)
+	// Budget is 10 - 4 ("\n...") = 6. No full line fits, so we truncate the first line.
+	if len(result) > 10 {
+		t.Errorf("result length %d exceeds maxChars 10: %q", len(result), result)
+	}
+	if result == "" {
+		t.Error("expected non-empty result")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `gplay release-notes generate` command that creates release notes from git history
- Supports `--since-tag`/`--since-ref` and `--until-ref` to select commit range
- Auto-truncates to `--max-chars` (default 500, Google Play limit)
- Output in JSON, table, or markdown format

Closes #99