### PR TITLE
[codex] Add missing Play API coverage

### DIFF
--- a/GPLAY.md
+++ b/GPLAY.md
@@ -48,6 +48,8 @@
 - [tracks create](#tracks-create)
 - [tracks update](#tracks-update)
 - [tracks patch](#tracks-patch)
+- [tracks releases](#tracks-releases)
+- [tracks releases list](#tracks-releases-list)
 - [users](#users)
 - [users list](#users-list)
 - [users create](#users-create)
@@ -127,6 +129,7 @@
 - [iap get](#iap-get)
 - [iap create](#iap-create)
 - [iap update](#iap-update)
+- [iap patch](#iap-patch)
 - [iap delete](#iap-delete)
 - [iap batch-get](#iap-batch-get)
 - [iap batch-update](#iap-batch-update)
@@ -195,9 +198,15 @@
 - [purchases productsv2 get](#purchases-productsv2-get)
 - [purchases subscriptions](#purchases-subscriptions)
 - [purchases subscriptions get](#purchases-subscriptions-get)
+- [purchases subscriptions acknowledge](#purchases-subscriptions-acknowledge)
 - [purchases subscriptions cancel](#purchases-subscriptions-cancel)
 - [purchases subscriptions defer](#purchases-subscriptions-defer)
 - [purchases subscriptions revoke](#purchases-subscriptions-revoke)
+- [purchases subscriptionsv2](#purchases-subscriptionsv2)
+- [purchases subscriptionsv2 get](#purchases-subscriptionsv2-get)
+- [purchases subscriptionsv2 cancel](#purchases-subscriptionsv2-cancel)
+- [purchases subscriptionsv2 defer](#purchases-subscriptionsv2-defer)
+- [purchases subscriptionsv2 revoke](#purchases-subscriptionsv2-revoke)
 - [purchases voided](#purchases-voided)
 - [purchases voided list](#purchases-voided-list)
 - [external-transactions](#external-transactions)
@@ -223,6 +232,7 @@
 - [expansion get](#expansion-get)
 - [expansion upload](#expansion-upload)
 - [expansion patch](#expansion-patch)
+- [expansion update](#expansion-update)
 - [recovery](#recovery)
 - [recovery list](#recovery-list)
 - [recovery create](#recovery-create)
@@ -443,6 +453,8 @@ gplay apps list [flags]
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--output` | Output format: json (default), table, markdown | `json` |
+| `--page-size` | Page size (1-1000) | `50` |
+| `--paginate` | Fetch all pages | `false` |
 | `--pretty` | Pretty-print JSON output | `false` |
 
 ---
@@ -1109,6 +1121,36 @@ gplay tracks patch --package <name> --edit <id> --track <name> --releases <json>
 | `--pretty` | Pretty-print JSON output | `false` |
 | `--releases` | JSON array of track releases (or @file) | `` |
 | `--track` | Track name | `` |
+
+---
+
+## gplay tracks releases
+
+List published releases for a track.
+
+```
+gplay tracks releases <subcommand> [flags]
+```
+
+---
+
+## gplay tracks releases list
+
+List non-obsolete published releases for a track.
+
+```
+gplay tracks releases list --package <name> --track <name>
+```
+
+List non-obsolete releases for a track using the
+applications.tracks.releases.list API. This does not require an edit ID.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--package` | Package name (applicationId) | `` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--track` | Track name (production, beta, alpha, internal, or custom track) | `` |
 
 ---
 
@@ -3021,6 +3063,38 @@ Use --allow-missing to create the product if it doesn't exist.
 | `--allow-missing` | Create if not exists | `false` |
 | `--auto-convert-prices` | Auto-convert missing prices to local currencies | `true` |
 | `--json` | InAppProduct JSON (or @file) | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--package` | Package name (applicationId) | `` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--sku` | Product SKU/ID | `` |
+
+---
+
+## gplay iap patch
+
+Patch an in-app product.
+
+```
+gplay iap patch --package <name> --sku <sku> --json <json>
+```
+
+Patch an in-app product using inappproducts.patch.
+
+JSON format:
+{
+  "status": "active",
+  "listings": {
+    "en-US": {
+      "title": "Premium Upgrade"
+    }
+  }
+}
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--auto-convert-prices` | Auto-convert missing prices to local currencies | `true` |
+| `--json` | InAppProduct JSON patch (or @file) | `` |
+| `--latency-tolerance` | Product update latency tolerance | `` |
 | `--output` | Output format: json (default), table, markdown | `json` |
 | `--package` | Package name (applicationId) | `` |
 | `--pretty` | Pretty-print JSON output | `false` |
@@ -4974,6 +5048,31 @@ The response includes:
 
 ---
 
+## gplay purchases subscriptions acknowledge
+
+Acknowledge a subscription purchase.
+
+```
+gplay purchases subscriptions acknowledge --package <name> --subscription-id <id> --token <token>
+```
+
+Acknowledge a subscription purchase using the legacy
+purchases.subscriptions.acknowledge API.
+
+Subscriptions must be acknowledged within 3 days or they are automatically
+refunded. Use this when server-side acknowledgement is required.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--developer-payload` | Optional developer payload | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--package` | Package name (applicationId) | `` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--subscription-id` | Subscription ID | `` |
+| `--token` | Purchase token | `` |
+
+---
+
 ## gplay purchases subscriptions cancel
 
 Cancel a subscription.
@@ -5052,6 +5151,122 @@ the user loses access right away.
 | `--package` | Package name (applicationId) | `` |
 | `--pretty` | Pretty-print JSON output | `false` |
 | `--subscription-id` | Subscription ID | `` |
+| `--token` | Purchase token | `` |
+
+---
+
+## gplay purchases subscriptionsv2
+
+Verify and mutate subscription purchases (v2 API).
+
+```
+gplay purchases subscriptionsv2 <subcommand> [flags]
+```
+
+Verify and mutate subscription purchases using the v2 API.
+
+The mutation commands accept Google API request JSON with --json so new request
+fields can be used without waiting for CLI-specific flags.
+
+---
+
+## gplay purchases subscriptionsv2 get
+
+Get subscription purchase details (v2 API).
+
+```
+gplay purchases subscriptionsv2 get --package <name> --token <token>
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--package` | Package name (applicationId) | `` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--token` | Purchase token | `` |
+
+---
+
+## gplay purchases subscriptionsv2 cancel
+
+Cancel a subscription purchase (v2 API).
+
+```
+gplay purchases subscriptionsv2 cancel --package <name> --token <token> --json <json> --confirm
+```
+
+Cancel a subscription purchase using the v2 API.
+
+JSON format:
+{
+  "cancellationContext": {
+    "cancellationType": "USER_REQUESTED_STOP_RENEWALS"
+  }
+}
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--confirm` | Confirm cancellation | `false` |
+| `--json` | CancelSubscriptionPurchaseRequest JSON (or @file) | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--package` | Package name (applicationId) | `` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--token` | Purchase token | `` |
+
+---
+
+## gplay purchases subscriptionsv2 defer
+
+Defer subscription renewal (v2 API).
+
+```
+gplay purchases subscriptionsv2 defer --package <name> --token <token> --json <json>
+```
+
+Defer subscription renewal using the v2 API.
+
+JSON format:
+{
+  "deferralContext": {
+    "deferDuration": "P7D",
+    "etag": "<etag from purchases subscriptionsv2 get>"
+  }
+}
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--json` | DeferSubscriptionPurchaseRequest JSON (or @file) | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--package` | Package name (applicationId) | `` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--token` | Purchase token | `` |
+
+---
+
+## gplay purchases subscriptionsv2 revoke
+
+Revoke a subscription purchase (v2 API).
+
+```
+gplay purchases subscriptionsv2 revoke --package <name> --token <token> --json <json> --confirm
+```
+
+Revoke a subscription purchase using the v2 API.
+
+JSON format:
+{
+  "revocationContext": {
+    "fullRefund": {}
+  }
+}
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--confirm` | Confirm revocation | `false` |
+| `--json` | RevokeSubscriptionPurchaseRequest JSON (or @file) | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--package` | Package name (applicationId) | `` |
+| `--pretty` | Pretty-print JSON output | `false` |
 | `--token` | Purchase token | `` |
 
 ---
@@ -5638,6 +5853,31 @@ Reference an expansion file from a different APK version.
 
 This allows you to reuse an existing expansion file for a new APK
 without re-uploading it.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--apk-version` | APK version code | `0` |
+| `--edit` | Edit ID | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--package` | Package name (applicationId) | `` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--references-version` | APK version code that contains the file to reference | `0` |
+| `--type` | Expansion file type: main (default), patch | `main` |
+
+---
+
+## gplay expansion update
+
+Update expansion file metadata.
+
+```
+gplay expansion update --package <name> --edit <id> --apk-version <code> --type <type> --references-version <code>
+```
+
+Update expansion file metadata using edits.expansionfiles.update.
+
+Use this to replace the expansion file reference for an APK version with a
+reference to an expansion file from another APK version.
 
 | Flag | Description | Default |
 |------|-------------|---------|

--- a/internal/cli/apps/apps_test.go
+++ b/internal/cli/apps/apps_test.go
@@ -3,7 +3,15 @@ package apps
 import (
 	"bytes"
 	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
 	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/reportingclient"
 )
 
 func TestAppsCommand_Help(t *testing.T) {
@@ -31,4 +39,109 @@ func TestAppsCommand_UnknownSubcommand(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for unknown subcommand")
 	}
+}
+
+func TestListCommand_CallsReportingAppsSearch(t *testing.T) {
+	var gotPath, gotPageSize string
+	installMockReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotPageSize = r.URL.Query().Get("pageSize")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"apps":[{"name":"apps/com.example.app","packageName":"com.example.app","displayName":"Example"}]}`)
+	})
+
+	cmd := ListCommand(nil)
+	if err := cmd.FlagSet.Parse([]string{"--page-size", "25"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	stdout, err := captureAppsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gotPath != "/v1beta1/apps:search" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if gotPageSize != "25" {
+		t.Fatalf("pageSize = %q, want 25", gotPageSize)
+	}
+	if !strings.Contains(stdout, "com.example.app") {
+		t.Fatalf("expected app in output, got %s", stdout)
+	}
+}
+
+func TestListCommand_PaginatesReportingAppsSearch(t *testing.T) {
+	var pageTokens []string
+	installMockReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		pageTokens = append(pageTokens, r.URL.Query().Get("pageToken"))
+		w.Header().Set("Content-Type", "application/json")
+		if len(pageTokens) == 1 {
+			_, _ = io.WriteString(w, `{"apps":[{"packageName":"com.example.one"}],"nextPageToken":"next"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"apps":[{"packageName":"com.example.two"}]}`)
+	})
+
+	cmd := ListCommand(nil)
+	if err := cmd.FlagSet.Parse([]string{"--paginate", "--page-size", "1"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	stdout, err := captureAppsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(pageTokens) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(pageTokens))
+	}
+	if pageTokens[0] != "" || pageTokens[1] != "next" {
+		t.Fatalf("unexpected page tokens: %#v", pageTokens)
+	}
+	if !strings.Contains(stdout, "com.example.one") || !strings.Contains(stdout, "com.example.two") {
+		t.Fatalf("expected both apps in paginated output, got %s", stdout)
+	}
+}
+
+func installMockReportingService(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	original := newReportingService
+	newReportingService = func(ctx context.Context) (*reportingclient.Service, error) {
+		return reportingclient.NewServiceWithClient(ctx, server.Client(), server.URL+"/")
+	}
+	t.Cleanup(func() {
+		newReportingService = original
+	})
+}
+
+func captureAppsStdout(fn func() error) (string, error) {
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = wOut
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, rOut)
+	}()
+
+	runErr := fn()
+
+	_ = wOut.Close()
+	os.Stdout = origStdout
+	wg.Wait()
+	_ = rOut.Close()
+
+	return buf.String(), runErr
 }

--- a/internal/cli/apps/list.go
+++ b/internal/cli/apps/list.go
@@ -4,19 +4,25 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"google.golang.org/api/playdeveloperreporting/v1beta1"
+
 	cliruntime "github.com/tamtom/play-console-cli/internal/cli/runtime"
 	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/reportingclient"
 )
+
+var newReportingService = reportingclient.NewService
 
 // ListCommand returns the apps list subcommand.
 func ListCommand(rt *cliruntime.Runtime) *ffcli.Command {
 	fs := flag.NewFlagSet("apps list", flag.ExitOnError)
+	pageSize := fs.Int("page-size", 50, "Page size (1-1000)")
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
 	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
 	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
-
-	rt = cliruntime.Ensure(rt)
 
 	return &ffcli.Command{
 		Name:       "list",
@@ -28,8 +34,11 @@ func ListCommand(rt *cliruntime.Runtime) *ffcli.Command {
 			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
 				return err
 			}
+			if *pageSize < 1 || *pageSize > 1000 {
+				return fmt.Errorf("--page-size must be between 1 and 1000")
+			}
 
-			service, err := rt.NewPlayService(ctx)
+			service, err := newReportingService(ctx)
 			if err != nil {
 				return fmt.Errorf("creating service: %w", err)
 			}
@@ -37,12 +46,32 @@ func ListCommand(rt *cliruntime.Runtime) *ffcli.Command {
 			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
 			defer cancel()
 
-			// Use the androidpublisher API to list apps
-			// The API doesn't have a direct "list apps" endpoint,
-			// but we can validate access by checking the service
-			_ = ctx
+			if !*paginate {
+				resp, err := service.API.Apps.Search().Context(ctx).PageSize(int64(*pageSize)).Do()
+				if err != nil {
+					return shared.WrapGoogleAPIError("list accessible apps", err)
+				}
+				return shared.PrintOutput(resp, *outputFlag, *pretty)
+			}
 
-			return fmt.Errorf("apps list requires the Play Developer Reporting API which is not yet configured. Use gplay tracks list --package <name> to verify access to a specific app")
+			var apps []*playdeveloperreporting.GooglePlayDeveloperReportingV1beta1App
+			pageToken := ""
+			for {
+				call := service.API.Apps.Search().Context(ctx).PageSize(int64(*pageSize))
+				if strings.TrimSpace(pageToken) != "" {
+					call.PageToken(pageToken)
+				}
+				resp, err := call.Do()
+				if err != nil {
+					return shared.WrapGoogleAPIError("list accessible apps", err)
+				}
+				apps = append(apps, resp.Apps...)
+				if resp.NextPageToken == "" {
+					break
+				}
+				pageToken = resp.NextPageToken
+			}
+			return shared.PrintOutput(apps, *outputFlag, *pretty)
 		},
 	}
 }

--- a/internal/cli/expansion/expansion.go
+++ b/internal/cli/expansion/expansion.go
@@ -15,6 +15,8 @@ import (
 	"github.com/tamtom/play-console-cli/internal/playclient"
 )
 
+var newPlayService = playclient.NewService
+
 func ExpansionCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("expansion", flag.ExitOnError)
 	return &ffcli.Command{
@@ -38,12 +40,74 @@ which provides a better user experience.`,
 			GetCommand(),
 			UploadCommand(),
 			PatchCommand(),
+			UpdateCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) == 0 {
 				return flag.ErrHelp
 			}
 			return flag.ErrHelp
+		},
+	}
+}
+
+func UpdateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("expansion update", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	editID := fs.String("edit", "", "Edit ID")
+	apkVersionCode := fs.Int64("apk-version", 0, "APK version code")
+	expansionType := fs.String("type", "main", "Expansion file type: main (default), patch")
+	referencesVersion := fs.Int64("references-version", 0, "APK version code that contains the file to reference")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "update",
+		ShortUsage: "gplay expansion update --package <name> --edit <id> --apk-version <code> --type <type> --references-version <code>",
+		ShortHelp:  "Update expansion file metadata.",
+		LongHelp: `Update expansion file metadata using edits.expansionfiles.update.
+
+Use this to replace the expansion file reference for an APK version with a
+reference to an expansion file from another APK version.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*editID) == "" {
+				return fmt.Errorf("--edit is required")
+			}
+			if *apkVersionCode == 0 {
+				return fmt.Errorf("--apk-version is required")
+			}
+			if *referencesVersion == 0 {
+				return fmt.Errorf("--references-version is required")
+			}
+			expType := strings.ToLower(strings.TrimSpace(*expansionType))
+			if expType != "main" && expType != "patch" {
+				return fmt.Errorf("--type must be 'main' or 'patch'")
+			}
+			service, err := newPlayService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
+			}
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			expansionFile := &androidpublisher.ExpansionFile{
+				ReferencesVersion: *referencesVersion,
+			}
+			resp, err := service.API.Edits.Expansionfiles.Update(pkg, *editID, *apkVersionCode, expType, expansionFile).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("update expansion file", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
 		},
 	}
 }

--- a/internal/cli/expansion/expansion_test.go
+++ b/internal/cli/expansion/expansion_test.go
@@ -1,0 +1,127 @@
+package expansion
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/playclient"
+)
+
+func TestExpansionCommand_HasUpdate(t *testing.T) {
+	cmd := ExpansionCommand()
+	expected := map[string]bool{
+		"get":    false,
+		"upload": false,
+		"patch":  false,
+		"update": false,
+	}
+	for _, sub := range cmd.Subcommands {
+		if _, ok := expected[sub.Name]; ok {
+			expected[sub.Name] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Fatalf("missing subcommand %q", name)
+		}
+	}
+}
+
+func TestExpansionCommand_NoArgsReturnsHelp(t *testing.T) {
+	cmd := ExpansionCommand()
+	if err := cmd.Exec(context.Background(), nil); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", err)
+	}
+}
+
+func TestExpansionUpdateCommand_CallsAPI(t *testing.T) {
+	var gotMethod, gotPath, gotBody string
+	installMockExpansionPlayService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"referencesVersion":123}`)
+	})
+
+	cmd := UpdateCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--package", "com.example.app",
+		"--edit", "edit-1",
+		"--apk-version", "456",
+		"--type", "main",
+		"--references-version", "123",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	stdout, err := captureExpansionStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gotMethod != http.MethodPut {
+		t.Fatalf("method = %s, want PUT", gotMethod)
+	}
+	if gotPath != "/androidpublisher/v3/applications/com.example.app/edits/edit-1/apks/456/expansionFiles/main" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if !strings.Contains(gotBody, `"referencesVersion":123`) {
+		t.Fatalf("expected referencesVersion in body, got %s", gotBody)
+	}
+	if !strings.Contains(stdout, "123") {
+		t.Fatalf("expected expansion file output, got %s", stdout)
+	}
+}
+
+func installMockExpansionPlayService(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	original := newPlayService
+	newPlayService = func(ctx context.Context) (*playclient.Service, error) {
+		return playclient.NewServiceWithClient(ctx, server.Client(), server.URL+"/")
+	}
+	t.Cleanup(func() {
+		newPlayService = original
+	})
+}
+
+func captureExpansionStdout(fn func() error) (string, error) {
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = wOut
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, rOut)
+	}()
+
+	runErr := fn()
+
+	_ = wOut.Close()
+	os.Stdout = origStdout
+	wg.Wait()
+	_ = rOut.Close()
+
+	return buf.String(), runErr
+}

--- a/internal/cli/grants/grants.go
+++ b/internal/cli/grants/grants.go
@@ -26,7 +26,6 @@ as opposed to account-wide permissions.`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
-			// ListCommand() is not available - Google Play API v3 Grants service does not expose List method
 			CreateCommand(),
 			UpdateCommand(),
 			DeleteCommand(),
@@ -36,27 +35,6 @@ as opposed to account-wide permissions.`,
 				return flag.ErrHelp
 			}
 			return flag.ErrHelp
-		},
-	}
-}
-
-// ListCommand is not implemented because the Google Play Android Publisher API v3
-// Grants service does not expose a List method. The available methods are:
-// Create, Delete, and Patch.
-//
-// To view grants, you would need to track them separately or use the
-// Google Play Console web interface.
-func ListCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("grants list", flag.ExitOnError)
-
-	return &ffcli.Command{
-		Name:       "list",
-		ShortUsage: "gplay grants list (not implemented)",
-		ShortHelp:  "List grants (not available in API v3).",
-		FlagSet:    fs,
-		UsageFunc:  shared.DefaultUsageFunc,
-		Exec: func(ctx context.Context, args []string) error {
-			return fmt.Errorf("grants list is not implemented: the Google Play Android Publisher API v3 does not expose a List method for Grants. Available operations are: create, update (patch), and delete")
 		},
 	}
 }

--- a/internal/cli/grants/grants_test.go
+++ b/internal/cli/grants/grants_test.go
@@ -66,45 +66,6 @@ func TestGrantsCommand_ExecWithArgs(t *testing.T) {
 	}
 }
 
-// --- ListCommand tests ---
-
-func TestListCommand_Name(t *testing.T) {
-	cmd := ListCommand()
-	if cmd.Name != "list" {
-		t.Errorf("Name = %q, want %q", cmd.Name, "list")
-	}
-}
-
-func TestListCommand_UsageFunc(t *testing.T) {
-	cmd := ListCommand()
-	if cmd.UsageFunc == nil {
-		t.Fatal("UsageFunc is nil, want shared.DefaultUsageFunc")
-	}
-	got := cmd.UsageFunc(cmd)
-	want := shared.DefaultUsageFunc(cmd)
-	if got != want {
-		t.Error("UsageFunc does not match shared.DefaultUsageFunc")
-	}
-}
-
-func TestListCommand_ReturnsAPILimitationError(t *testing.T) {
-	cmd := ListCommand()
-	err := cmd.Exec(context.Background(), []string{})
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-	msg := err.Error()
-	if !strings.Contains(msg, "not implemented") {
-		t.Errorf("error should mention 'not implemented', got: %v", msg)
-	}
-	if !strings.Contains(msg, "List method") {
-		t.Errorf("error should mention 'List method', got: %v", msg)
-	}
-	if !strings.Contains(msg, "API v3") {
-		t.Errorf("error should mention 'API v3', got: %v", msg)
-	}
-}
-
 // --- CreateCommand tests ---
 
 func TestCreateCommand_Name(t *testing.T) {

--- a/internal/cli/iap/iap.go
+++ b/internal/cli/iap/iap.go
@@ -13,6 +13,8 @@ import (
 	"github.com/tamtom/play-console-cli/internal/playclient"
 )
 
+var newPlayService = playclient.NewService
+
 func IAPCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("iap", flag.ExitOnError)
 	return &ffcli.Command{
@@ -30,6 +32,7 @@ For subscriptions, use the "subscriptions" command instead.`,
 			GetCommand(),
 			CreateCommand(),
 			UpdateCommand(),
+			PatchCommand(),
 			DeleteCommand(),
 			BatchGetCommand(),
 			BatchUpdateCommand(),
@@ -40,6 +43,78 @@ For subscriptions, use the "subscriptions" command instead.`,
 				return flag.ErrHelp
 			}
 			return flag.ErrHelp
+		},
+	}
+}
+
+func PatchCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("iap patch", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	sku := fs.String("sku", "", "Product SKU/ID")
+	jsonFlag := fs.String("json", "", "InAppProduct JSON patch (or @file)")
+	autoConvertPrices := fs.Bool("auto-convert-prices", true, "Auto-convert missing prices to local currencies")
+	latencyTolerance := fs.String("latency-tolerance", "", "Product update latency tolerance")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "patch",
+		ShortUsage: "gplay iap patch --package <name> --sku <sku> --json <json>",
+		ShortHelp:  "Patch an in-app product.",
+		LongHelp: `Patch an in-app product using inappproducts.patch.
+
+JSON format:
+{
+  "status": "active",
+  "listings": {
+    "en-US": {
+      "title": "Premium Upgrade"
+    }
+  }
+}`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*sku) == "" {
+				return fmt.Errorf("--sku is required")
+			}
+			if strings.TrimSpace(*jsonFlag) == "" {
+				return fmt.Errorf("--json is required")
+			}
+			service, err := newPlayService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
+			}
+
+			var product androidpublisher.InAppProduct
+			if err := shared.LoadJSONArg(*jsonFlag, &product); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+			product.PackageName = pkg
+			product.Sku = *sku
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			call := service.API.Inappproducts.Patch(pkg, *sku, &product).Context(ctx)
+			if *autoConvertPrices {
+				call = call.AutoConvertMissingPrices(true)
+			}
+			if strings.TrimSpace(*latencyTolerance) != "" {
+				call = call.LatencyTolerance(*latencyTolerance)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return err
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
 		},
 	}
 }

--- a/internal/cli/iap/iap_test.go
+++ b/internal/cli/iap/iap_test.go
@@ -1,11 +1,19 @@
 package iap
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/playclient"
 )
 
 func TestIAPCommand_Name(t *testing.T) {
@@ -50,6 +58,7 @@ func TestIAPCommand_SubcommandNames(t *testing.T) {
 		"get":          false,
 		"create":       false,
 		"update":       false,
+		"patch":        false,
 		"delete":       false,
 		"batch-get":    false,
 		"batch-update": false,
@@ -222,6 +231,55 @@ func TestIAPUpdateCommand_MissingJson(t *testing.T) {
 	}
 }
 
+// --- iap patch ---
+
+func TestIAPPatchCommand_Name(t *testing.T) {
+	cmd := PatchCommand()
+	if cmd.Name != "patch" {
+		t.Errorf("expected name %q, got %q", "patch", cmd.Name)
+	}
+}
+
+func TestIAPPatchCommand_CallsAPI(t *testing.T) {
+	var gotMethod, gotPath, gotBody string
+	installMockIAPPlayService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"packageName":"com.example.app","sku":"coins_100","status":"active"}`)
+	})
+
+	cmd := PatchCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--package", "com.example.app",
+		"--sku", "coins_100",
+		"--json", `{"status":"active"}`,
+		"--auto-convert-prices",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	stdout, err := captureIAPStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gotMethod != http.MethodPatch {
+		t.Fatalf("method = %s, want PATCH", gotMethod)
+	}
+	if gotPath != "/androidpublisher/v3/applications/com.example.app/inappproducts/coins_100" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if !strings.Contains(gotBody, `"sku":"coins_100"`) {
+		t.Fatalf("expected SKU to be set in body, got %s", gotBody)
+	}
+	if !strings.Contains(stdout, "coins_100") {
+		t.Fatalf("expected patched product in output, got %s", stdout)
+	}
+}
+
 // --- iap delete ---
 
 func TestIAPDeleteCommand_Name(t *testing.T) {
@@ -280,6 +338,48 @@ func TestIAPBatchGetCommand_MissingSkus(t *testing.T) {
 	if !strings.Contains(err.Error(), "--skus") {
 		t.Errorf("error should mention --skus, got: %s", err.Error())
 	}
+}
+
+func installMockIAPPlayService(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	original := newPlayService
+	newPlayService = func(ctx context.Context) (*playclient.Service, error) {
+		return playclient.NewServiceWithClient(ctx, server.Client(), server.URL+"/")
+	}
+	t.Cleanup(func() {
+		newPlayService = original
+	})
+}
+
+func captureIAPStdout(fn func() error) (string, error) {
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = wOut
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, rOut)
+	}()
+
+	runErr := fn()
+
+	_ = wOut.Close()
+	os.Stdout = origStdout
+	wg.Wait()
+	_ = rOut.Close()
+
+	return buf.String(), runErr
 }
 
 func TestIAPBatchGetCommand_WhitespaceSkus(t *testing.T) {

--- a/internal/cli/purchases/purchases.go
+++ b/internal/cli/purchases/purchases.go
@@ -13,6 +13,8 @@ import (
 	"github.com/tamtom/play-console-cli/internal/playclient"
 )
 
+var newPlayService = playclient.NewService
+
 func PurchasesCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("purchases", flag.ExitOnError)
 	return &ffcli.Command{
@@ -29,6 +31,7 @@ and subscription management.`,
 			ProductsCommand(),
 			ProductsV2Command(),
 			SubscriptionsCommand(),
+			SubscriptionsV2Command(),
 			VoidedCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
@@ -313,6 +316,7 @@ func SubscriptionsCommand() *ffcli.Command {
 		UsageFunc:  shared.DefaultUsageFunc,
 		Subcommands: []*ffcli.Command{
 			SubscriptionsGetCommand(),
+			SubscriptionsAcknowledgeCommand(),
 			SubscriptionsCancelCommand(),
 			SubscriptionsDeferCommand(),
 			SubscriptionsRevokeCommand(),
@@ -322,6 +326,320 @@ func SubscriptionsCommand() *ffcli.Command {
 				return flag.ErrHelp
 			}
 			return flag.ErrHelp
+		},
+	}
+}
+
+func SubscriptionsAcknowledgeCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("purchases subscriptions acknowledge", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	subscriptionID := fs.String("subscription-id", "", "Subscription ID")
+	token := fs.String("token", "", "Purchase token")
+	developerPayload := fs.String("developer-payload", "", "Optional developer payload")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "acknowledge",
+		ShortUsage: "gplay purchases subscriptions acknowledge --package <name> --subscription-id <id> --token <token>",
+		ShortHelp:  "Acknowledge a subscription purchase.",
+		LongHelp: `Acknowledge a subscription purchase using the legacy
+purchases.subscriptions.acknowledge API.
+
+Subscriptions must be acknowledged within 3 days or they are automatically
+refunded. Use this when server-side acknowledgement is required.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*subscriptionID) == "" {
+				return fmt.Errorf("--subscription-id is required")
+			}
+			if strings.TrimSpace(*token) == "" {
+				return fmt.Errorf("--token is required")
+			}
+			service, err := newPlayService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
+			}
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			req := &androidpublisher.SubscriptionPurchasesAcknowledgeRequest{}
+			if strings.TrimSpace(*developerPayload) != "" {
+				req.DeveloperPayload = *developerPayload
+			}
+			if err := service.API.Purchases.Subscriptions.Acknowledge(pkg, *subscriptionID, *token, req).Context(ctx).Do(); err != nil {
+				return err
+			}
+
+			result := map[string]interface{}{
+				"acknowledged":   true,
+				"subscriptionId": *subscriptionID,
+			}
+			return shared.PrintOutput(result, *outputFlag, *pretty)
+		},
+	}
+}
+
+// SubscriptionsV2Command handles subscription purchases using the v2 API.
+func SubscriptionsV2Command() *ffcli.Command {
+	fs := flag.NewFlagSet("purchases subscriptionsv2", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "subscriptionsv2",
+		ShortUsage: "gplay purchases subscriptionsv2 <subcommand> [flags]",
+		ShortHelp:  "Verify and mutate subscription purchases (v2 API).",
+		LongHelp: `Verify and mutate subscription purchases using the v2 API.
+
+The mutation commands accept Google API request JSON with --json so new request
+fields can be used without waiting for CLI-specific flags.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			SubscriptionsV2GetCommand(),
+			SubscriptionsV2CancelCommand(),
+			SubscriptionsV2DeferCommand(),
+			SubscriptionsV2RevokeCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) == 0 {
+				return flag.ErrHelp
+			}
+			return flag.ErrHelp
+		},
+	}
+}
+
+func SubscriptionsV2GetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("purchases subscriptionsv2 get", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	token := fs.String("token", "", "Purchase token")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "gplay purchases subscriptionsv2 get --package <name> --token <token>",
+		ShortHelp:  "Get subscription purchase details (v2 API).",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*token) == "" {
+				return fmt.Errorf("--token is required")
+			}
+			service, err := newPlayService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
+			}
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.API.Purchases.Subscriptionsv2.Get(pkg, *token).Context(ctx).Do()
+			if err != nil {
+				return err
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func SubscriptionsV2CancelCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("purchases subscriptionsv2 cancel", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	token := fs.String("token", "", "Purchase token")
+	jsonFlag := fs.String("json", "", "CancelSubscriptionPurchaseRequest JSON (or @file)")
+	confirm := fs.Bool("confirm", false, "Confirm cancellation")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "cancel",
+		ShortUsage: "gplay purchases subscriptionsv2 cancel --package <name> --token <token> --json <json> --confirm",
+		ShortHelp:  "Cancel a subscription purchase (v2 API).",
+		LongHelp: `Cancel a subscription purchase using the v2 API.
+
+JSON format:
+{
+  "cancellationContext": {
+    "cancellationType": "USER_REQUESTED_STOP_RENEWALS"
+  }
+}`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*token) == "" {
+				return fmt.Errorf("--token is required")
+			}
+			if strings.TrimSpace(*jsonFlag) == "" {
+				return fmt.Errorf("--json is required")
+			}
+			if !*confirm {
+				return fmt.Errorf("--confirm is required")
+			}
+			service, err := newPlayService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
+			}
+			var req androidpublisher.CancelSubscriptionPurchaseRequest
+			if err := shared.LoadJSONArg(*jsonFlag, &req); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if _, err := service.API.Purchases.Subscriptionsv2.Cancel(pkg, *token, &req).Context(ctx).Do(); err != nil {
+				return err
+			}
+			result := map[string]interface{}{
+				"canceled": true,
+				"token":    *token,
+			}
+			return shared.PrintOutput(result, *outputFlag, *pretty)
+		},
+	}
+}
+
+func SubscriptionsV2DeferCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("purchases subscriptionsv2 defer", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	token := fs.String("token", "", "Purchase token")
+	jsonFlag := fs.String("json", "", "DeferSubscriptionPurchaseRequest JSON (or @file)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "defer",
+		ShortUsage: "gplay purchases subscriptionsv2 defer --package <name> --token <token> --json <json>",
+		ShortHelp:  "Defer subscription renewal (v2 API).",
+		LongHelp: `Defer subscription renewal using the v2 API.
+
+JSON format:
+{
+  "deferralContext": {
+    "deferDuration": "P7D",
+    "etag": "<etag from purchases subscriptionsv2 get>"
+  }
+}`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*token) == "" {
+				return fmt.Errorf("--token is required")
+			}
+			if strings.TrimSpace(*jsonFlag) == "" {
+				return fmt.Errorf("--json is required")
+			}
+			service, err := newPlayService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
+			}
+			var req androidpublisher.DeferSubscriptionPurchaseRequest
+			if err := shared.LoadJSONArg(*jsonFlag, &req); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.API.Purchases.Subscriptionsv2.Defer(pkg, *token, &req).Context(ctx).Do()
+			if err != nil {
+				return err
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func SubscriptionsV2RevokeCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("purchases subscriptionsv2 revoke", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	token := fs.String("token", "", "Purchase token")
+	jsonFlag := fs.String("json", "", "RevokeSubscriptionPurchaseRequest JSON (or @file)")
+	confirm := fs.Bool("confirm", false, "Confirm revocation")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "revoke",
+		ShortUsage: "gplay purchases subscriptionsv2 revoke --package <name> --token <token> --json <json> --confirm",
+		ShortHelp:  "Revoke a subscription purchase (v2 API).",
+		LongHelp: `Revoke a subscription purchase using the v2 API.
+
+JSON format:
+{
+  "revocationContext": {
+    "fullRefund": {}
+  }
+}`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*token) == "" {
+				return fmt.Errorf("--token is required")
+			}
+			if strings.TrimSpace(*jsonFlag) == "" {
+				return fmt.Errorf("--json is required")
+			}
+			if !*confirm {
+				return fmt.Errorf("--confirm is required")
+			}
+			service, err := newPlayService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
+			}
+			var req androidpublisher.RevokeSubscriptionPurchaseRequest
+			if err := shared.LoadJSONArg(*jsonFlag, &req); err != nil {
+				return fmt.Errorf("invalid JSON: %w", err)
+			}
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if _, err := service.API.Purchases.Subscriptionsv2.Revoke(pkg, *token, &req).Context(ctx).Do(); err != nil {
+				return err
+			}
+			result := map[string]interface{}{
+				"revoked": true,
+				"token":   *token,
+			}
+			return shared.PrintOutput(result, *outputFlag, *pretty)
 		},
 	}
 }

--- a/internal/cli/purchases/purchases_test.go
+++ b/internal/cli/purchases/purchases_test.go
@@ -1,0 +1,148 @@
+package purchases
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/playclient"
+)
+
+func TestPurchasesCommand_HasSubscriptionsV2(t *testing.T) {
+	cmd := PurchasesCommand()
+	found := false
+	for _, sub := range cmd.Subcommands {
+		if sub.Name == "subscriptionsv2" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected purchases command to expose subscriptionsv2")
+	}
+}
+
+func TestSubscriptionsCommand_HasAcknowledge(t *testing.T) {
+	cmd := SubscriptionsCommand()
+	found := false
+	for _, sub := range cmd.Subcommands {
+		if sub.Name == "acknowledge" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected purchases subscriptions to expose acknowledge")
+	}
+}
+
+func TestSubscriptionsAcknowledgeCommand_CallsAPI(t *testing.T) {
+	var gotPath, gotBody string
+	installMockPlayService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	cmd := SubscriptionsAcknowledgeCommand()
+	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--subscription-id", "premium", "--token", "tok", "--developer-payload", "payload"})
+	stdout, err := capturePurchasesStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gotPath != "/androidpublisher/v3/applications/com.example.app/purchases/subscriptions/premium/tokens/tok:acknowledge" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if !strings.Contains(gotBody, "payload") {
+		t.Fatalf("expected developer payload in body, got %s", gotBody)
+	}
+	if !strings.Contains(stdout, `"acknowledged":true`) {
+		t.Fatalf("expected acknowledged output, got %s", stdout)
+	}
+}
+
+func TestSubscriptionsV2CancelCommand_CallsAPI(t *testing.T) {
+	var gotPath, gotBody string
+	installMockPlayService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{}`)
+	})
+
+	cmd := SubscriptionsV2CancelCommand()
+	_ = cmd.FlagSet.Parse([]string{
+		"--package", "com.example.app",
+		"--token", "tok",
+		"--json", `{"cancellationContext":{"cancellationType":"USER_REQUESTED_STOP_RENEWALS"}}`,
+		"--confirm",
+	})
+	stdout, err := capturePurchasesStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gotPath != "/androidpublisher/v3/applications/com.example.app/purchases/subscriptionsv2/tokens/tok:cancel" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if !strings.Contains(gotBody, "USER_REQUESTED_STOP_RENEWALS") {
+		t.Fatalf("expected cancellation request body, got %s", gotBody)
+	}
+	if !strings.Contains(stdout, `"canceled":true`) {
+		t.Fatalf("expected canceled output, got %s", stdout)
+	}
+}
+
+func installMockPlayService(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	original := newPlayService
+	newPlayService = func(ctx context.Context) (*playclient.Service, error) {
+		return playclient.NewServiceWithClient(ctx, server.Client(), server.URL+"/")
+	}
+	t.Cleanup(func() {
+		newPlayService = original
+	})
+}
+
+func capturePurchasesStdout(fn func() error) (string, error) {
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = wOut
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, rOut)
+	}()
+
+	runErr := fn()
+
+	_ = wOut.Close()
+	os.Stdout = origStdout
+	wg.Wait()
+	_ = rOut.Close()
+
+	return buf.String(), runErr
+}

--- a/internal/cli/tracks/tracks.go
+++ b/internal/cli/tracks/tracks.go
@@ -13,6 +13,8 @@ import (
 	"github.com/tamtom/play-console-cli/internal/playclient"
 )
 
+var newPlayService = playclient.NewService
+
 func TracksCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("tracks", flag.ExitOnError)
 	return &ffcli.Command{
@@ -27,12 +29,77 @@ func TracksCommand() *ffcli.Command {
 			CreateCommand(),
 			UpdateCommand(),
 			PatchCommand(),
+			ReleasesCommand(),
 		},
 		Exec: func(ctx context.Context, args []string) error {
 			if len(args) == 0 {
 				return flag.ErrHelp
 			}
 			return flag.ErrHelp
+		},
+	}
+}
+
+func ReleasesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("tracks releases", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "releases",
+		ShortUsage: "gplay tracks releases <subcommand> [flags]",
+		ShortHelp:  "List published releases for a track.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			ReleasesListCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) == 0 {
+				return flag.ErrHelp
+			}
+			return flag.ErrHelp
+		},
+	}
+}
+
+func ReleasesListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("tracks releases list", flag.ExitOnError)
+	packageName := fs.String("package", "", "Package name (applicationId)")
+	track := fs.String("track", "", "Track name (production, beta, alpha, internal, or custom track)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "gplay tracks releases list --package <name> --track <name>",
+		ShortHelp:  "List non-obsolete published releases for a track.",
+		LongHelp: `List non-obsolete releases for a track using the
+applications.tracks.releases.list API. This does not require an edit ID.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*track) == "" {
+				return fmt.Errorf("--track is required")
+			}
+			service, err := newPlayService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
+			}
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			parent := fmt.Sprintf("applications/%s/tracks/%s", pkg, *track)
+			resp, err := service.API.Applications.Tracks.Releases.List(parent).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("list track releases", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
 		},
 	}
 }

--- a/internal/cli/tracks/tracks_test.go
+++ b/internal/cli/tracks/tracks_test.go
@@ -1,11 +1,19 @@
 package tracks
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/playclient"
 )
 
 func TestTracksCommand_Name(t *testing.T) {
@@ -39,11 +47,12 @@ func TestTracksCommand_HasSubcommands(t *testing.T) {
 func TestTracksCommand_SubcommandNames(t *testing.T) {
 	cmd := TracksCommand()
 	expected := map[string]bool{
-		"list":   false,
-		"get":    false,
-		"create": false,
-		"update": false,
-		"patch":  false,
+		"list":     false,
+		"get":      false,
+		"create":   false,
+		"update":   false,
+		"patch":    false,
+		"releases": false,
 	}
 	for _, sub := range cmd.Subcommands {
 		if _, ok := expected[sub.Name]; ok {
@@ -117,6 +126,74 @@ func TestTracksListCommand_PrettyWithTable(t *testing.T) {
 	if !strings.Contains(err.Error(), "--pretty") {
 		t.Errorf("error should mention --pretty, got: %s", err.Error())
 	}
+}
+
+func TestTrackReleasesListCommand_CallsAPI(t *testing.T) {
+	var gotPath string
+	installMockTracksPlayService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"releases":[{"track":"production","releaseName":"42","releaseLifecycleState":"RELEASE_LIFECYCLE_STATE_PUBLISHED"}]}`)
+	})
+
+	cmd := ReleasesListCommand()
+	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--track", "production"}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	stdout, err := captureTracksStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if gotPath != "/androidpublisher/v3/applications/com.example.app/tracks/production/releases" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if !strings.Contains(stdout, "RELEASE_LIFECYCLE_STATE_PUBLISHED") {
+		t.Fatalf("expected release in output, got %s", stdout)
+	}
+}
+
+func installMockTracksPlayService(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	original := newPlayService
+	newPlayService = func(ctx context.Context) (*playclient.Service, error) {
+		return playclient.NewServiceWithClient(ctx, server.Client(), server.URL+"/")
+	}
+	t.Cleanup(func() {
+		newPlayService = original
+	})
+}
+
+func captureTracksStdout(fn func() error) (string, error) {
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = wOut
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, rOut)
+	}()
+
+	runErr := fn()
+
+	_ = wOut.Close()
+	os.Stdout = origStdout
+	wg.Wait()
+	_ = rOut.Close()
+
+	return buf.String(), runErr
 }
 
 // --- tracks get ---

--- a/internal/cli/vitals/anomalies.go
+++ b/internal/cli/vitals/anomalies.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"google.golang.org/api/playdeveloperreporting/v1beta1"
 
 	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/reportingclient"
 )
 
 // anomalyMetricSets maps the --type flag to the Play Developer Reporting API
@@ -18,7 +20,7 @@ var anomalyMetricSets = map[string]string{
 	"crash":       "crashRateMetricSet",
 	"anr":         "anrRateMetricSet",
 	"errors":      "errorCountMetricSet",
-	"performance": "slowRenderingRate20FpsMetricSet",
+	"performance": "slowRenderingRateMetricSet",
 	"all":         "*",
 }
 
@@ -70,13 +72,99 @@ from the Android Publisher API used by other commands.`,
 				return fmt.Errorf("--limit must be between 1 and 1000")
 			}
 
-			return fmt.Errorf(
-				"play Developer Reporting API client is not yet connected, "+
-					"would list anomalies for app %s (metricSet=%s, from=%s, to=%s, limit=%d)",
-				*packageName, metricSet, fromDate, toDate, *limit,
-			)
+			service, err := newReportingService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
+			}
+
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := listAnomalies(ctx, service, pkg, metricSet, fromDate, toDate, *limit)
+			if err != nil {
+				return err
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
 		},
 	}
+}
+
+func listAnomalies(ctx context.Context, service *reportingclient.Service, pkg, metricSet, fromDate, toDate string, limit int) (*playdeveloperreporting.GooglePlayDeveloperReportingV1beta1ListAnomaliesResponse, error) {
+	filter, err := anomalyActiveBetweenFilter(fromDate, toDate)
+	if err != nil {
+		return nil, err
+	}
+
+	var anomalies []*playdeveloperreporting.GooglePlayDeveloperReportingV1beta1Anomaly
+	parent := fmt.Sprintf("apps/%s", pkg)
+	pageToken := ""
+	nextPageToken := ""
+	for len(anomalies) < limit {
+		pageSize := limit - len(anomalies)
+		if pageSize > 100 {
+			pageSize = 100
+		}
+		call := service.API.Anomalies.List(parent).Context(ctx).Filter(filter).PageSize(int64(pageSize))
+		if pageToken != "" {
+			call.PageToken(pageToken)
+		}
+		resp, err := call.Do()
+		if err != nil {
+			return nil, shared.WrapGoogleAPIError("list anomalies", err)
+		}
+		nextPageToken = resp.NextPageToken
+		for _, anomaly := range resp.Anomalies {
+			if anomalyMetricMatches(anomaly, metricSet) {
+				anomalies = append(anomalies, anomaly)
+				if len(anomalies) == limit {
+					break
+				}
+			}
+		}
+		if resp.NextPageToken == "" {
+			nextPageToken = ""
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+
+	return &playdeveloperreporting.GooglePlayDeveloperReportingV1beta1ListAnomaliesResponse{
+		Anomalies:     anomalies,
+		NextPageToken: nextPageToken,
+	}, nil
+}
+
+func anomalyActiveBetweenFilter(fromDate, toDate string) (string, error) {
+	from, err := time.Parse("2006-01-02", fromDate)
+	if err != nil {
+		return "", fmt.Errorf("--from: invalid date format: %q (expected YYYY-MM-DD)", fromDate)
+	}
+	to, err := time.Parse("2006-01-02", toDate)
+	if err != nil {
+		return "", fmt.Errorf("--to: invalid date format: %q (expected YYYY-MM-DD)", toDate)
+	}
+	if from.After(to) {
+		return "", fmt.Errorf("--from must be on or before --to")
+	}
+	return fmt.Sprintf(
+		`activeBetween("%sT00:00:00Z", "%sT00:00:00Z")`,
+		from.Format("2006-01-02"),
+		to.AddDate(0, 0, 1).Format("2006-01-02"),
+	), nil
+}
+
+func anomalyMetricMatches(anomaly *playdeveloperreporting.GooglePlayDeveloperReportingV1beta1Anomaly, metricSet string) bool {
+	if metricSet == "*" {
+		return true
+	}
+	if anomaly == nil {
+		return false
+	}
+	return anomaly.MetricSet == metricSet || strings.HasSuffix(anomaly.MetricSet, "/"+metricSet)
 }
 
 func resolveAnomalyMetric(input string) (string, error) {

--- a/internal/cli/vitals/anomalies_test.go
+++ b/internal/cli/vitals/anomalies_test.go
@@ -2,6 +2,8 @@ package vitals
 
 import (
 	"context"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -15,7 +17,7 @@ func TestAnomaliesMetricTypeValid(t *testing.T) {
 		{"crash", "crashRateMetricSet", false},
 		{"anr", "anrRateMetricSet", false},
 		{"errors", "errorCountMetricSet", false},
-		{"performance", "slowRenderingRate20FpsMetricSet", false},
+		{"performance", "slowRenderingRateMetricSet", false},
 		{"all", "*", false},
 		{"", "*", false},
 		{"nonsense", "", true},
@@ -84,14 +86,24 @@ func TestAnomaliesLimitBounds(t *testing.T) {
 	}
 }
 
-func TestAnomaliesHappyPathStillStub(t *testing.T) {
+func TestAnomaliesFiltersByMetricSet(t *testing.T) {
+	installMockVitalsReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"anomalies":[{"metricSet":"apps/com.example.app/crashRateMetricSet"},{"metricSet":"apps/com.example.app/anrRateMetricSet"}]}`)
+	})
+
 	cmd := AnomaliesCommand()
 	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--type", "crash", "--limit", "10"})
