### PR TITLE
[codex] Complete canonical publish workflow

### DIFF
--- a/GPLAY.md
+++ b/GPLAY.md
@@ -2181,6 +2181,7 @@ This command:
 | `--apk` | Path to .apk file | `` |
 | `--bundle` | Path to .aab bundle file | `` |
 | `--changes-not-sent-for-review` | Changes not sent for review | `false` |
+| `--dry-run` | Preview the canonical publish workflow without making changes | `false` |
 | `--listings-dir` | Path to listings metadata directory | `` |
 | `--output` | Output format: json (default), table, markdown | `json` |
 | `--package` | Package name (applicationId) | `` |
@@ -2193,7 +2194,7 @@ This command:
 | `--skip-screenshots` | Skip screenshot sync even if --screenshots-dir is set | `false` |
 | `--status` | Release status: draft, inProgress, halted, completed | `completed` |
 | `--strict` | Treat readiness warnings as publish blockers | `false` |
-| `--track` | Target track | `production` |
+| `--track` | Target track | `` |
 | `--version-name` | Optional version name override | `` |
 | `--wait` | Wait for the published release to appear in the target track | `false` |
 

--- a/README.md
+++ b/README.md
@@ -237,12 +237,12 @@ gplay tracks update --package com.example.app --edit <id> --track internal --jso
 ### High-Level Workflow
 
 ```bash
-# One-command release (creates edit, uploads, updates track, commits)
-gplay release --package com.example.app --track internal --bundle app.aab
+# Canonical one-command release (preflight, creates edit, uploads, updates track, commits)
+gplay publish track --package com.example.app --track internal --bundle app.aab
 
 # With release notes and staged rollout
-gplay release --package com.example.app --track production --bundle app.aab \
-  --release-notes @notes.json --rollout 10
+gplay publish track --package com.example.app --track production --bundle app.aab \
+  --release-notes @notes.json --rollout 0.1
 
 # Promote between tracks
 gplay promote --package com.example.app --from internal --to beta
@@ -254,11 +254,14 @@ gplay rollout resume --package com.example.app --track production
 gplay rollout complete --package com.example.app --track production
 
 # Release with metadata and screenshots
-gplay release --package com.example.app --track production --bundle app.aab \
+gplay publish track --package com.example.app --track production --bundle app.aab \
   --listings-dir ./metadata --screenshots-dir ./screenshots
 
-# Dry-run any command (intercepts write operations)
-gplay --dry-run release --package com.example.app --track internal --bundle app.aab
+# Dry-run the canonical publish workflow
+gplay publish track --package com.example.app --track internal --bundle app.aab --dry-run
+
+# Lower-level release remains available for advanced control and debugging
+gplay release --package com.example.app --track internal --bundle app.aab
 ```
 
 ### App Management
@@ -691,7 +694,7 @@ deploy:
     - curl -fsSL https://raw.githubusercontent.com/tamtom/play-console-cli/main/install.sh | bash
     - export PATH="$HOME/.local/bin:$PATH"
   script:
-    - gplay release --package $PACKAGE_NAME --track internal --bundle app.aab
+    - gplay publish track --package $PACKAGE_NAME --track internal --bundle app.aab
   variables:
     GPLAY_SERVICE_ACCOUNT: $PLAY_SERVICE_ACCOUNT
 ```

--- a/internal/cli/publish/publish.go
+++ b/internal/cli/publish/publish.go
@@ -47,7 +47,7 @@ advanced control and debugging.`,
 func TrackCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("publish track", flag.ExitOnError)
 	packageName := fs.String("package", "", "Package name (applicationId)")
-	track := fs.String("track", "production", "Target track")
+	track := fs.String("track", "", "Target track")
 	bundlePath := fs.String("bundle", "", "Path to .aab bundle file")
 	apkPath := fs.String("apk", "", "Path to .apk file")
 	releaseNotes := fs.String("release-notes", "", "Release notes: plain text, JSON array, or @file")
