### PR TITLE
feat: add secureopen package for path-validated file access

### DIFF
--- a/internal/secureopen/secureopen.go
+++ b/internal/secureopen/secureopen.go
@@ -1,0 +1,63 @@
+package secureopen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SecureOpen opens a file after verifying it resolves within one of the allowedDirs.
+// It cleans the path, resolves symlinks, and checks the resolved path is within bounds.
+func SecureOpen(path string, allowedDirs ...string) (*os.File, error) {
+	return SecureOpenFile(path, os.O_RDONLY, 0, allowedDirs...)
+}
+
+// SecureOpenFile opens a file with custom flags and permissions after path validation.
+func SecureOpenFile(path string, flag int, perm os.FileMode, allowedDirs ...string) (*os.File, error) {
+	if len(allowedDirs) == 0 {
+		return nil, fmt.Errorf("secureopen: at least one allowed directory is required")
+	}
+
+	// Clean the path
+	cleaned := filepath.Clean(path)
+
+	// Resolve symlinks
+	resolved, err := filepath.EvalSymlinks(cleaned)
+	if err != nil {
+		return nil, fmt.Errorf("secureopen: resolving path %q: %w", path, err)
+	}
+
+	// Check it's not a directory
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return nil, fmt.Errorf("secureopen: stat %q: %w", path, err)
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("secureopen: %q is a directory, not a file", path)
+	}
+
+	// Verify resolved path is within at least one allowed directory
+	allowed := false
+	for _, dir := range allowedDirs {
+		absDir, err := filepath.Abs(dir)
+		if err != nil {
+			continue
+		}
+		// Resolve symlinks in the allowed dir too
+		resolvedDir, err := filepath.EvalSymlinks(absDir)
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(resolved, resolvedDir+string(filepath.Separator)) || resolved == resolvedDir {
+			allowed = true
+			break
+		}
+	}
+
+	if !allowed {
+		return nil, fmt.Errorf("secureopen: path %q resolves to %q which is outside allowed directories", path, resolved)
+	}
+
+	return os.OpenFile(resolved, flag, perm)
+}

--- a/internal/secureopen/secureopen_test.go
+++ b/internal/secureopen/secureopen_test.go
@@ -1,0 +1,211 @@
+package secureopen_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/secureopen"
+)
+
+func TestSecureOpen_RegularFileInAllowedDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := secureopen.SecureOpen(path, dir)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer f.Close()
+
+	buf := make([]byte, 5)
+	n, err := f.Read(buf)
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if string(buf[:n]) != "hello" {
+		t.Fatalf("expected %q, got %q", "hello", string(buf[:n]))
+	}
+}
+
+func TestSecureOpen_SymlinkWithinAllowedDir(t *testing.T) {
+	dir := t.TempDir()
+	realFile := filepath.Join(dir, "real.txt")
+	if err := os.WriteFile(realFile, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(dir, "link.txt")
+	if err := os.Symlink(realFile, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := secureopen.SecureOpen(linkPath, dir)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	f.Close()
+}
+
+func TestSecureOpen_SymlinkOutsideAllowedDir(t *testing.T) {
+	allowedDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	outsideFile := filepath.Join(outsideDir, "secret.txt")
+	if err := os.WriteFile(outsideFile, []byte("secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	linkPath := filepath.Join(allowedDir, "escape.txt")
+	if err := os.Symlink(outsideFile, linkPath); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := secureopen.SecureOpen(linkPath, allowedDir)
+	if err == nil {
+		t.Fatal("expected error for symlink escaping allowed dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "outside allowed directories") {
+		t.Fatalf("expected 'outside allowed directories' error, got %v", err)
+	}
+}
+
+func TestSecureOpen_PathTraversal(t *testing.T) {
+	dir := t.TempDir()
+	traversal := filepath.Join(dir, "..", "..", "..", "etc", "passwd")
+
+	_, err := secureopen.SecureOpen(traversal, dir)
+	if err == nil {
+		t.Fatal("expected error for path traversal, got nil")
+	}
+}
+
+func TestSecureOpen_NonexistentFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent.txt")
+
+	_, err := secureopen.SecureOpen(path, dir)
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+	if !strings.Contains(err.Error(), "resolving path") {
+		t.Fatalf("expected 'resolving path' error, got %v", err)
+	}
+}
+
+func TestSecureOpen_DirectoryPath(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "subdir")
+	if err := os.Mkdir(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := secureopen.SecureOpen(subdir, dir)
+	if err == nil {
+		t.Fatal("expected error for directory path, got nil")
+	}
+	if !strings.Contains(err.Error(), "is a directory") {
+		t.Fatalf("expected 'is a directory' error, got %v", err)
+	}
+}
+
+func TestSecureOpen_NoAllowedDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.txt")
+	if err := os.WriteFile(path, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := secureopen.SecureOpen(path)
+	if err == nil {
+		t.Fatal("expected error for no allowed dirs, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one allowed directory is required") {
+		t.Fatalf("expected 'at least one allowed directory' error, got %v", err)
+	}
+}
+
+func TestSecureOpen_MultipleAllowedDirs(t *testing.T) {
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
+	dir3 := t.TempDir()
+
+	path := filepath.Join(dir2, "test.txt")
+	if err := os.WriteFile(path, []byte("found"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := secureopen.SecureOpen(path, dir1, dir2, dir3)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	f.Close()
+}
+
+func TestSecureOpenFile_CustomFlags(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "writable.txt")
+	if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := secureopen.SecureOpenFile(path, os.O_WRONLY|os.O_TRUNC, 0644, dir)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString("written"); err != nil {
+		t.Fatalf("write error: %v", err)
+	}
+	f.Close()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "written" {
+		t.Fatalf("expected %q, got %q", "written", string(data))
+	}
+}
+
+func TestSecureOpen_FileOutsideAllowedDir(t *testing.T) {
+	allowedDir := t.TempDir()
+	outsideDir := t.TempDir()
+
+	path := filepath.Join(outsideDir, "outside.txt")
+	if err := os.WriteFile(path, []byte("nope"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := secureopen.SecureOpen(path, allowedDir)
+	if err == nil {
+		t.Fatal("expected error for file outside allowed dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "outside allowed directories") {
+		t.Fatalf("expected 'outside allowed directories' error, got %v", err)
+	}
+}
+
+func TestSecureOpen_NestedSubdirectory(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b", "c")
+	if err := os.MkdirAll(nested, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(nested, "deep.txt")
+	if err := os.WriteFile(path, []byte("deep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := secureopen.SecureOpen(path, dir)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	f.Close()
+}


### PR DESCRIPTION
## Summary
- Add `secureopen` package with `SecureOpen` and `SecureOpenFile` functions
- Validates file paths resolve within allowed directories after symlink resolution
- Prevents path traversal attacks for file upload operations

Closes #48