-	err := cmd.Exec(context.Background(), nil)
-	if err == nil || !strings.Contains(err.Error(), "not yet connected") {
-		t.Fatalf("expected stub error, got %v", err)
+	stdout, err := captureVitalsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "crashRateMetricSet") {
-		t.Errorf("expected metric set in error, got %v", err)
+	if !strings.Contains(stdout, "crashRateMetricSet") {
+		t.Fatalf("expected crash anomaly in output, got %s", stdout)
+	}
+	if strings.Contains(stdout, "anrRateMetricSet") {
+		t.Fatalf("did not expect ANR anomaly after crash filter, got %s", stdout)
 	}
 }

--- a/internal/cli/vitals/crashes.go
+++ b/internal/cli/vitals/crashes.go
@@ -5,10 +5,38 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
+	"google.golang.org/api/playdeveloperreporting/v1beta1"
 
 	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/reportingclient"
+)
+
+const defaultCrashQueryPageSize int64 = 1000
+
+var newReportingService = reportingclient.NewService
+
+var (
+	crashRateMetrics = []string{
+		"crashRate",
+		"crashRate7dUserWeighted",
+		"crashRate28dUserWeighted",
+		"userPerceivedCrashRate",
+		"userPerceivedCrashRate7dUserWeighted",
+		"userPerceivedCrashRate28dUserWeighted",
+		"distinctUsers",
+	}
+	anrRateMetrics = []string{
+		"anrRate",
+		"anrRate7dUserWeighted",
+		"anrRate28dUserWeighted",
+		"userPerceivedAnrRate",
+		"userPerceivedAnrRate7dUserWeighted",
+		"userPerceivedAnrRate28dUserWeighted",
+		"distinctUsers",
+	}
 )
 
 // CrashesQueryCommand returns the "gplay vitals crashes query" command.