@@ -62,6 +62,7 @@ func TrackCommand() *ffcli.Command {
 	skipMetadata := fs.Bool("skip-metadata", false, "Skip metadata sync even if --listings-dir is set")
 	skipScreenshots := fs.Bool("skip-screenshots", false, "Skip screenshot sync even if --screenshots-dir is set")
 	strict := fs.Bool("strict", false, "Treat readiness warnings as publish blockers")
+	dryRun := fs.Bool("dry-run", false, "Preview the canonical publish workflow without making changes")
 	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
 	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
 
@@ -78,8 +79,15 @@ This command:
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if *dryRun {
+				ctx = shared.ContextWithDryRun(ctx, true)
+			}
 			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
 				return err
+			}
+			trackName := strings.TrimSpace(*track)
+			if trackName == "" {
+				return fmt.Errorf("--track is required")
 			}
 			if strings.TrimSpace(*bundlePath) == "" && strings.TrimSpace(*apkPath) == "" {
 				return fmt.Errorf("either --bundle or --apk is required")
@@ -96,22 +104,34 @@ This command:
 				return err
 			}
 
+			readinessListingsDir := *listingsDir
+			if *skipMetadata {
+				readinessListingsDir = ""
+			}
+			readinessScreenshotsDir := *screenshotsDir
+			if *skipScreenshots {
+				readinessScreenshotsDir = ""
+			}
+
 			preflight := buildReadinessReportFn(ctx, validatecli.ReadinessOptions{
 				PackageName:    pkgName,
-				Track:          *track,
+				Track:          trackName,
 				BundlePath:     *bundlePath,
 				APKPath:        *apkPath,
-				ListingsDir:    *listingsDir,
-				ScreenshotsDir: *screenshotsDir,
+				ListingsDir:    readinessListingsDir,
+				ScreenshotsDir: readinessScreenshotsDir,
 				ReleaseNotes:   *releaseNotes,
 				Strict:         *strict,
 			})
 
 			result := map[string]interface{}{
 				"packageName": pkgName,
-				"track":       *track,
+				"track":       trackName,
 				"published":   false,
 				"preflight":   preflight,
+			}
+			if shared.IsDryRun(ctx) {
+				result["dryRun"] = true
 			}
 
 			if preflight.Summary.Blocking > 0 {
@@ -129,7 +149,7 @@ This command:
 
 			releaseResult, err := executeReleaseFn(ctx, release.Options{
 				PackageName:     pkgName,
-				Track:           *track,
+				Track:           trackName,
 				BundlePath:      *bundlePath,
 				APKPath:         *apkPath,
 				ReleaseNotes:    *releaseNotes,
@@ -148,7 +168,7 @@ This command:
 				return err
 			}
 
-			result["published"] = true
+			result["published"] = !shared.IsDryRun(ctx)
 			result["release"] = releaseResult
 
 			return shared.PrintOutput(result, *outputFlag, *pretty)

--- a/internal/cli/publish/publish_test.go
+++ b/internal/cli/publish/publish_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/tamtom/play-console-cli/internal/cli/release"
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
 	validatecli "github.com/tamtom/play-console-cli/internal/cli/validate"
 	"github.com/tamtom/play-console-cli/internal/validation"
 )
@@ -46,7 +47,7 @@ func TestTrackCommand_PreflightBlockingStopsPublish(t *testing.T) {
 	})
 
 	cmd := TrackCommand()
-	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--bundle", "app.aab"}); err != nil {
+	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--track", "internal", "--bundle", "app.aab"}); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
 