@@ -21,7 +49,7 @@ func CrashesQueryCommand() *ffcli.Command {
 	metricType := fs.String("type", "crash", "Metric type: crash (default) or anr")
 	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
 	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
-	_ = fs.Bool("paginate", false, "Fetch all pages")
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
 
 	return &ffcli.Command{
 		Name:       "query",
@@ -61,38 +89,188 @@ separate from the Android Publisher API used by other commands.`,
 				}
 			}
 
-			_ = *dimension // validated but not used until API client is connected
-
-			metricSet := "crashRateMetricSet"
-			if normalizedType == "anr" {
-				metricSet = "anrRateMetricSet"
+			service, err := newReportingService(ctx)
+			if err != nil {
+				return err
+			}
+			pkg := shared.ResolvePackageName(*packageName, service.Cfg)
+			if strings.TrimSpace(pkg) == "" {
+				return fmt.Errorf("--package is required")
 			}
 
-			return fmt.Errorf(
-				"play Developer Reporting API client is not yet connected, "+
-					"would call POST apps/%s/%s:query with the provided parameters",
-				*packageName, metricSet,
-			)
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			opts := crashQueryOptions{
+				from:      *from,
+				to:        *to,
+				dimension: *dimension,
+				paginate:  *paginate,
+			}
+			var result interface{}
+			if normalizedType == "anr" {
+				result, err = queryANRRate(ctx, service, pkg, opts)
+			} else {
+				result, err = queryCrashRate(ctx, service, pkg, opts)
+			}
+			if err != nil {
+				return err
+			}
+			return shared.PrintOutput(result, *outputFlag, *pretty)
 		},
 	}
+}
+
+type crashQueryOptions struct {
+	from      string
+	to        string
+	dimension string
+	paginate  bool
+}
+
+func queryCrashRate(ctx context.Context, service *reportingclient.Service, pkg string, opts crashQueryOptions) (interface{}, error) {
+	timelineSpec, err := buildCrashTimelineSpec(opts.from, opts.to)
+	if err != nil {
+		return nil, err
+	}
+
+	name := fmt.Sprintf("apps/%s/crashRateMetricSet", pkg)
+	if !opts.paginate {
+		resp, err := service.API.Vitals.Crashrate.Query(name, &playdeveloperreporting.GooglePlayDeveloperReportingV1beta1QueryCrashRateMetricSetRequest{
+			Dimensions:   buildCrashDimensions(opts.dimension),
+			Metrics:      append([]string(nil), crashRateMetrics...),
+			PageSize:     defaultCrashQueryPageSize,
+			TimelineSpec: timelineSpec,
+		}).Context(ctx).Do()
+		if err != nil {
+			return nil, shared.WrapGoogleAPIError("query crash rate metrics", err)
+		}
+		return resp, nil
+	}
+
+	var rows []*playdeveloperreporting.GooglePlayDeveloperReportingV1beta1MetricsRow
+	pageToken := ""
+	for {
+		resp, err := service.API.Vitals.Crashrate.Query(name, &playdeveloperreporting.GooglePlayDeveloperReportingV1beta1QueryCrashRateMetricSetRequest{
+			Dimensions:   buildCrashDimensions(opts.dimension),
+			Metrics:      append([]string(nil), crashRateMetrics...),
+			PageSize:     defaultCrashQueryPageSize,
+			PageToken:    pageToken,
+			TimelineSpec: timelineSpec,
+		}).Context(ctx).Do()
+		if err != nil {
+			return nil, shared.WrapGoogleAPIError("query crash rate metrics", err)
+		}
+		rows = append(rows, resp.Rows...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return rows, nil
+}
+
+func queryANRRate(ctx context.Context, service *reportingclient.Service, pkg string, opts crashQueryOptions) (interface{}, error) {
+	timelineSpec, err := buildCrashTimelineSpec(opts.from, opts.to)
+	if err != nil {
+		return nil, err
+	}
+
+	name := fmt.Sprintf("apps/%s/anrRateMetricSet", pkg)
+	if !opts.paginate {
+		resp, err := service.API.Vitals.Anrrate.Query(name, &playdeveloperreporting.GooglePlayDeveloperReportingV1beta1QueryAnrRateMetricSetRequest{
+			Dimensions:   buildCrashDimensions(opts.dimension),
+			Metrics:      append([]string(nil), anrRateMetrics...),
+			PageSize:     defaultCrashQueryPageSize,
+			TimelineSpec: timelineSpec,
+		}).Context(ctx).Do()
+		if err != nil {
+			return nil, shared.WrapGoogleAPIError("query ANR rate metrics", err)
+		}
+		return resp, nil
+	}
+
+	var rows []*playdeveloperreporting.GooglePlayDeveloperReportingV1beta1MetricsRow
+	pageToken := ""
+	for {
+		resp, err := service.API.Vitals.Anrrate.Query(name, &playdeveloperreporting.GooglePlayDeveloperReportingV1beta1QueryAnrRateMetricSetRequest{
+			Dimensions:   buildCrashDimensions(opts.dimension),
+			Metrics:      append([]string(nil), anrRateMetrics...),
+			PageSize:     defaultCrashQueryPageSize,
+			PageToken:    pageToken,
+			TimelineSpec: timelineSpec,
+		}).Context(ctx).Do()
+		if err != nil {
+			return nil, shared.WrapGoogleAPIError("query ANR rate metrics", err)
+		}
+		rows = append(rows, resp.Rows...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		pageToken = resp.NextPageToken
+	}
+	return rows, nil
+}
+
+func buildCrashTimelineSpec(from, to string) (*playdeveloperreporting.GooglePlayDeveloperReportingV1beta1TimelineSpec, error) {
+	startTime, startDate, err := parseCrashDateFlag("--from", from)
+	if err != nil {
+		return nil, err
+	}
+	endTime, endDate, err := parseCrashDateFlag("--to", to)
+	if err != nil {
+		return nil, err
+	}
+	if !startDate.IsZero() && !endDate.IsZero() && startDate.After(endDate) {
+		return nil, fmt.Errorf("--from must be on or before --to")
+	}
+	if startTime == nil && endTime == nil {
+		return nil, nil
+	}
+	if endTime != nil {
+		endExclusive := endDate.AddDate(0, 0, 1)
+		endTime = &playdeveloperreporting.GoogleTypeDateTime{
+			Year:  int64(endExclusive.Year()),
+			Month: int64(endExclusive.Month()),
+			Day:   int64(endExclusive.Day()),
+		}
+	}
+	return &playdeveloperreporting.GooglePlayDeveloperReportingV1beta1TimelineSpec{
+		AggregationPeriod: "DAILY",
+		StartTime:         startTime,
+		EndTime:           endTime,
+	}, nil
+}
+
+func parseCrashDateFlag(flagName, value string) (*playdeveloperreporting.GoogleTypeDateTime, time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return nil, time.Time{}, nil
+	}
+	parsed, err := time.Parse("2006-01-02", trimmed)
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("invalid %s date %q: expected YYYY-MM-DD", flagName, value)
+	}
+	return &playdeveloperreporting.GoogleTypeDateTime{
+		Year:  int64(parsed.Year()),
+		Month: int64(parsed.Month()),
+		Day:   int64(parsed.Day()),
+	}, parsed, nil
+}
+
+func buildCrashDimensions(dimension string) []string {
+	trimmed := strings.TrimSpace(dimension)
+	if trimmed == "" {
+		return nil
+	}
+	return []string{trimmed}
 }
 
 // validateISO8601Date checks that a date string is in YYYY-MM-DD format.
 func validateISO8601Date(date string) error {
 	date = strings.TrimSpace(date)
-	if len(date) != 10 {
+	if _, err := time.Parse("2006-01-02", date); err != nil {
 		return fmt.Errorf("invalid date format: %q (expected YYYY-MM-DD)", date)
-	}
-	if date[4] != '-' || date[7] != '-' {
-		return fmt.Errorf("invalid date format: %q (expected YYYY-MM-DD)", date)
-	}
-	for i, ch := range date {
-		if i == 4 || i == 7 {
-			continue
-		}
-		if ch < '0' || ch > '9' {
-			return fmt.Errorf("invalid date format: %q (expected YYYY-MM-DD)", date)
-		}
 	}
 	return nil
 }

--- a/internal/cli/vitals/vitals_test.go
+++ b/internal/cli/vitals/vitals_test.go
@@ -1,11 +1,21 @@
 package vitals
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/reportingclient"
 )
 
 func TestVitalsCommandName(t *testing.T) {
@@ -90,26 +100,64 @@ func TestCrashesQueryInvalidType(t *testing.T) {
 }
 
 func TestCrashesQueryValidTypeCrash(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]interface{}
+	installMockVitalsReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"rows":[{"metrics":[{"metric":"crashRate","decimalValue":{"value":"0.02"}}]}]}`)
+	})
+
 	cmd := CrashesQueryCommand()