@@ -56,6 +57,103 @@ func TestTrackCommand_PreflightBlockingStopsPublish(t *testing.T) {
 	}
 	if executeCalled {
 		t.Fatal("release execution should not run when preflight blocks publish")
+	}
+}
+
+func TestTrackCommand_RequiresTrack(t *testing.T) {
+	cmd := TrackCommand()
+	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--bundle", "app.aab"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected missing track error")
+	}
+	if !strings.Contains(err.Error(), "--track is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTrackCommand_SkipFlagsOmitReadinessDirs(t *testing.T) {
+	origBuild := buildReadinessReportFn
+	origExecute := executeReleaseFn
+	var got validatecli.ReadinessOptions
+	buildReadinessReportFn = func(_ context.Context, opts validatecli.ReadinessOptions) *validation.ReadinessReport {
+		got = opts
+		return readyReport()
+	}
+	executeReleaseFn = func(context.Context, release.Options) (map[string]interface{}, error) {
+		return map[string]interface{}{"track": "internal"}, nil
+	}
+	t.Cleanup(func() {
+		buildReadinessReportFn = origBuild
+		executeReleaseFn = origExecute
+	})
+
+	cmd := TrackCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--package", "com.example.app",
+		"--track", "internal",
+		"--bundle", "app.aab",
+		"--listings-dir", "/bad/listings",
+		"--screenshots-dir", "/bad/screenshots",
+		"--skip-metadata",
+		"--skip-screenshots",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	if _, err := captureOutput(func() error { return cmd.Exec(context.Background(), nil) }); err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if got.ListingsDir != "" {
+		t.Fatalf("ListinsDir = %q, want empty when --skip-metadata is set", got.ListingsDir)
+	}
+	if got.ScreenshotsDir != "" {
+		t.Fatalf("ScreenshotsDir = %q, want empty when --skip-screenshots is set", got.ScreenshotsDir)
+	}
+}
+
+func TestTrackCommand_DryRunFlagSetsContextAndDoesNotMarkPublished(t *testing.T) {
+	origBuild := buildReadinessReportFn
+	origExecute := executeReleaseFn
+	buildReadinessReportFn = func(ctx context.Context, _ validatecli.ReadinessOptions) *validation.ReadinessReport {
+		if !shared.IsDryRun(ctx) {
+			t.Fatal("expected readiness context to be dry-run")
+		}
+		return readyReport()
+	}
+	executeReleaseFn = func(ctx context.Context, _ release.Options) (map[string]interface{}, error) {
+		if !shared.IsDryRun(ctx) {
+			t.Fatal("expected release context to be dry-run")
+		}
+		return map[string]interface{}{"dryRun": true}, nil
+	}
+	t.Cleanup(func() {
+		buildReadinessReportFn = origBuild
+		executeReleaseFn = origExecute
+	})
+
+	cmd := TrackCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--package", "com.example.app",
+		"--track", "internal",
+		"--bundle", "app.aab",
+		"--dry-run",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+
+	stdout, err := captureOutput(func() error { return cmd.Exec(context.Background(), nil) })
+	if err != nil {
+		t.Fatalf("Exec() error = %v", err)
+	}
+	if !strings.Contains(stdout, "\"dryRun\":true") {
+		t.Fatalf("expected dryRun output, got %s", stdout)
+	}
+	if !strings.Contains(stdout, "\"published\":false") {
+		t.Fatalf("expected dry-run output to leave published false, got %s", stdout)
 	}
 }
 
@@ -74,7 +172,7 @@ func TestTrackCommand_Success(t *testing.T) {
 	})
 
 	cmd := TrackCommand()
-	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--bundle", "app.aab"}); err != nil {
+	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--track", "production", "--bundle", "app.aab"}); err != nil {
 		t.Fatalf("parse flags: %v", err)
 	}
 

--- a/internal/cli/release/release_test.go
+++ b/internal/cli/release/release_test.go
@@ -2,8 +2,21 @@ package release
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+
+	"google.golang.org/api/androidpublisher/v3"
+	"google.golang.org/api/option"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/config"
+	"github.com/tamtom/play-console-cli/internal/playclient"
 )
 
 func TestReleaseCommand_Name(t *testing.T) {
@@ -180,4 +193,155 @@ func TestReleaseCommand_RolloutBoundary_One(t *testing.T) {
 	if strings.Contains(err.Error(), "--rollout") {
 		t.Errorf("rollout=1.0 should be valid, got: %s", err.Error())
 	}
+}
+
+func TestExecute_DryRunBuildsPlanWithoutService(t *testing.T) {
+	origNewService := newServiceFn
+	newServiceFn = func(context.Context) (*playclient.Service, error) {
+		t.Fatal("dry-run should not create an authenticated Play service")
+		return nil, nil
+	}
+	t.Cleanup(func() { newServiceFn = origNewService })
+
+	bundlePath := filepath.Join(t.TempDir(), "app.aab")
+	if err := os.WriteFile(bundlePath, []byte("bundle"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Execute(shared.ContextWithDryRun(context.Background(), true), Options{
+		PackageName:  "com.example",
+		Track:        "internal",
+		BundlePath:   bundlePath,
+		ReleaseNotes: "Bug fixes",
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if result["dryRun"] != true {
+		t.Fatalf("dryRun = %#v, want true", result["dryRun"])
+	}
+	steps, ok := result["steps"].([]string)
+	if !ok || len(steps) == 0 {
+		t.Fatalf("expected dry-run steps, got %#v", result["steps"])
+	}
+	if !containsString(steps, "commit edit") {
+		t.Fatalf("expected commit step in dry-run plan, got %#v", steps)
+	}
+}
+
+func TestExecute_UpdatesListingsAndReplacesScreenshots(t *testing.T) {
+	bundlePath := filepath.Join(t.TempDir(), "app.aab")
+	if err := os.WriteFile(bundlePath, []byte("bundle"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	listingsDir := t.TempDir()
+	localeDir := filepath.Join(listingsDir, "en-US")
+	if err := os.MkdirAll(localeDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(localeDir, "title.txt"), []byte("Updated Title"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(localeDir, "short_description.txt"), []byte("Updated Short"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(localeDir, "full_description.txt"), []byte("Updated Full"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	screenshotsDir := t.TempDir()
+	phoneDir := filepath.Join(screenshotsDir, "en-US", "phoneScreenshots")
+	if err := os.MkdirAll(phoneDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(phoneDir, "01.png"), []byte("png"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var listingUpdates atomic.Int32
+	var imageDeletes atomic.Int32
+	var imageUploads atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		path := r.URL.Path
+		switch {
+		case r.Method == http.MethodPost && strings.HasSuffix(path, "/androidpublisher/v3/applications/com.example/edits"):
+			_ = json.NewEncoder(w).Encode(androidpublisher.AppEdit{Id: "edit-123"})
+		case r.Method == http.MethodPost && strings.Contains(path, "/upload/androidpublisher/v3/applications/com.example/edits/edit-123/bundles"):
+			_ = json.NewEncoder(w).Encode(androidpublisher.Bundle{VersionCode: 42})
+		case r.Method == http.MethodPut && strings.Contains(path, "/androidpublisher/v3/applications/com.example/edits/edit-123/listings/en-US"):
+			listingUpdates.Add(1)
+			var listing androidpublisher.Listing
+			if err := json.NewDecoder(r.Body).Decode(&listing); err != nil {
+				t.Errorf("decode listing: %v", err)
+			}
+			if listing.Title != "Updated Title" {
+				t.Errorf("Title = %q, want Updated Title", listing.Title)
+			}
+			_ = json.NewEncoder(w).Encode(listing)
+		case r.Method == http.MethodDelete && strings.Contains(path, "/androidpublisher/v3/applications/com.example/edits/edit-123/listings/en-US/phoneScreenshots"):
+			imageDeletes.Add(1)
+			_ = json.NewEncoder(w).Encode(androidpublisher.ImagesDeleteAllResponse{})
+		case r.Method == http.MethodPost && strings.Contains(path, "/upload/androidpublisher/v3/applications/com.example/edits/edit-123/listings/en-US/phoneScreenshots"):
+			imageUploads.Add(1)
+			_ = json.NewEncoder(w).Encode(androidpublisher.ImagesUploadResponse{Image: &androidpublisher.Image{Id: "img-1"}})
+		case r.Method == http.MethodPut && strings.Contains(path, "/androidpublisher/v3/applications/com.example/edits/edit-123/tracks/internal"):
+			_ = json.NewEncoder(w).Encode(androidpublisher.Track{Track: "internal"})
+		case r.Method == http.MethodPost && strings.Contains(path, "/androidpublisher/v3/applications/com.example/edits/edit-123:validate"):
+			_ = json.NewEncoder(w).Encode(androidpublisher.AppEdit{Id: "edit-123"})
+		case r.Method == http.MethodPost && strings.Contains(path, "/androidpublisher/v3/applications/com.example/edits/edit-123:commit"):
+			_ = json.NewEncoder(w).Encode(androidpublisher.AppEdit{Id: "edit-123"})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, path)
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	api, err := androidpublisher.NewService(context.Background(), option.WithHTTPClient(server.Client()), option.WithEndpoint(server.URL))
+	if err != nil {
+		t.Fatal(err)
+	}
+	origNewService := newServiceFn
+	newServiceFn = func(context.Context) (*playclient.Service, error) {
+		return &playclient.Service{API: api, Cfg: &config.Config{}}, nil
+	}
+	t.Cleanup(func() { newServiceFn = origNewService })
+
+	result, err := Execute(context.Background(), Options{
+		PackageName:    "com.example",
+		Track:          "internal",
+		BundlePath:     bundlePath,
+		ListingsDir:    listingsDir,
+		ScreenshotsDir: screenshotsDir,
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if listingUpdates.Load() != 1 {
+		t.Fatalf("listing updates = %d, want 1", listingUpdates.Load())
+	}
+	if imageDeletes.Load() != 1 {
+		t.Fatalf("image deletes = %d, want 1", imageDeletes.Load())
+	}
+	if imageUploads.Load() != 1 {
+		t.Fatalf("image uploads = %d, want 1", imageUploads.Load())
+	}
+	if result["metadataLocales"] != 1 {
+		t.Fatalf("metadataLocales = %#v, want 1", result["metadataLocales"])
+	}
+	if result["screenshotImages"] != 1 {
+		t.Fatalf("screenshotImages = %#v, want 1", result["screenshotImages"])
+	}
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/cli/release/run.go
+++ b/internal/cli/release/run.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,6 +15,8 @@ import (
 	"github.com/tamtom/play-console-cli/internal/cli/shared"
 	"github.com/tamtom/play-console-cli/internal/playclient"
 )
+
+var newServiceFn = playclient.NewService
 
 // Options describes the high-level release workflow inputs.
 type Options struct {
@@ -35,13 +39,24 @@ type Options struct {
 
 // Execute runs the high-level release workflow and returns the resulting payload.
 func Execute(ctx context.Context, opts Options) (map[string]interface{}, error) {
-	service, err := playclient.NewService(ctx)
+	if shared.IsDryRun(ctx) {
+		return dryRunReleasePlan(opts)
+	}
+	if err := validateArtifactPaths(opts); err != nil {
+		return nil, err
+	}
+
+	service, err := newServiceFn(ctx)
 	if err != nil {
 		return nil, err
 	}
 	pkg := shared.ResolvePackageName(opts.PackageName, service.Cfg)
 	if strings.TrimSpace(pkg) == "" {
 		return nil, fmt.Errorf("--package is required")
+	}
+	opts.Track = strings.TrimSpace(opts.Track)
+	if opts.Track == "" {
+		return nil, fmt.Errorf("--track is required")
 	}
 
 	fmt.Fprintf(os.Stderr, "Creating edit...\n")
@@ -89,6 +104,27 @@ func Execute(ctx context.Context, opts Options) (map[string]interface{}, error) 
 		}
 		versionCode = int64(apk.VersionCode)
 		fmt.Fprintf(os.Stderr, "APK uploaded: version code %d\n", versionCode)
+	}
+
+	metadataLocales := 0
+	if strings.TrimSpace(opts.ListingsDir) != "" && !opts.SkipMetadata {
+		fmt.Fprintf(os.Stderr, "Updating listing metadata: %s\n", opts.ListingsDir)
+		metadataLocales, err = updateListings(ctx, service, pkg, edit.Id, opts.ListingsDir)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(os.Stderr, "Listing metadata updated: %d locale(s)\n", metadataLocales)
+	}
+
+	screenshotReplacements := 0
+	screenshotImages := 0
+	if strings.TrimSpace(opts.ScreenshotsDir) != "" && !opts.SkipScreenshots {
+		fmt.Fprintf(os.Stderr, "Replacing screenshots: %s\n", opts.ScreenshotsDir)
+		screenshotReplacements, screenshotImages, err = replaceScreenshots(ctx, service, pkg, edit.Id, opts.ScreenshotsDir)
+		if err != nil {
+			return nil, err
+		}
+		fmt.Fprintf(os.Stderr, "Screenshots replaced: %d type(s), %d image(s)\n", screenshotReplacements, screenshotImages)
 	}
 
 	fmt.Fprintf(os.Stderr, "Configuring track: %s\n", opts.Track)
@@ -198,12 +234,224 @@ done:
 	if release.UserFraction > 0 && release.UserFraction < 1 {
 		result["rolloutFraction"] = release.UserFraction
 	}
-
-	// These flags are validated up-front and reserved for future release-media wiring.
-	_ = opts.ListingsDir
-	_ = opts.ScreenshotsDir
-	_ = opts.SkipMetadata
-	_ = opts.SkipScreenshots
+	if metadataLocales > 0 {
+		result["metadataLocales"] = metadataLocales
+	}
+	if screenshotReplacements > 0 {
+		result["screenshotReplacements"] = screenshotReplacements
+		result["screenshotImages"] = screenshotImages
+	}
 
 	return result, nil
+}
+
+func dryRunReleasePlan(opts Options) (map[string]interface{}, error) {
+	pkg, err := shared.RequirePackageName(opts.PackageName, nil)
+	if err != nil {
+		return nil, err
+	}
+	opts.Track = strings.TrimSpace(opts.Track)
+	if opts.Track == "" {
+		return nil, fmt.Errorf("--track is required")
+	}
+	if err := validateArtifactPaths(opts); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(opts.ReleaseNotes) != "" {
+		if _, err := ParseReleaseNotes(opts.ReleaseNotes); err != nil {
+			return nil, fmt.Errorf("--release-notes: %w", err)
+		}
+	}
+
+	artifactType := "bundle"
+	artifactPath := strings.TrimSpace(opts.BundlePath)
+	if artifactPath == "" {
+		artifactType = "apk"
+		artifactPath = strings.TrimSpace(opts.APKPath)
+	}
+
+	metadataLocales := 0
+	if strings.TrimSpace(opts.ListingsDir) != "" && !opts.SkipMetadata {
+		listings, err := ParseListingsDir(opts.ListingsDir)
+		if err != nil {
+			return nil, fmt.Errorf("--listings-dir: %w", err)
+		}
+		metadataLocales = len(listings)
+	}
+
+	screenshotReplacements := 0
+	screenshotImages := 0
+	if strings.TrimSpace(opts.ScreenshotsDir) != "" && !opts.SkipScreenshots {
+		screenshots, err := ParseScreenshotsDir(opts.ScreenshotsDir)
+		if err != nil {
+			return nil, fmt.Errorf("--screenshots-dir: %w", err)
+		}
+		for _, deviceTypes := range screenshots {
+			screenshotReplacements += len(deviceTypes)
+			for _, files := range deviceTypes {
+				screenshotImages += len(files)
+			}
+		}
+	}
+
+	steps := []string{
+		"create edit",
+		"upload " + artifactType,
+	}
+	if metadataLocales > 0 {
+		steps = append(steps, "update listings")
+	}
+	if screenshotReplacements > 0 {
+		steps = append(steps, "replace screenshots")
+	}
+	steps = append(steps, "update track", "validate edit", "commit edit")
+	if opts.Wait {
+		steps = append(steps, "wait for track")
+	}
+
+	result := map[string]interface{}{
+		"dryRun":      true,
+		"packageName": pkg,
+		"track":       opts.Track,
+		"artifact": map[string]string{
+			"type": artifactType,
+			"path": artifactPath,
+		},
+		"status": opts.Status,
+		"steps":  steps,
+	}
+	if opts.RolloutFraction > 0 && opts.RolloutFraction < 1 {
+		result["rolloutFraction"] = opts.RolloutFraction
+	}
+	if metadataLocales > 0 {
+		result["metadataLocales"] = metadataLocales
+	}
+	if screenshotReplacements > 0 {
+		result["screenshotReplacements"] = screenshotReplacements
+		result["screenshotImages"] = screenshotImages
+	}
+	return result, nil
+}
+
+func validateArtifactPaths(opts Options) error {
+	bundlePath := strings.TrimSpace(opts.BundlePath)
+	apkPath := strings.TrimSpace(opts.APKPath)
+	if bundlePath == "" && apkPath == "" {
+		return fmt.Errorf("either --bundle or --apk is required")
+	}
+	if bundlePath != "" && apkPath != "" {
+		return fmt.Errorf("use either --bundle or --apk, not both")
+	}
+	if bundlePath != "" {
+		if _, err := os.Stat(bundlePath); err != nil {
+			return shared.WrapActionable(err, "failed to open bundle", "Check that the file exists and is readable.")
+		}
+	}
+	if apkPath != "" {
+		if _, err := os.Stat(apkPath); err != nil {
+			return shared.WrapActionable(err, "failed to open APK", "Check that the file exists and is readable.")
+		}
+	}
+	return nil
+}
+
+func updateListings(ctx context.Context, service *playclient.Service, pkg, editID, dir string) (int, error) {
+	listings, err := ParseListingsDir(dir)
+	if err != nil {
+		return 0, fmt.Errorf("--listings-dir: %w", err)
+	}
+
+	locales := make([]string, 0, len(listings))
+	for locale := range listings {
+		locales = append(locales, locale)
+	}
+	sort.Strings(locales)
+
+	for _, locale := range locales {
+		data := listings[locale]
+		listing := &androidpublisher.Listing{
+			Title:            data.Title,
+			ShortDescription: data.ShortDescription,
+			FullDescription:  data.FullDescription,
+			Video:            data.Video,
+		}
+		reqCtx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+		_, err := service.API.Edits.Listings.Update(pkg, editID, locale, listing).Context(reqCtx).Do()
+		cancel()
+		if err != nil {
+			return 0, fmt.Errorf("failed to update listing for %s: %w", locale, err)
+		}
+	}
+	return len(locales), nil
+}
+
+func replaceScreenshots(ctx context.Context, service *playclient.Service, pkg, editID, dir string) (int, int, error) {
+	screenshots, err := ParseScreenshotsDir(dir)
+	if err != nil {
+		return 0, 0, fmt.Errorf("--screenshots-dir: %w", err)
+	}
+
+	locales := make([]string, 0, len(screenshots))
+	for locale := range screenshots {
+		locales = append(locales, locale)
+	}
+	sort.Strings(locales)
+
+	replacements := 0
+	uploads := 0
+	for _, locale := range locales {
+		deviceTypes := screenshots[locale]
+		types := make([]string, 0, len(deviceTypes))
+		for imageType := range deviceTypes {
+			types = append(types, imageType)
+		}
+		sort.Strings(types)
+
+		for _, imageType := range types {
+			deleteCtx, deleteCancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			_, err := service.API.Edits.Images.Deleteall(pkg, editID, locale, imageType).Context(deleteCtx).Do()
+			deleteCancel()
+			if err != nil {
+				return replacements, uploads, fmt.Errorf("failed to clear screenshots for %s/%s: %w", locale, imageType, err)
+			}
+			replacements++
+
+			for _, filePath := range deviceTypes[imageType] {
+				file, err := os.Open(filePath)
+				if err != nil {
+					return replacements, uploads, shared.WrapActionable(err, "failed to open screenshot", "Check that the file exists and is readable.")
+				}
+				uploadCtx, uploadCancel := shared.ContextWithUploadTimeout(ctx, service.Cfg)
+				call := service.API.Edits.Images.Upload(pkg, editID, locale, imageType)
+				call.Media(file, googleapi.ContentType(mimeTypeForUpload(filePath)))
+				_, err = call.Context(uploadCtx).Do()
+				uploadCancel()
+				closeErr := file.Close()
+				if err != nil {
+					return replacements, uploads, shared.WrapGoogleAPIError(fmt.Sprintf("failed to upload screenshot %s", filepath.Base(filePath)), err)
+				}
+				if closeErr != nil {
+					return replacements, uploads, closeErr
+				}
+				uploads++
+			}
+		}
+	}
+
+	return replacements, uploads, nil
+}
+
+func mimeTypeForUpload(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".png":
+		return "image/png"
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".webp":
+		return "image/webp"
+	case ".gif":
+		return "image/gif"
+	default:
+		return "application/octet-stream"
+	}
 }

--- a/internal/cli/validate/readiness.go
+++ b/internal/cli/validate/readiness.go
@@ -281,6 +281,17 @@ func addReleaseNotesChecks(report *validation.ReadinessReport, input string) {
 }
 
 func addRemoteChecks(ctx context.Context, report *validation.ReadinessReport, opts readinessOptions) {
+	if shared.IsDryRun(ctx) {
+		report.AddCheck(validation.ReadinessCheck{
+			ID:          "remote-play-state-skipped-dry-run",
+			Section:     "remote",
+			State:       validation.ReadinessInfo,
+			Message:     "Remote Play state check skipped for dry-run.",
+			Remediation: "Run without --dry-run before publishing if you need to verify current Play track and listing state.",
+		})
+		return
+	}
+
 	state, err := fetchRemoteReadinessStateFn(ctx, opts.PackageName, normalizedTrack(opts.Track))
 	if err != nil {
 		report.AddCheck(validation.ReadinessCheck{

--- a/internal/cmdtest/publish_test.go
+++ b/internal/cmdtest/publish_test.go
@@ -35,10 +35,25 @@ func TestPublishTrack_RequiresArtifact(t *testing.T) {
 	}
 }
 
+func TestPublishTrack_RequiresTrack(t *testing.T) {
+	_, _, err := runCommand(t,
+		"publish", "track",
+		"--package", "com.example.app",
+		"--bundle", "app.aab",
+	)
+	if err == nil {
+		t.Fatal("expected missing track error")
+	}
+	if !strings.Contains(err.Error(), "--track is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestPublishTrack_RejectsBothArtifactFlags(t *testing.T) {
 	_, _, err := runCommand(t,
 		"publish", "track",
 		"--package", "com.example.app",
+		"--track", "internal",
 		"--bundle", "app.aab",
 		"--apk", "app.apk",
 	)


### PR DESCRIPTION
## Summary

Completes the existing `gplay publish track` implementation for the canonical Google Play release workflow.

- Require explicit `--track` for `publish track` and add a command-local `--dry-run` mode.
- Honor `--skip-metadata` and `--skip-screenshots` during readiness checks.
- Skip remote Play state checks during dry-run so local preview does not require Play API writes or remote state.
- Wire `--listings-dir` and `--screenshots-dir` into the release edit before track update and commit.
- Update README examples to use `gplay publish track` as the canonical high-level path and regenerate `GPLAY.md`.

Closes #187.

## Validation

- `go test ./internal/cli/publish ./internal/cli/release ./internal/cli/validate ./internal/cmdtest`
- `make check-docs`
- `make lint` (`go vet` fallback because `golangci-lint` is not installed)
- `make test`
- `make build`
- Manual `./gplay publish track --help`
- Manual missing-track smoke check
- Manual `publish track --dry-run` smoke check