-	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--type", "crash"})
-	err := cmd.Exec(context.Background(), nil)
-	if err == nil {
-		t.Fatal("expected error (stub implementation)")
+	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--type", "crash", "--dimension", "versionCode"})
+	stdout, err := captureVitalsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "crashRateMetricSet") {
-		t.Errorf("expected error to mention crashRateMetricSet, got: %v", err)
+	if gotPath != "/v1beta1/apps/com.example.app/crashRateMetricSet:query" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if !requestListContains(gotBody["metrics"], "crashRate") {
+		t.Fatalf("expected crashRate metric in body: %#v", gotBody["metrics"])
+	}
+	if !requestListContains(gotBody["dimensions"], "versionCode") {
+		t.Fatalf("expected versionCode dimension in body: %#v", gotBody["dimensions"])
+	}
+	if !strings.Contains(stdout, "crashRate") {
+		t.Fatalf("expected response in output, got %s", stdout)
 	}
 }
 
 func TestCrashesQueryValidTypeANR(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]interface{}
+	installMockVitalsReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"rows":[{"metrics":[{"metric":"anrRate","decimalValue":{"value":"0.01"}}]}]}`)
+	})
+
 	cmd := CrashesQueryCommand()
 	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--type", "anr"})
-	err := cmd.Exec(context.Background(), nil)
-	if err == nil {
-		t.Fatal("expected error (stub implementation)")
+	_, err := captureVitalsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "anrRateMetricSet") {
-		t.Errorf("expected error to mention anrRateMetricSet, got: %v", err)
+	if gotPath != "/v1beta1/apps/com.example.app/anrRateMetricSet:query" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if !requestListContains(gotBody["metrics"], "anrRate") {
+		t.Fatalf("expected anrRate metric in body: %#v", gotBody["metrics"])
 	}
 }
 
@@ -138,15 +186,32 @@ func TestCrashesQueryInvalidToDate(t *testing.T) {
 }
 
 func TestCrashesQueryValidDates(t *testing.T) {
+	var gotBody map[string]interface{}
+	installMockVitalsReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"rows":[]}`)
+	})
+
 	cmd := CrashesQueryCommand()
 	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--from", "2025-01-01", "--to", "2025-01-31"})
-	err := cmd.Exec(context.Background(), nil)
-	if err == nil {
-		t.Fatal("expected error (stub implementation)")
+	_, err := captureVitalsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
 	}
-	// Should reach the stub error, not a date validation error
-	if strings.Contains(err.Error(), "--from") || strings.Contains(err.Error(), "--to") {
-		t.Errorf("expected stub error, not date validation error, got: %v", err)
+	timeline, ok := gotBody["timelineSpec"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected timelineSpec in request, got %#v", gotBody)
+	}
+	if got := timelineDate(timeline["startTime"]); got != "2025-1-1" {
+		t.Fatalf("startTime = %s, want 2025-1-1", got)
+	}
+	if got := timelineDate(timeline["endTime"]); got != "2025-2-1" {
+		t.Fatalf("endTime = %s, want exclusive 2025-2-1", got)
 	}
 }
 
@@ -161,15 +226,35 @@ func TestAnomaliesRequiresPackage(t *testing.T) {
 	}
 }
 
-func TestAnomaliesStubWithPackage(t *testing.T) {
+func TestAnomaliesCallsReportingAPI(t *testing.T) {
+	var gotPath, gotFilter, gotPageSize string
+	installMockVitalsReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotFilter = r.URL.Query().Get("filter")
+		gotPageSize = r.URL.Query().Get("pageSize")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"anomalies":[{"name":"apps/com.example.app/anomalies/1","metricSet":"apps/com.example.app/crashRateMetricSet"}]}`)
+	})
+
 	cmd := AnomaliesCommand()
-	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app"})
-	err := cmd.Exec(context.Background(), nil)
-	if err == nil {
-		t.Fatal("expected error (stub implementation)")
+	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--type", "crash", "--from", "2026-03-01", "--to", "2026-03-31", "--limit", "10"})
+	stdout, err := captureVitalsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
-	if !strings.Contains(err.Error(), "not yet connected") {
-		t.Errorf("expected stub error, got: %v", err)
+	if gotPath != "/v1beta1/apps/com.example.app/anomalies" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	if gotPageSize != "10" {
+		t.Fatalf("pageSize = %q, want 10", gotPageSize)
+	}
+	if !strings.Contains(gotFilter, `activeBetween("2026-03-01T00:00:00Z", "2026-04-01T00:00:00Z")`) {
+		t.Fatalf("unexpected filter: %s", gotFilter)
+	}
+	if !strings.Contains(stdout, "crashRateMetricSet") {
+		t.Fatalf("expected anomaly in output, got %s", stdout)
 	}
 }
 
@@ -217,6 +302,84 @@ func TestAnomaliesHelpOutput(t *testing.T) {
 	}
 	if cmd.LongHelp == "" {
 		t.Error("expected AnomaliesCommand to have LongHelp")
+	}
+}
+
+func installMockVitalsReportingService(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	original := newReportingService
+	newReportingService = func(ctx context.Context) (*reportingclient.Service, error) {
+		return reportingclient.NewServiceWithClient(ctx, server.Client(), server.URL+"/")
+	}
+	t.Cleanup(func() {
+		newReportingService = original
+	})
+}
+
+func captureVitalsStdout(fn func() error) (string, error) {
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = wOut
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, rOut)
+	}()
+
+	runErr := fn()
+
+	_ = wOut.Close()
+	os.Stdout = origStdout
+	wg.Wait()
+	_ = rOut.Close()
+
+	return buf.String(), runErr
+}
+
+func requestListContains(raw interface{}, want string) bool {
+	items, ok := raw.([]interface{})
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}
+
+func timelineDate(raw interface{}) string {
+	date, ok := raw.(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	return strings.TrimSuffix(strings.TrimSuffix(strings.Join([]string{
+		strings.TrimSuffix(strings.TrimSuffix(jsonNumber(date["year"]), ".0"), "."),
+		strings.TrimSuffix(strings.TrimSuffix(jsonNumber(date["month"]), ".0"), "."),
+		strings.TrimSuffix(strings.TrimSuffix(jsonNumber(date["day"]), ".0"), "."),
+	}, "-"), ".0"), ".")
+}
+
+func jsonNumber(raw interface{}) string {
+	switch v := raw.(type) {
+	case float64:
+		return fmt.Sprintf("%.0f", v)
+	case json.Number:
+		return v.String()
+	default:
+		return ""
 	}
 }
 

--- a/internal/playclient/service.go
+++ b/internal/playclient/service.go
@@ -52,6 +52,19 @@ func NewService(ctx context.Context) (*Service, error) {
 	return &Service{API: api, Cfg: cfg}, nil
 }
 
+// NewServiceWithClient creates an Android Publisher service using a provided
+// HTTP client. Tests use this to point the generated client at a mock server.
+func NewServiceWithClient(ctx context.Context, client *http.Client, basePath string) (*Service, error) {
+	api, err := androidpublisher.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	if basePath != "" {
+		api.BasePath = basePath
+	}
+	return &Service{API: api, Cfg: &config.Config{}}, nil
+}
+
 func newHTTPClient(ctx context.Context, cfg *config.Config) (*http.Client, error) {
 	creds, err := resolveCredentials(ctx, cfg)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Wires previously missing CLI coverage to real Play/Reporting API endpoints for apps, vitals, purchases, tracks, IAP, and expansion files.
- Adds focused tests around new API paths, request bodies, pagination, and command surfaces.
- Removes the dead grants-list stub and regenerates `GPLAY.md`.

## Why
Issue #225 identified Play API coverage gaps where commands were missing, stubbed, or not using the underlying API surface. This fills the highest-value gaps and removes the remaining user-visible placeholder code found during the follow-up stub audit.

## What Changed
- `gplay apps list` now uses Reporting API `apps.search` with pagination support.
- Vitals crash/ANR queries and anomaly listing now call the Reporting API.
- Purchases adds subscription acknowledge plus explicit `subscriptionsv2` get/cancel/defer/revoke commands.
- Tracks adds releases listing, IAP adds patch support, and expansion files add update support.
- Added `playclient.NewServiceWithClient` for API-backed command tests.

## Alternatives Considered
Kept unsupported grants listing out of the command surface instead of retaining a callable command that only returns “not implemented,” because the Android Publisher API v3 Grants service does not expose a list method.

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [x] Documentation update

Refs #225

## Implementation Checklist

### Command & Registration
- [x] Command implementation in `internal/cli/<package>/`
- [x] Registered in parent command group or `internal/cli/registry/registry.go`
- [x] `UsageFunc: shared.DefaultUsageFunc` set on command and subcommands
- [x] Required flags validated with stderr error messages (not just `flag.ErrHelp`)
- [x] `shared.ContextWithTimeout` (or `shared.ContextWithUploadTimeout`) used for HTTP calls

### Tests
- [ ] CLI black-box tests in `internal/cmdtest/` — flag validation, error messages, output formats
- [x] Package-level unit tests for non-trivial logic
- [x] Error paths tested explicitly (missing required flags, invalid inputs, conflicting flags)

### Docs & Help
- [x] `--help` output is accurate and follows existing conventions
- [x] Command docs regenerated: `make docs`

## Validation

```bash
make check-docs
make format-check
make lint
make test
make build
git diff --check
```

- [x] `make format` passes
- [x] `make lint` passes
- [x] `make test` passes (full suite)
- [x] `make build` succeeds
- [x] `--help` verified for new/changed commands through generated docs and command tests
- [x] Error paths verified (missing flags, bad input)
- [ ] Smoke tested against real API or with `--dry-run`

## Notes
No live Google Play API calls were run from this environment; new behavior is covered with mocked API services and request assertions.