### PR TITLE
feat(checks): integrate Google Checks API for compliance & AI safety (#200)

### DIFF
--- a/GPLAY.md
+++ b/GPLAY.md
@@ -12,6 +12,7 @@
 - [auth logout](#auth-logout)
 - [auth status](#auth-status)
 - [auth doctor](#auth-doctor)
+- [setup](#setup)
 - [apps](#apps)
 - [apps list](#apps-list)
 - [audit](#audit)
@@ -325,34 +326,36 @@ gplay auth init [flags]
 
 ## gplay auth setup
 
-Create a Google Cloud service account and link it to this CLI.
+Set up Google Play authentication end-to-end.
 
 ```
 gplay auth setup --auto [--project <id>] [flags]
 ```
 
-Automated setup for Google Play authentication.
+One-command setup for Google Play authentication.
 
-With --auto, runs these steps via gcloud:
-  1. Detect/confirm GCP project
-  2. Enable the androidpublisher API
-  3. Create a service account (--sa-name)
-  4. Download a JSON key (--key-out)
+With --auto, gplay drives the whole flow via gcloud:
+  1. Install the gcloud CLI if it is missing (Homebrew on macOS, curl on Linux)
+  2. Log you into Google Cloud (gcloud auth login) if needed
+  3. Enable the androidpublisher API
+  4. Create a service account (--sa-name) and download a JSON key
   5. Store the profile in ~/.gplay/config.json
-
-You still need to link the service account email in Play Console afterwards;
-the URL is printed at the end.
+  6. Open Play Console for the one manual step: granting the account access
 
 Example:
-  gplay auth setup --auto --project my-gcp-project
-  gplay auth setup --auto --dry-run        # preview commands
-  gplay auth setup                          # open a how-to instead (no gcloud)
+  gplay setup --auto                        # full automated setup
+  gplay setup --auto --project my-gcp-project
+  gplay setup --auto --dry-run              # preview commands
+  gplay setup --auto --no-browser           # CI/agent friendly (no browser)
+  gplay setup                                # print manual instructions
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--auto` | Automate GCP service-account creation using gcloud | `false` |
 | `--dry-run` | Print the gcloud commands without executing them | `false` |
 | `--key-out` | Path to write the service-account JSON (defaults to ~/.gplay/<sa>.json) | `` |
+| `--no-browser` | Do not open a browser (for login or the Play Console grant step) | `false` |
+| `--no-install` | Do not auto-install gcloud when it is missing | `false` |
 | `--output` | Output format: text (default), json | `text` |
 | `--pretty` | Pretty-print JSON output | `false` |
 | `--profile` | gplay auth profile to create | `default` |
@@ -447,6 +450,47 @@ gplay auth doctor [flags]
 | `--fix` | Attempt to auto-fix detected issues | `false` |
 | `--output` | Output format: text (default), json | `text` |
 | `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay setup
+
+Set up Google Play authentication end-to-end.
+
+```
+gplay setup --auto [flags]
+```
+
+One-command setup for Google Play authentication.
+
+With --auto, gplay drives the whole flow via gcloud:
+  1. Install the gcloud CLI if it is missing (Homebrew on macOS, curl on Linux)
+  2. Log you into Google Cloud (gcloud auth login) if needed
+  3. Enable the androidpublisher API
+  4. Create a service account (--sa-name) and download a JSON key
+  5. Store the profile in ~/.gplay/config.json
+  6. Open Play Console for the one manual step: granting the account access
+
+Example:
+  gplay setup --auto                        # full automated setup
+  gplay setup --auto --project my-gcp-project
+  gplay setup --auto --dry-run              # preview commands
+  gplay setup --auto --no-browser           # CI/agent friendly (no browser)
+  gplay setup                                # print manual instructions
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--auto` | Automate GCP service-account creation using gcloud | `false` |
+| `--dry-run` | Print the gcloud commands without executing them | `false` |
+| `--key-out` | Path to write the service-account JSON (defaults to ~/.gplay/<sa>.json) | `` |
+| `--no-browser` | Do not open a browser (for login or the Play Console grant step) | `false` |
+| `--no-install` | Do not auto-install gcloud when it is missing | `false` |
+| `--output` | Output format: text (default), json | `text` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--profile` | gplay auth profile to create | `default` |
+| `--project` | GCP project ID (defaults to gcloud default) | `` |
+| `--sa-name` | Service account name | `play-console-cli` |
+| `--set-default` | Set as default profile in config | `true` |
 
 ---
 

--- a/GPLAY.md
+++ b/GPLAY.md
@@ -38,6 +38,24 @@
 - [bundles list](#bundles-list)
 - [bundles analyze](#bundles-analyze)
 - [bundles compare](#bundles-compare)
+- [checks](#checks)
+- [checks apps](#checks-apps)
+- [checks apps list](#checks-apps-list)
+- [checks apps get](#checks-apps-get)
+- [checks reports](#checks-reports)
+- [checks reports list](#checks-reports-list)
+- [checks reports get](#checks-reports-get)
+- [checks operations](#checks-operations)
+- [checks operations get](#checks-operations-get)
+- [checks operations wait](#checks-operations-wait)
+- [checks operations cancel](#checks-operations-cancel)
+- [checks operations list](#checks-operations-list)
+- [checks operations delete](#checks-operations-delete)
+- [checks upload](#checks-upload)
+- [checks analyze](#checks-analyze)
+- [checks content](#checks-content)
+- [checks content classify](#checks-content-classify)
+- [checks classify](#checks-classify)
 - [apks](#apks)
 - [apks upload](#apks-upload)
 - [apks list](#apks-list)
@@ -930,6 +948,334 @@ When --threshold is set, exits non-zero if the uncompressed delta exceeds it.
 | `--output` | Output format: json (default), table, markdown | `json` |
 | `--pretty` | Pretty-print JSON output | `false` |
 | `--threshold` | Regression threshold in bytes (e.g. 500K, 2M, 1G) | `` |
+
+---
+
+## gplay checks
+
+Analyze app privacy, compliance, and AI safety with the Google Checks API.
+
+```
+gplay checks <subcommand> [flags]
+```
+
+Analyze app privacy, compliance, and AI safety with the Google Checks API.
+
+Checks commands use the https://www.googleapis.com/auth/checks OAuth scope and
+the https://checks.googleapis.com/v1alpha API surface. App bundle analysis uses
+the current media upload endpoint, /upload/v1alpha/{parent=accounts/*/apps/*}/reports:analyzeUpload.
+
+---
+
+## gplay checks apps
+
+List and inspect apps connected to Checks.
+
+```
+gplay checks apps <subcommand> [flags]
+```
+
+---
+
+## gplay checks apps list
+
+List apps under a Checks account.
+
+```
+gplay checks apps list --account <account-id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--page-size` | Results per page (1-50) | `10` |
+| `--paginate` | Fetch all pages | `false` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay checks apps get
+
+Get a Checks app.
+
+```
+gplay checks apps get --account <account-id> --app <app-id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay checks reports
+
+List and inspect Checks compliance reports.
+
+```
+gplay checks reports <subcommand> [flags]
+```
+
+---
+
+## gplay checks reports list
+
+List Checks reports for an app.
+
+```
+gplay checks reports list --account <account-id> --app <app-id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--checks-filter` | AIP-160 filter for checks within reports | `` |
+| `--filter` | AIP-160 filter for reports | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--page-size` | Results per page (1-50) | `10` |
+| `--paginate` | Fetch all pages | `false` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay checks reports get
+
+Get a Checks report.
+
+```
+gplay checks reports get --account <account-id> --app <app-id> --report <report-id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--checks-filter` | AIP-160 filter for checks within the report | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--report` | Checks report ID or resource name | `` |
+
+---
+
+## gplay checks operations
+
+Manage Checks app analysis operations.
+
+```
+gplay checks operations <subcommand> [flags]
+```
+
+---
+
+## gplay checks operations get
+
+Get a Checks operation.
+
+```
+gplay checks operations get --account <account-id> --app <app-id> --operation <operation-id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--operation` | Operation ID or resource name | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay checks operations wait
+
+Wait for a Checks operation.
+
+```
+gplay checks operations wait --account <account-id> --app <app-id> --operation <operation-id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--operation` | Operation ID or resource name | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--timeout` | Maximum time to wait | `10m0s` |
+
+---
+
+## gplay checks operations cancel
+
+Cancel a Checks operation.
+
+```
+gplay checks operations cancel --account <account-id> --app <app-id> --operation <operation-id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--operation` | Operation ID or resource name | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay checks operations list
+
+List Checks operations for an app.
+
+```
+gplay checks operations list --account <account-id> --app <app-id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--filter` | AIP-160 filter for operations | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--page-size` | Results per page (1-50) | `10` |
+| `--paginate` | Fetch all pages | `false` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay checks operations delete
+
+Delete a Checks operation.
+
+```
+gplay checks operations delete --account <account-id> --app <app-id> --operation <operation-id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--operation` | Operation ID or resource name | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay checks upload
+
+Upload an app binary for Checks compliance analysis.
+
+```
+gplay checks upload --account <account-id> --app <app-id> --binary <path> [flags]
+```
+
+Upload an APK, AAB, or IPA to the Checks media upload endpoint and start
+an asynchronous compliance analysis.
+
+Use --severity-threshold PRIORITY in CI before release commands to fail the
+pipeline when high-priority failed checks are present. The command polls
+operations.get when --wait is true and prints progress to stderr.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--binary` | Path to APK, AAB, or IPA file | `` |
+| `--binary-type` | App binary file type: ANDROID_APK, ANDROID_AAB, IOS_IPA | `ANDROID_APK` |
+| `--checks-filter` | AIP-160 filter for checks in the resulting report (e.g. state = FAILED) | `` |
+| `--code-ref` | Git commit hash or changelist number for the upload | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--severity-threshold` | Fail if a failed check meets severity: PRIORITY, POTENTIAL, OPPORTUNITY | `` |
+| `--wait` | Wait for analysis to complete and print the report | `true` |
+| `--wait-timeout` | Maximum time to wait for analysis | `10m0s` |
+
+---
+
+## gplay checks analyze
+
+Alias for `gplay checks upload`.
+
+```
+gplay checks analyze --account <account-id> --app <app-id> --binary <path> [flags]
+```
+
+Upload an APK, AAB, or IPA to the Checks media upload endpoint and start
+an asynchronous compliance analysis.
+
+Use --severity-threshold PRIORITY in CI before release commands to fail the
+pipeline when high-priority failed checks are present. The command polls
+operations.get when --wait is true and prints progress to stderr.
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--account` | Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account) | `` |
+| `--app` | Checks app ID or resource name | `` |
+| `--binary` | Path to APK, AAB, or IPA file | `` |
+| `--binary-type` | App binary file type: ANDROID_APK, ANDROID_AAB, IOS_IPA | `ANDROID_APK` |
+| `--checks-filter` | AIP-160 filter for checks in the resulting report (e.g. state = FAILED) | `` |
+| `--code-ref` | Git commit hash or changelist number for the upload | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--severity-threshold` | Fail if a failed check meets severity: PRIORITY, POTENTIAL, OPPORTUNITY | `` |
+| `--wait` | Wait for analysis to complete and print the report | `true` |
+| `--wait-timeout` | Maximum time to wait for analysis | `10m0s` |
+
+---
+
+## gplay checks content
+
+Classify app content with Checks AI safety policies.
+
+```
+gplay checks content <subcommand> [flags]
+```
+
+---
+
+## gplay checks content classify
+
+Classify text content against Checks AI safety policies.
+
+```
+gplay checks content classify --text <content> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--classifier-version` | Classifier version: STABLE or LATEST | `` |
+| `--context` | Prompt or context that generated the content | `` |
+| `--language` | ISO 639-1 language code | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--policies` | Comma-separated policies, or all | `all` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--severity-threshold` | Fail if any policy result is VIOLATIVE | `false` |
+| `--text` | Text content to classify, or @file | `` |
+
+---
+
+## gplay checks classify
+
+Classify text content against Checks AI safety policies.
+
+```
+gplay checks classify --text <content> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--classifier-version` | Classifier version: STABLE or LATEST | `` |
+| `--context` | Prompt or context that generated the content | `` |
+| `--language` | ISO 639-1 language code | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--policies` | Comma-separated policies, or all | `all` |
+| `--pretty` | Pretty-print JSON output | `false` |
+| `--severity-threshold` | Fail if any policy result is VIOLATIVE | `false` |
+| `--text` | Text content to classify, or @file | `` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -306,6 +306,30 @@ gplay rtdn decode --file payload.json      # typed subscription/one-time/voided 
 cat payload.json | gplay rtdn decode --file -
 ```
 
+### Compliance (Google Checks)
+
+```bash
+# Upload an AAB/APK to Google Checks for privacy & policy analysis (async)
+# Requires a Checks account: pass --account, or set GPLAY_CHECKS_ACCOUNT / checks_account.
+gplay checks apps list --account <account-id>
+gplay checks analyze --account <account-id> --app <app-id> --binary app.aab
+
+# CI/CD gate: analyze, wait for the report, exit non-zero on high-priority failures.
+# Chain before `gplay publish`/`gplay release` to block non-compliant builds.
+gplay checks analyze --account <account-id> --app <app-id> --binary app.aab \
+  --code-ref "$GIT_SHA" --severity-threshold PRIORITY --checks-filter "state = FAILED"
+
+# Browse compliance reports (verifies what the app *does* vs. what data-safety *declares*)
+gplay checks reports list --account <account-id> --app <app-id> --checks-filter "state = FAILED"
+gplay checks reports get --account <account-id> --app <app-id> --report <report-id>
+
+# Manage the async analysis operation directly
+gplay checks operations wait --account <account-id> --app <app-id> --operation <op-id>
+
+# AI safety content classification (moderate app/generated text against policies)
+gplay checks classify --text @content.txt --policies all --severity-threshold
+```
+
 ### Vitals & Quality
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Google Play Console CLI (gplay) optimized for your AI agentic development flows, claude code, codex
+# gplay — Google Play Console CLI for AI Agents
 
 <p align="center">
   <img src="https://img.shields.io/badge/Go-1.24+-00ADD8?style=for-the-badge&logo=go" alt="Go Version">
@@ -6,130 +6,20 @@
   <img src="https://img.shields.io/badge/Homebrew-compatible-blue?style=for-the-badge" alt="Homebrew">
 </p>
 
-A **fast**, **lightweight**, and **scriptable** CLI for Google Play Console. Automate your Android app workflows from your terminal,optimized for your AI agentic development flows, claude code, codex, cursor
+**gplay** is a fast, single-binary CLI for **Google Play Console**, built for **AI coding agents** — Claude Code, Codex, Cursor, Gemini CLI — and for humans who script. Release Android apps, create **subscriptions, in-app products, and one-time purchases**, verify purchases server-side, monitor crashes and reviews — all from the terminal, no Play Console clicking.
 
-## Why gplay?
-
-Stop clicking through Play Console. Ship your Android apps with a single command.
-
-### Where gplay wins
-
-Compared against [Fastlane `supply`](https://docs.fastlane.tools/actions/supply/) and [gradle-play-publisher (GPP)](https://github.com/Triple-T/gradle-play-publisher). Areas where all three wrap the same Play Publisher API equivalently (APK/AAB upload, tracks, staged rollout, release notes, store listing text fields, app details, screenshots, mapping files, internal app sharing) are omitted.
-
-**API coverage gplay has that the others lack**
-
-| Capability | gplay | Fastlane | gradle-play-publisher |
-|---|---|---|---|
-| **Monetization depth** | IAPs, subscriptions, base plans, offers, pricing | No support | Basic IAPs + subscriptions (no base plans or offers) |
-| **Purchase verification** | Products + subscriptions + acknowledge + orders refund | No support | No support |
-| **Vitals (crashes, ANRs, perf)** | Clusters, reports, startup/rendering/battery metrics | No support | No support |
-| **Review management** | Read + reply | No support | No support |
-| **Financial & stats reports** | GCS download (earnings, sales, installs, ratings) | No support | No support |
-| **User & permission management** | Developer users + per-app grants CRUD | No support | No support |
-| **Tester management** | List and update closed-track tester emails | No support | No support |
-| **Data safety** | Declarations management | No support | No support |
-| **Webhook notifications** | Slack, Discord, generic (`gplay notify`) | No support | No support |
-
-**Runtime and ergonomics**
-
-| Capability | gplay | Fastlane | gradle-play-publisher |
-|---|---|---|---|
-| **Runtime** | Compiled Go binary, instant startup, no deps | Ruby + gems + bundler, slow to load | JVM + Gradle daemon, must run inside an AGP project |
-| **Agent-friendly output** | JSON by default (saves tokens) | Human-oriented, colorized | Gradle task logs |
-
-**Publish & Release**
-- One-command releases: upload, configure track, and go live in a single step
-- Staged rollouts with pause, resume, and percentage control
-- Promote builds between tracks (internal → beta → production)
-- Generate release notes automatically from your git history
-- Upload bundles (AAB) or APKs, manage edits, and commit changes
-
-**Store Presence**
-- Update store listings, screenshots, and app details across all locales
-- Manage images: phone screenshots, tablet screenshots, feature graphics, and more
-- Sync metadata with your local directory — export, import, and diff
-- Migrate from Fastlane metadata format with a single command
-- Validate listings, screenshots, and bundles before you submit
-- Manage data safety declarations
-
-**Monetization**
-- In-app products: create, update, and batch-manage managed products
-- One-time products for single purchases
-- Subscriptions with base plans and promotional offers
-- Price conversion across regions
-- External transaction reporting (EU compliance)
-
-**Purchases & Orders**
-- Verify in-app purchases and subscription tokens server-side
-- Look up and refund orders
-- Acknowledge purchases programmatically
-
-**Monitor Your App**
-- Crash clusters and detailed crash reports
-- ANR and error issue tracking
-- Performance metrics: startup time, rendering jank, and battery drain
-- Read and reply to user reviews without opening a browser
-
-**Testing & Distribution**
-- Manage testers for closed testing tracks
-- Internal app sharing for quick testing without review
-- Check country availability for your tracks
-- Download device-specific APKs generated from your app bundle
-- Upload deobfuscation files (ProGuard/R8 mapping) for readable crash reports
-- System APK creation and expansion file (OBB) management
-- App recovery actions
-
-**Team & Permissions**
-- Manage developer account users: invite, update roles, or remove
-- Fine-grained per-app permission grants
-- Multiple profiles for different accounts or apps
-
-**Reports & Notifications**
-- Download financial reports (earnings, sales, payouts) from Google Cloud Storage
-- Download statistics reports (installs, ratings, crashes, store performance)
-- Send release notifications to Slack, Discord, or any webhook
-
-**Built for Automation**
-- Works in any CI/CD pipeline — GitHub Actions, GitLab CI, Jenkins, and more
-- JSON output by default — pipe to `jq`, scripts, or dashboards
-- Table and Markdown output for human-friendly views
-- Dry-run mode to preview changes before they go live
-- Shell completions for Bash, Zsh, Fish, and PowerShell
-- Self-updating: checks for new versions and upgrades in place
-- Instant startup: single binary, no dependencies, no runtime
-- Project initialization and auth diagnostics (`init`, `auth doctor`)
-- Auto-generated command documentation (`docs generate`)
-- Device tier configuration management
+It **completely replaces opening the web browser console** for day-to-day work. Most deployment tools only handle standard AAB uploads — gplay covers the **full Google Play Developer API v3**: complete console management, staged rollouts, store listings, screenshots, and localization. And it's **lightweight with zero runtime to install** — no Node.js, no Python, no JVM, just one static binary.
 
 ## Table of Contents
 
-- [Why gplay?](#why-gplay)
 - [Quick Start](#quick-start)
-- [Commands](#commands)
-  - [Scripting Tips](#scripting-tips)
-  - [Publishing](#publishing)
-  - [High-Level Workflow](#high-level-workflow)
-  - [Store Listing](#store-listing)
-  - [Monetization](#monetization)
-  - [Purchase Management](#purchase-management)
-  - [Reviews](#reviews)
-  - [Testing](#testing)
-  - [App Management](#app-management)
-  - [Diagnostics & Observability](#diagnostics--observability)
-  - [Vitals & Quality](#vitals--quality)
-  - [User & Permission Management](#user--permission-management)
-  - [Reports](#reports)
-  - [Notifications](#notifications)
-  - [FastLane Integration](#fastlane-integration)
-- [Output Formats](#output-formats)
-- [Design Philosophy](#design-philosophy)
-- [Installation](#installation)
-- [Authentication](#authentication)
-- [Configuration](#configuration)
-- [CI/CD Integration](#cicd-integration)
-- [Security](#security)
+  - [Install](#install)
+  - [Authentication](#authentication)
+- [Highlights](#highlights)
+- [Use it with your AI agent](#use-it-with-your-ai-agent)
+- [How gplay compares](#how-gplay-compares)
+- [Documentation](#documentation)
 - [Contributing](#contributing)
-- [Agent Skills](#agent-skills)
 - [License](#license)
 
 ## Quick Start
@@ -137,40 +27,48 @@ Compared against [Fastlane `supply`](https://docs.fastlane.tools/actions/supply/
 ### Install
 
 ```bash
-# Via Homebrew (recommended)
+# Homebrew (recommended)
 brew tap tamtom/tap
 brew install tamtom/tap/gplay
 
 # Install script (macOS/Linux)
 curl -fsSL https://raw.githubusercontent.com/tamtom/play-console-cli/main/install.sh | bash
 
-# Build from source
-git clone https://github.com/tamtom/play-console-cli.git
-cd play-console-cli
-make build
-./gplay --help
+# From source
+git clone https://github.com/tamtom/play-console-cli.git && cd play-console-cli && make build
 ```
 
-### Updates
+**Update:** `gplay update` self-updates in place. It also checks for new versions on startup (disable with `GPLAY_NO_UPDATE=1`).
 
-`gplay` checks for updates on startup and shows upgrade hints. Disable with `--no-update` or `GPLAY_NO_UPDATE=1`.
+### Authentication
 
-### Authenticate (Service Account)
+`gplay` authenticates to Google Play with a **service account**.
 
-**Fastest path — automated setup (recommended):**
+#### One-command setup (recommended)
 
 ```bash
-# One command: creates a GCP service account, enables the API, downloads the key,
-# and wires the profile into ~/.gplay/config.json.
-gplay auth setup --auto --project <your-gcp-project-id>
-
-# Preview the gcloud commands without running them
-gplay auth setup --auto --project <your-gcp-project-id> --dry-run
+gplay setup --auto
 ```
 
-Requirements: `gcloud` installed and authenticated (`gcloud auth login`). After the wizard finishes, it prints a Play Console link to grant the service account access — that's the only manual step left.
+That's it. This will:
+- Install `gcloud` if needed (via Homebrew on macOS, or curl on Linux)
+- Log you into Google Cloud
+- Create a service account and download credentials
+- Open Play Console for the one manual step (granting access)
+- Configure everything automatically
 
-**Manual path — full control:**
+Pass `--project <id>` if `gcloud` has no default project, `--dry-run` to preview the commands, or `--no-browser` for CI/agent runs. Then verify with `gplay auth doctor`.
+
+Already have a service account key?
+
+```bash
+gplay auth login --service-account /path/to/service-account.json
+```
+
+#### Manual setup
+
+<details>
+<summary>Set up the service account by hand (full control)</summary>
 
 **Step 1: Create a Google Cloud Project**
 1. Go to [Google Cloud Console](https://console.cloud.google.com)
@@ -206,587 +104,84 @@ gplay auth login --service-account /path/to/service-account.json
 gplay auth doctor
 ```
 
-## Commands
+</details>
 
-### Scripting Tips
+Profiles for multiple accounts and troubleshooting: **[docs/authentication.md](docs/authentication.md)**
 
-- JSON output is default for easy parsing; add `--pretty` when debugging
-- Use `--paginate` to automatically fetch all pages
-- Sort with `--sort` (prefix `-` for descending): `--sort -uploadedDate`
-- Use `--limit` + `--next` for manual pagination control
-
-### Publishing
+Once authenticated, you're ready to go:
 
 ```bash
-# Edit lifecycle
-gplay edits create --package com.example.app
-gplay edits list --package com.example.app
-gplay edits validate --package com.example.app --edit <id>
-gplay edits commit --package com.example.app --edit <id>
+# Ship a release in one command
+gplay release --package com.example.app --track production --bundle app.aab --rollout 10
 
-# Upload artifacts
-gplay bundles upload --package com.example.app --edit <id> --file app.aab
-gplay apks upload --package com.example.app --edit <id> --file app.apk
-
-# Manage tracks
-gplay tracks list --package com.example.app --edit <id>
-gplay tracks get --package com.example.app --edit <id> --track production
-gplay tracks update --package com.example.app --edit <id> --track internal --json @release.json
-```
-
-### High-Level Workflow
-
-```bash
-# One-command release (creates edit, uploads, updates track, commits)
-gplay release --package com.example.app --track internal --bundle app.aab
-
-# With release notes and staged rollout
-gplay release --package com.example.app --track production --bundle app.aab \
-  --release-notes @notes.json --rollout 10
-
-# Promote between tracks
-gplay promote --package com.example.app --from internal --to beta
-
-# Manage staged rollout
-gplay rollout update --package com.example.app --track production --rollout 50
-gplay rollout halt --package com.example.app --track production
-gplay rollout resume --package com.example.app --track production
-gplay rollout complete --package com.example.app --track production
-
-# Release with metadata and screenshots
-gplay release --package com.example.app --track production --bundle app.aab \
-  --listings-dir ./metadata --screenshots-dir ./screenshots
-
-# Dry-run any command (intercepts write operations)
-gplay --dry-run release --package com.example.app --track internal --bundle app.aab
-```
-
-### App Management
-
-```bash
-# List apps accessible by your service account
-gplay apps list
-
-# Initialize project configuration
-gplay init
-gplay init --package com.example.app --service-account /path/to/sa.json
-```
-
-### Diagnostics & Observability
-
-```bash
-# Full environment health check (16 checks: gcloud, config, SA, DNS, disk, clock, ...)
-gplay doctor
-gplay doctor --output json --pretty
-
-# Offline compliance scan on an AAB or APK (no API calls)
-# Checks: manifest, bundle size, native ABIs, dex, debuggable, testOnly,
-# cleartext traffic, dangerous permissions, secret scan, misplaced files.
-gplay preflight --file app.aab
-gplay preflight --file app.aab --max-size 100M --fail-on warning   # CI gate
-
-# Bundle size analysis (offline)
-gplay bundles analyze --file app.aab --top-files 20
-gplay bundles compare --base old.aab --candidate new.aab --threshold 2M
-
-# Local audit log of every invocation (auto-written to ~/.gplay/audit.log)
-gplay audit list --limit 50
-gplay audit search --command vitals --status error
-gplay audit clear --confirm
-# Disable with GPLAY_AUDIT=0; override path with GPLAY_AUDIT_LOG.
-
-# API quota usage (derived from audit log)
-gplay quota status                 # daily + per-minute windows
-gplay quota status --top 10
-
-# Real-Time Developer Notifications (RTDN)
-gplay rtdn setup --project <gcp-project> --topic play-rtdn
-gplay rtdn status --project <gcp-project>
-gplay rtdn decode --file payload.json      # typed subscription/one-time/voided decoder
-cat payload.json | gplay rtdn decode --file -
-```
-
-### Compliance (Google Checks)
-
-```bash
-# Upload an AAB/APK to Google Checks for privacy & policy analysis (async)
-# Requires a Checks account: pass --account, or set GPLAY_CHECKS_ACCOUNT / checks_account.
-gplay checks apps list --account <account-id>
-gplay checks analyze --account <account-id> --app <app-id> --binary app.aab
-
-# CI/CD gate: analyze, wait for the report, exit non-zero on high-priority failures.
-# Chain before `gplay publish`/`gplay release` to block non-compliant builds.
-gplay checks analyze --account <account-id> --app <app-id> --binary app.aab \
-  --code-ref "$GIT_SHA" --severity-threshold PRIORITY --checks-filter "state = FAILED"
-
-# Browse compliance reports (verifies what the app *does* vs. what data-safety *declares*)
-gplay checks reports list --account <account-id> --app <app-id> --checks-filter "state = FAILED"
-gplay checks reports get --account <account-id> --app <app-id> --report <report-id>
-
-# Manage the async analysis operation directly
-gplay checks operations wait --account <account-id> --app <app-id> --operation <op-id>
-
-# AI safety content classification (moderate app/generated text against policies)
-gplay checks classify --text @content.txt --policies all --severity-threshold
-```
-
-### Vitals & Quality
-
-```bash
-# Crash reports
-gplay vitals crashes clusters --package com.example.app
-gplay vitals crashes reports --package com.example.app
-
-# Performance metrics
-gplay vitals performance startup --package com.example.app
-gplay vitals performance rendering --package com.example.app
-gplay vitals performance battery --package com.example.app
-
-# Error tracking
-gplay vitals errors issues --package com.example.app
-gplay vitals errors reports --package com.example.app
-```
-
-### User & Permission Management
-
-```bash
-# Manage developer account users
-gplay users list --developer <id>
-gplay users create --developer <id> --email user@example.com --json @permissions.json
-gplay users delete --developer <id> --email user@example.com --confirm
-
-# Manage per-app grants
-gplay grants create --developer <id> --email user@example.com --package com.example.app --json @grant.json
-gplay grants update --developer <id> --email user@example.com --package com.example.app --json @grant.json
-gplay grants delete --developer <id> --email user@example.com --package com.example.app --confirm
-```
-
-### Reports
-
-Reports are stored as CSV/ZIP files in Google Cloud Storage buckets (`pubsite_prod_rev_<developer_id>`). The service account must have access to the GCS bucket (granted automatically when added to Play Console).
-
-> **Important:** The `--developer` ID for reports is **not** the developer ID in your Play Console URL. To find the correct ID, go to **Play Console > Download reports > Copy Cloud Storage URI**. The URI looks like `gs://pubsite_prod_rev_XXXX/` — the number after `pubsite_prod_rev_` is your developer ID.
-
-```bash
-# Financial reports (earnings, sales, payouts)
-gplay reports financial list --developer <id>
-gplay reports financial list --developer <id> --type earnings --from 2026-01 --to 2026-06
-gplay reports financial download --developer <id> --from 2026-01 --type earnings --dir ./reports
-
-# Statistics reports (installs, ratings, crashes, store_performance, subscriptions)
-gplay reports stats list --developer <id>
-gplay reports stats list --developer <id> --package com.example.app --type installs
-gplay reports stats download --developer <id> --package com.example.app --from 2026-01 --type installs --dir ./reports
-```
-
-### Notifications
-
-```bash
-# Send webhook notifications (Slack, Discord, generic)
-gplay notify send --webhook-url https://hooks.slack.com/... --message "Deploy complete" --format slack
-gplay notify send --webhook-url https://discord.com/... --message "New release" --format discord
-```
-
-### Store Listing
-
-```bash
-# Listings
-gplay listings list --package com.example.app --edit <id>
-gplay listings get --package com.example.app --edit <id> --locale en-US
-gplay listings update --package com.example.app --edit <id> --locale en-US --json @listing.json
-
-# Images
-gplay images list --package com.example.app --edit <id> --locale en-US --type phoneScreenshots
-gplay images upload --package com.example.app --edit <id> --locale en-US --type phoneScreenshots --file screenshot.png
-
-# App details
-gplay details get --package com.example.app --edit <id>
-gplay details update --package com.example.app --edit <id> --contact-email dev@example.com
-```
-
-### Monetization
-
-```bash
-# In-app products
-gplay iap list --package com.example.app
-gplay iap create --package com.example.app --sku premium_upgrade --json @product.json
-gplay iap update --package com.example.app --sku premium_upgrade --json @product.json
-gplay iap batch-update --package com.example.app --json @products.json
-
-# Subscriptions
-gplay subscriptions list --package com.example.app
+# Create a subscription with base plans and offers
 gplay subscriptions create --package com.example.app --json @subscription.json
 
-# Base plans
-gplay baseplans activate --package com.example.app --product-id sub_premium --base-plan monthly
-gplay baseplans deactivate --package com.example.app --product-id sub_premium --base-plan monthly
-
-# Offers
-gplay offers list --package com.example.app --product-id sub_premium --base-plan monthly
-gplay offers create --package com.example.app --product-id sub_premium --base-plan monthly --json @offer.json
-
-# Price conversion
-gplay pricing convert --package com.example.app --json @price.json
+# Everything outputs minified JSON — built for agents and pipes
+gplay reviews list --package com.example.app | jq '.reviews[0]'
 ```
 
-### Purchase Management
-
-```bash
-# Verify purchases
-gplay purchases products get --package com.example.app --product-id premium --token <token>
-gplay purchases products acknowledge --package com.example.app --product-id premium --token <token>
-gplay purchases subscriptions get --package com.example.app --token <token>
-
-# Orders
-gplay orders get --package com.example.app --order-id <id>
-gplay orders refund --package com.example.app --order-id <id> --revoke
-
-# External transactions (EU compliance)
-gplay external-transactions create --package com.example.app --json @transaction.json
-```
-
-### Reviews
-
-```bash
-# List and filter reviews
-gplay reviews list --package com.example.app
-gplay reviews list --package com.example.app --paginate
-
-# Reply to reviews
-gplay reviews get --package com.example.app --review-id <id>
-gplay reviews reply --package com.example.app --review-id <id> --text "Thank you!"
-```
-
-### Testing
-
-```bash
-# Manage testers
-gplay testers list --package com.example.app --edit <id> --track internal
-gplay testers update --package com.example.app --edit <id> --track internal --emails user@example.com
-
-# Internal app sharing (quick sharing without review)
-gplay internal-sharing upload-bundle --package com.example.app --file app.aab
-gplay internal-sharing upload-apk --package com.example.app --file app.apk
-```
-
-### FastLane Integration
-
-```bash
-# Export metadata to FastLane format
-gplay sync export-listings --package com.example.app --dir ./fastlane/metadata/android
-
-# Import metadata from FastLane format
-gplay sync import-listings --package com.example.app --dir ./fastlane/metadata/android
-
-# Compare local metadata with Play Store
-gplay sync diff-listings --package com.example.app --dir ./fastlane/metadata/android
-
-# Validate before upload
-gplay validate listing --dir ./fastlane/metadata/android --locale en-US
-gplay validate screenshots --dir ./fastlane/metadata/android/en-US/images
-gplay validate bundle --file app.aab
-```
-
-### Shell Completion
-
-```bash
-# Bash
-gplay completion bash > /etc/bash_completion.d/gplay
-
-# Zsh
-gplay completion zsh > "${fpath[1]}/_gplay"
-
-# Fish
-gplay completion fish > ~/.config/fish/completions/gplay.fish
-
-# PowerShell
-gplay completion powershell >> $PROFILE
-```
-
-## Output Formats
-
-| Format | Flag | Use Case |
-|--------|------|----------|
-| JSON (minified) | default | Scripting, automation |
-| JSON (pretty) | `--pretty` | Debugging |
-| Table | `--output table` | Terminal display |
-| Markdown | `--output markdown` | Documentation |
-
-```bash
-# Parse with jq
-gplay tracks list --package com.example.app | jq '.tracks[].track'
-
-# Human-readable
-gplay reviews list --package com.example.app --output table
-```
-
-## Design Philosophy
-
-### Explicit Over Cryptic
-
-```bash
-# Good - self-documenting
-gplay reviews list --package com.example.app --output table
-
-# Avoid - cryptic flags (not supported)
-# gplay reviews -p com.example.app -o table
-```
-
-### JSON-First Output
-
-All commands output minified JSON by default for easy parsing:
-
-```bash
-gplay tracks list --package com.example.app | jq '.tracks[] | select(.track == "production")'
-```
-
-### No Interactive Prompts
-
-Everything is flag-based for automation:
-
-```bash
-# Non-interactive (CI/CD safe)
-gplay edits delete --package com.example.app --edit <id> --confirm
-```
-
-## Installation
-
-### Homebrew (macOS)
-
-```bash
-brew tap tamtom/tap
-brew install tamtom/tap/gplay
-```
-
-### Install Script (macOS/Linux)
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/tamtom/play-console-cli/main/install.sh | bash
-```
-
-Specify version:
-```bash
-GPLAY_VERSION=1.0.0 curl -fsSL https://raw.githubusercontent.com/tamtom/play-console-cli/main/install.sh | bash
-```
-
-### From Source
-
-```bash
-git clone https://github.com/tamtom/play-console-cli.git
-cd play-console-cli
-make build
-make install  # Installs to /usr/local/bin
-```
-
-## Authentication
-
-### Service Account Setup (Required)
-
-Service accounts are required for the Google Play Android Developer API.
-
-#### 1. Create Google Cloud Project & Enable API
-
-```
-Google Cloud Console → Create Project → APIs & Services → Library
-→ Search "Google Play Android Developer API" → Enable
-```
-
-#### 2. Create Service Account & Download Key
-
-```
-IAM & Admin → Service Accounts → Create Service Account
-→ Name it (e.g., "gplay-cli") → Create → Done
-→ Click the account → Keys → Add Key → Create new key → JSON
-→ Save the JSON file securely (never commit to git!)
-```
-
-#### 3. Grant Access in Play Console
-
-```
-Play Console → Users and permissions → Invite new users
-→ Paste service account email (from JSON: "client_email" field)
-→ Set permissions (Admin, or per-app access)
-→ Invite user
-```
-
-#### 4. Configure gplay
-
-```bash
-# Option A: Login command (saves to profile)
-gplay auth login --service-account /path/to/service-account.json
-
-# Option B: Environment variable
-export GPLAY_SERVICE_ACCOUNT=/path/to/service-account.json
-
-# Verify setup
-gplay auth doctor
-```
-
-### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `GPLAY_SERVICE_ACCOUNT` | Path to service account JSON |
-| `GPLAY_PACKAGE` | Default package name |
-| `GPLAY_PROFILE` | Active profile name |
-| `GPLAY_TIMEOUT` | Request timeout (e.g., `90s`, `2m`) |
-| `GPLAY_UPLOAD_TIMEOUT` | Upload timeout (e.g., `5m`, `10m`) |
-| `GPLAY_NO_UPDATE` | Disable update checks (set to `1`) |
-| `GPLAY_DEBUG` | Enable debug logging (`1` or `api`) |
-| `GPLAY_MAX_RETRIES` | Max retries for failed requests |
-| `GPLAY_RETRY_DELAY` | Base delay between retries |
-| `GPLAY_DEFAULT_OUTPUT` | Default output format (`json`, `table`, `markdown`) |
-
-## Configuration
-
-### Config File
-
-Global: `~/.gplay/config.yaml`
-Local (takes precedence): `./.gplay/config.yaml`
-
-```yaml
-default_package: com.example.app
-timeout: 120s
-upload_timeout: 5m
-max_retries: 3
-debug: false
-```
-
-### Profiles
-
-```bash
-# Add profiles for different accounts/apps
-gplay auth login --profile work --service-account /path/to/work-sa.json
-gplay auth login --profile personal --service-account /path/to/personal-sa.json
-
-# Switch default profile
-gplay auth switch --profile work
-
-# Check current status
-gplay auth status
-
-# Use specific profile for a command
-GPLAY_PROFILE=personal gplay tracks list --package com.example.app
-```
-
-## CI/CD Integration
-
-### GitHub Actions
-
-```yaml
-name: Deploy to Play Store
-
-on:
-  push:
-    tags:
-      - 'v*'
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up gplay
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/tamtom/play-console-cli/main/install.sh | bash
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Build app
-        run: ./gradlew bundleRelease
-
-      - name: Deploy to internal track
-        env:
-          GPLAY_SERVICE_ACCOUNT: ${{ secrets.PLAY_SERVICE_ACCOUNT }}
-        run: |
-          gplay release \
-            --package com.example.app \
-            --track internal \
-            --bundle app/build/outputs/bundle/release/app-release.aab
-```
-
-### GitLab CI
-
-```yaml
-deploy:
-  stage: deploy
-  image: ubuntu:latest
-  before_script:
-    - curl -fsSL https://raw.githubusercontent.com/tamtom/play-console-cli/main/install.sh | bash
-    - export PATH="$HOME/.local/bin:$PATH"
-  script:
-    - gplay release --package $PACKAGE_NAME --track internal --bundle app.aab
-  variables:
-    GPLAY_SERVICE_ACCOUNT: $PLAY_SERVICE_ACCOUNT
-```
-
-## Security
-
-- **Never commit service account keys** to version control
-- **Use environment variables** or secrets management in CI/CD
-- **Limit service account permissions** to only what's needed
-- **Rotate keys regularly**
-- **Use separate service accounts** for different environments
-
-Credentials are stored in config with file path reference only (not the key content).
-
-## How to test in <10 minutes
-
-```bash
-make tools   # installs gofumpt + golangci-lint
-make format
-make lint
-make test
-make build
-./gplay --help
-```
-
-## Contributing
-
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details.
-
-## Documentation
-
-- [Agents.md](Agents.md) - Guidelines for AI agents (CLI usage, structure, patterns)
-- [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines
-
-## Agent Skills
-
-Use `gplay` with AI coding agents for assisted Android publishing workflows. Compatible with any agent that supports the [Agent Skills](https://github.com/anthropics/agent-skills) format.
-
-### Install Skills
+## Highlights
+
+- **Full Google Play Developer API v3 coverage** — not just AAB uploads like most deployment tools. Complete console management from the terminal, so gplay replaces opening the web browser console.
+- **Complete releases & rollouts** — upload, track assignment, staged rollout with pause/resume/percentage control, promote between tracks, release notes from git history.
+- **Store listings, screenshots & localization** — manage listing text, images, and metadata across every locale; sync with a local directory or Fastlane.
+- **Full monetization stack** — subscriptions, base plans, promotional offers, in-app products, one-time purchases, regional price conversion. Pairs with [RevenueCat](docs/monetization.md#using-gplay-with-revenuecat): create products in Play with `gplay`, import them into RevenueCat.
+- **Purchase verification** — verify tokens, acknowledge purchases, refund orders, decode RTDN webhooks.
+- **App health** — crash clusters, ANRs, performance vitals, review replies, financial & statistics reports.
+- **AI-agent native** — minified JSON output, explicit flags, `--help` everywhere, `--dry-run` for every write, no interactive prompts, [Agent Skills](docs/ai-agents.md) included.
+- **Lightweight, zero runtime to install** — a single compiled Go binary with instant startup. No Node.js, no Python, no JVM, no Gradle project required.
+
+## Use it with your AI agent
+
+Every command is discoverable via `--help`, outputs token-efficient JSON, and never blocks on a prompt — so agents can drive the whole Play workflow. Install the ready-made skills:
 
 ```bash
 npx skills add tamtom/gplay-cli-skills
 ```
 
-### Available Skills
+Then ask your agent things like *"release this AAB to internal"*, *"create monthly + yearly subscriptions with a 7-day trial and convert prices for all regions"*, or *"summarize this week's crash clusters"*. Full guide: **[docs/ai-agents.md](docs/ai-agents.md)**
 
-| Skill | Description |
-|-------|-------------|
-| `gplay-cli-usage` | Guidance for running gplay commands (flags, pagination, output, auth) |
-| `gplay-release-flow` | End-to-end release workflows for internal, beta, and production tracks |
-| `gplay-gradle-build` | Build, sign, and package Android apps with Gradle before uploading |
-| `gplay-metadata-sync` | Metadata and localization sync (including FastLane format) |
-| `gplay-rollout-management` | Staged rollout orchestration and monitoring |
-| `gplay-review-management` | Review monitoring, filtering, and automated responses |
-| `gplay-iap-setup` | In-app products, subscriptions, base plans, and offers |
-| `gplay-purchase-verification` | Server-side purchase verification |
-| `gplay-testers-orchestration` | Beta testing groups and tester management |
-| `gplay-signing-setup` | Android app signing, keystores, and Play App Signing |
-| `gplay-vitals-monitoring` | App vitals monitoring for crashes, errors, and performance |
-| `gplay-user-management` | Developer account user and permission grant management |
-| `gplay-migrate-fastlane` | Migration from Fastlane metadata to gplay format |
-| `gplay-reports-download` | Financial and statistics report listing/downloading from GCS |
+## How gplay compares
 
-Skills repository: [github.com/tamtom/gplay-cli-skills](https://github.com/tamtom/gplay-cli-skills)
+Versus [Fastlane `supply`](https://docs.fastlane.tools/actions/supply/) and [gradle-play-publisher](https://github.com/Triple-T/gradle-play-publisher) (all three cover AAB/APK upload, tracks, rollouts, and listings equivalently):
+
+| Capability | gplay | Fastlane supply | gradle-play-publisher |
+|---|---|---|---|
+| Subscriptions, base plans, offers, one-time purchases | ✅ Full | ❌ | ⚠️ Basic (no base plans/offers) |
+| Purchase verification, orders, refunds | ✅ | ❌ | ❌ |
+| Vitals: crashes, ANRs, performance | ✅ | ❌ | ❌ |
+| Reviews: read + reply | ✅ | ❌ | ❌ |
+| Financial & statistics reports | ✅ | ❌ | ❌ |
+| Users & permission grants | ✅ | ❌ | ❌ |
+| Google Checks compliance gate | ✅ | ❌ | ❌ |
+| AI-agent-friendly output | ✅ JSON default | ❌ Human logs | ❌ Gradle logs |
+| Runtime | Single Go binary | Ruby + gems | JVM + Gradle project |
+
+## Documentation
+
+| Guide | What's inside |
+|-------|---------------|
+| **[Command reference (GPLAY.md)](GPLAY.md)** | Every command and flag, auto-generated |
+| [Authentication](docs/authentication.md) | Service account setup, profiles, `auth doctor` |
+| [Releasing](docs/releasing.md) | Releases, rollouts, listings, testers, pre-submission checks, Fastlane interop |
+| [Monetization](docs/monetization.md) | Subscriptions, IAP, one-time purchases, pricing, purchase verification, RevenueCat |
+| [Monitoring & operations](docs/monitoring.md) | Vitals, reviews, reports, users, notifications, diagnostics |
+| [AI agents](docs/ai-agents.md) | Agent setup, skills, example prompts |
+| [Configuration](docs/configuration.md) | Config file, env vars, output formats, shell completion |
+| [CI/CD](docs/ci-cd.md) | GitHub Actions, GitLab CI, release gates |
+| [Contributing](CONTRIBUTING.md) | Development setup, testing, PR guidelines |
+
+## Contributing
+
+Contributions welcome — see [CONTRIBUTING.md](CONTRIBUTING.md). Quick local check: `make dev` (format + lint + test + build).
 
 ## License
 
-MIT License - see [LICENSE](LICENSE) for details.
+MIT — see [LICENSE](LICENSE).
 
 ---
 
 <p align="center">
-  Built with Go and the <a href="https://github.com/peterbourgon/ff">ffcli</a> framework
+  Built with Go and <a href="https://github.com/peterbourgon/ff">ffcli</a>
 </p>

--- a/docs/API_NOTES.md
+++ b/docs/API_NOTES.md
@@ -18,6 +18,7 @@ about API constraints when implementing new features.
 5. [Error Response Formats](#error-response-formats)
 6. [Pagination Behavior](#pagination-behavior)
 7. [Upload Behavior](#upload-behavior)
+8. [Google Checks API](#google-checks-api)
 
 ---
 
@@ -349,6 +350,84 @@ unhelpful message. Always set it explicitly based on file extension.
 
 ---
 
+## Google Checks API
+
+**Reference**: [Checks API](https://developers.google.com/checks/reference/rest)
+
+> **Last verified**: April 2026 against Checks API `v1alpha`.
+
+The Google Checks API is separate from the Android Publisher API and uses the
+service endpoint `https://checks.googleapis.com`. All CLI calls must authenticate
+with the `https://www.googleapis.com/auth/checks` OAuth scope.
+
+### Current v1alpha Resources
+
+| Resource | Methods used by `gplay checks` |
+|---|---|
+| `accounts.apps` | `get`, `list` |
+| `accounts.apps.reports` | `get`, `list` |
+| `accounts.apps.operations` | `cancel`, `delete`, `get`, `list`, `wait` |
+| `media` | `upload` |
+| `aisafety` | `classifyContent` |
+
+### App Analysis Upload
+
+Checks binary analysis uses the media upload endpoint:
+
+```
+POST /upload/v1alpha/{parent=accounts/*/apps/*}/reports:analyzeUpload
+```
+
+The request metadata is `GoogleChecksReportV1alphaAnalyzeUploadRequest` and can
+include:
+
+| Field | Detail |
+|---|---|
+| `appBinaryFileType` | `ANDROID_APK`, `ANDROID_AAB`, or `IOS_IPA`. If omitted, the API infers APK for Android apps and IPA for iOS apps. |
+| `codeReferenceId` | Optional git commit hash or changelist number associated with the upload. |
+
+The response is a `google.longrunning.Operation`. For CI-friendly behavior,
+`gplay checks upload --wait` polls `accounts.apps.operations.get` until
+`done=true`, decodes the operation response as a Checks report, and can fail the
+command when a failed report check meets `--severity-threshold`.
+
+### Reports and Filters
+
+Reports are addressed as:
+
+```
+accounts/{account}/apps/{app}/reports/{report}
+```
+
+`reports.list` supports both report-level `filter` and per-report
+`checksFilter` parameters. `reports.get` supports `checksFilter`.
+
+### AI Safety Classification
+
+Checks content classification uses:
+
+```
+POST /v1alpha/aisafety:classifyContent
+```
+
+Requests require an `input` and a non-empty list of policy configs. The
+supported policy types are currently:
+
+- `DANGEROUS_CONTENT`
+- `PII_SOLICITING_RECITING`
+- `HARASSMENT`
+- `SEXUALLY_EXPLICIT`
+- `HATE_SPEECH`
+- `MEDICAL_INFO`
+- `VIOLENCE_AND_GORE`
+- `OBSCENITY_AND_PROFANITY`
+
+The response returns one `policyResult` per requested policy. Treat
+`violationResult == VIOLATIVE` as the failure condition for
+`gplay checks classify --severity-threshold`.
+
+---
+
 ## Further Reading
 
 - [Google Play Developer API Overview](https://developers.google.com/android-publisher)
@@ -356,3 +435,4 @@ unhelpful message. Always set it explicitly based on file extension.
 - [Getting Started Guide](https://developers.google.com/android-publisher/getting_started)
 - [Upload Guide](https://developers.google.com/android-publisher/upload)
 - [Quota & Rate Limits](https://developers.google.com/android-publisher/quotas)
+- [Checks API Reference](https://developers.google.com/checks/reference/rest)

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -1,0 +1,63 @@
+# Using gplay with AI Agents
+
+`gplay` is designed to be driven by AI coding agents — Claude Code, Codex, Cursor, Gemini CLI, Windsurf, or anything that can run shell commands.
+
+## Why it works well with agents
+
+- **Minified JSON by default** — machine-parseable output that saves tokens
+- **Self-documenting** — every command supports `--help`; agents discover the interface instead of hallucinating it
+- **Explicit long flags only** (`--package`, never `-p`) — unambiguous for generation and review
+- **No interactive prompts** — destructive operations use `--confirm` flags, so agents never hang on stdin
+- **`--dry-run` everywhere** — agents can show you exactly what would change before executing
+- **`GPLAY.md`** — a complete auto-generated command reference an agent can read in one shot
+
+## Point your agent at the reference
+
+Add this to your project's `CLAUDE.md` / `AGENTS.md` / rules file:
+
+```markdown
+Use the `gplay` CLI for all Google Play Console operations.
+Discover commands with `gplay --help` and `gplay <command> --help`.
+Full reference: https://github.com/tamtom/play-console-cli/blob/main/GPLAY.md
+```
+
+## Install the Agent Skills
+
+Pre-built workflow skills compatible with any agent that supports the [Agent Skills](https://github.com/anthropics/agent-skills) format:
+
+```bash
+npx skills add tamtom/gplay-cli-skills
+```
+
+| Skill | Description |
+|-------|-------------|
+| `gplay-cli-usage` | Guidance for running gplay commands (flags, pagination, output, auth) |
+| `gplay-release-flow` | End-to-end release workflows for internal, beta, and production tracks |
+| `gplay-gradle-build` | Build, sign, and package Android apps with Gradle before uploading |
+| `gplay-metadata-sync` | Metadata and localization sync (including Fastlane format) |
+| `gplay-rollout-management` | Staged rollout orchestration and monitoring |
+| `gplay-review-management` | Review monitoring, filtering, and automated responses |
+| `gplay-iap-setup` | In-app products, subscriptions, base plans, and offers |
+| `gplay-ppp-pricing` | Purchasing-power-parity regional pricing |
+| `gplay-purchase-verification` | Server-side purchase verification |
+| `gplay-testers-orchestration` | Beta testing groups and tester management |
+| `gplay-signing-setup` | Android app signing, keystores, and Play App Signing |
+| `gplay-vitals-monitoring` | App vitals monitoring for crashes, errors, and performance |
+| `gplay-user-management` | Developer account user and permission grant management |
+| `gplay-migrate-fastlane` | Migration from Fastlane metadata to gplay format |
+| `gplay-reports-download` | Financial and statistics report listing/downloading from GCS |
+| `gplay-submission-checks` | Pre-submission validation |
+| `gplay-screenshot-automation` | Screenshot management workflows |
+| `gplay-subscription-localization` | Subscription and in-app product localization |
+
+Skills repository: [github.com/tamtom/gplay-cli-skills](https://github.com/tamtom/gplay-cli-skills)
+
+## Example agent prompts
+
+Things you can ask your agent once `gplay` is installed and authenticated:
+
+- *"Release the AAB in `app/build/outputs` to the internal track with release notes from git history."*
+- *"Create a monthly and yearly subscription with a 7-day free trial, priced at $4.99/$29.99, then convert prices for all regions."*
+- *"Summarize this week's crash clusters and reply to every 1-star review mentioning crashes."*
+- *"Set up the Play products, then import them into RevenueCat and attach them to a `premium` entitlement."*
+- *"Download last month's earnings report and tell me revenue by country."*

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,113 @@
+# Authentication
+
+`gplay` authenticates to the Google Play Android Developer API with a **service account**. This guide covers the automated setup, the manual setup, profiles, and troubleshooting.
+
+## Automated setup (recommended)
+
+```bash
+gplay setup --auto
+```
+
+That's it. This drives the whole flow via `gcloud`:
+- Installs `gcloud` if needed (Homebrew on macOS, curl on Linux)
+- Logs you into Google Cloud (`gcloud auth login`) if you aren't already
+- Enables the `androidpublisher` API
+- Creates a service account and downloads its JSON key
+- Wires the profile into `~/.gplay/config.json`
+- Opens Play Console for the one manual step (granting the account access)
+
+`gplay auth setup --auto` is an alias of the same command.
+
+Useful flags:
+
+```bash
+gplay setup --auto --project <id>     # if gcloud has no default project
+gplay setup --auto --dry-run          # preview the gcloud commands, run nothing
+gplay setup --auto --no-browser       # CI/agent friendly: never open a browser
+gplay setup --auto --sa-name my-ci    # custom service-account name
+gplay setup --auto --output json      # machine-readable result
+
+# Verify
+gplay auth doctor
+```
+
+`--no-browser` requires that `gcloud` is already installed and authenticated (it won't launch the interactive login), which makes it the right choice for CI and headless agents.
+
+## Manual setup
+
+### 1. Create a Google Cloud project & enable the API
+
+```
+Google Cloud Console → Create Project → APIs & Services → Library
+→ Search "Google Play Android Developer API" → Enable
+```
+
+### 2. Create a service account & download a key
+
+```
+IAM & Admin → Service Accounts → Create Service Account
+→ Name it (e.g., "gplay-cli") → Create → Done
+→ Click the account → Keys → Add Key → Create new key → JSON
+→ Save the JSON file securely (never commit to git!)
+```
+
+### 3. Grant access in Play Console
+
+```
+Play Console → Users and permissions → Invite new users
+→ Paste service account email (from JSON: "client_email" field)
+→ Set permissions (Admin, or per-app access)
+→ Invite user
+```
+
+### 4. Configure gplay
+
+```bash
+# Option A: Login command (saves to profile)
+gplay auth login --service-account /path/to/service-account.json
+
+# Option B: Environment variable
+export GPLAY_SERVICE_ACCOUNT=/path/to/service-account.json
+
+# Verify setup
+gplay auth doctor
+```
+
+## Profiles
+
+Use profiles to switch between multiple developer accounts or apps:
+
+```bash
+# Add profiles for different accounts/apps
+gplay auth login --profile work --service-account /path/to/work-sa.json
+gplay auth login --profile personal --service-account /path/to/personal-sa.json
+
+# Switch default profile
+gplay auth switch --profile work
+
+# Check current status
+gplay auth status
+
+# Use a specific profile for a single command
+GPLAY_PROFILE=personal gplay tracks list --package com.example.app
+```
+
+## Diagnostics
+
+```bash
+# Validate auth setup (16 checks: gcloud, config, SA key, DNS, disk, clock, ...)
+gplay auth doctor
+
+# Auto-fix issues (with confirmation)
+gplay auth doctor --fix --confirm
+```
+
+## Security best practices
+
+- **Never commit service account keys** to version control
+- **Use environment variables** or secrets management in CI/CD
+- **Limit service account permissions** to only what's needed
+- **Rotate keys regularly**
+- **Use separate service accounts** for different environments
+
+Credentials are stored in config as a file path reference only — never the key content itself.

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -1,0 +1,76 @@
+# CI/CD Integration
+
+`gplay` is a single static binary with JSON output and no interactive prompts — it drops into any CI/CD pipeline: GitHub Actions, GitLab CI, Jenkins, Bitrise, CircleCI.
+
+## GitHub Actions
+
+```yaml
+name: Deploy to Play Store
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up gplay
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/tamtom/play-console-cli/main/install.sh | bash
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Build app
+        run: ./gradlew bundleRelease
+
+      - name: Deploy to internal track
+        env:
+          GPLAY_SERVICE_ACCOUNT: ${{ secrets.PLAY_SERVICE_ACCOUNT }}
+        run: |
+          gplay release \
+            --package com.example.app \
+            --track internal \
+            --bundle app/build/outputs/bundle/release/app-release.aab
+```
+
+## GitLab CI
+
+```yaml
+deploy:
+  stage: deploy
+  image: ubuntu:latest
+  before_script:
+    - curl -fsSL https://raw.githubusercontent.com/tamtom/play-console-cli/main/install.sh | bash
+    - export PATH="$HOME/.local/bin:$PATH"
+  script:
+    - gplay release --package $PACKAGE_NAME --track internal --bundle app.aab
+  variables:
+    GPLAY_SERVICE_ACCOUNT: $PLAY_SERVICE_ACCOUNT
+```
+
+## Useful CI gates
+
+```bash
+# Fail the build on compliance issues before uploading (offline, no API calls)
+gplay preflight --file app.aab --max-size 100M --fail-on warning
+
+# Fail on bundle size regression
+gplay bundles compare --base old.aab --candidate new.aab --threshold 2M
+
+# Google Checks privacy/policy gate — exits non-zero on high-priority failures
+gplay checks analyze --account <account-id> --app <app-id> --binary app.aab \
+  --code-ref "$GIT_SHA" --severity-threshold PRIORITY --checks-filter "state = FAILED"
+
+# Notify the team after release
+gplay notify send --webhook-url $SLACK_WEBHOOK --message "v1.2.3 → internal" --format slack
+```
+
+## Security in CI
+
+- Store the service account key in your CI secrets manager, never in the repo
+- Point `GPLAY_SERVICE_ACCOUNT` at the key file materialized at runtime
+- Use separate service accounts per environment with least-privilege Play Console permissions
+- Rotate keys regularly

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,102 @@
+# Configuration
+
+## Config file
+
+Global: `~/.gplay/config.yaml`
+Local (takes precedence): `./.gplay/config.yaml`
+
+```yaml
+default_package: com.example.app
+timeout: 120s
+upload_timeout: 5m
+max_retries: 3
+debug: false
+```
+
+Bootstrap a local config with:
+
+```bash
+gplay init
+gplay init --package com.example.app --service-account /path/to/sa.json
+```
+
+## Environment variables
+
+| Variable | Description |
+|----------|-------------|
+| `GPLAY_SERVICE_ACCOUNT` | Path to service account JSON |
+| `GPLAY_PACKAGE` | Default package name |
+| `GPLAY_PROFILE` | Active profile name |
+| `GPLAY_TIMEOUT` | Request timeout (e.g., `90s`, `2m`) |
+| `GPLAY_TIMEOUT_SECONDS` | Timeout in seconds (alternative) |
+| `GPLAY_UPLOAD_TIMEOUT` | Upload timeout (e.g., `5m`, `10m`) |
+| `GPLAY_NO_UPDATE` | Disable update checks (set to `1`) |
+| `GPLAY_DEBUG` | Enable debug logging (`1` or `api`) |
+| `GPLAY_MAX_RETRIES` | Max retries for failed requests (default: 3) |
+| `GPLAY_RETRY_DELAY` | Base delay between retries (default: `1s`) |
+| `GPLAY_DEFAULT_OUTPUT` | Default output format (`json`, `table`, `markdown`) |
+| `GPLAY_AUDIT` | Set to `0` to disable the local audit log |
+| `GPLAY_AUDIT_LOG` | Override audit log path (default `~/.gplay/audit.log`) |
+| `GPLAY_CHECKS_ACCOUNT` | Default Google Checks account ID |
+
+## Output formats
+
+| Format | Flag | Use case |
+|--------|------|----------|
+| JSON (minified) | default | Scripting, automation, AI agents |
+| JSON (pretty) | `--pretty` | Debugging |
+| Table | `--output table` | Terminal display |
+| Markdown | `--output markdown` | Documentation |
+
+```bash
+# Parse with jq
+gplay tracks list --package com.example.app | jq '.tracks[].track'
+
+# Human-readable
+gplay reviews list --package com.example.app --output table
+```
+
+## Scripting tips
+
+- JSON output is default for easy parsing; add `--pretty` when debugging
+- Use `--paginate` to automatically fetch all pages
+- Sort with `--sort` (prefix `-` for descending): `--sort -uploadedDate`
+- Use `--limit` + `--next` for manual pagination control
+- `--dry-run` (global) intercepts write HTTP methods and logs them to stderr without executing
+- Destructive operations require `--confirm` — there are no interactive prompts
+
+## Design philosophy
+
+**Explicit over cryptic.** Always `--package`, never `-p`. Commands are self-documenting:
+
+```bash
+gplay reviews list --package com.example.app --output table
+```
+
+**JSON-first output.** All commands output minified JSON by default:
+
+```bash
+gplay tracks list --package com.example.app | jq '.tracks[] | select(.track == "production")'
+```
+
+**No interactive prompts.** Everything is flag-based for automation:
+
+```bash
+gplay edits delete --package com.example.app --edit <id> --confirm
+```
+
+## Shell completion
+
+```bash
+# Bash
+gplay completion bash > /etc/bash_completion.d/gplay
+
+# Zsh
+gplay completion zsh > "${fpath[1]}/_gplay"
+
+# Fish
+gplay completion fish > ~/.config/fish/completions/gplay.fish
+
+# PowerShell
+gplay completion powershell >> $PROFILE
+```

--- a/docs/monetization.md
+++ b/docs/monetization.md
@@ -1,0 +1,86 @@
+# Monetization
+
+Create and manage **subscriptions**, **in-app products (IAP)**, and **one-time purchases** on Google Play from the command line — no clicking through Play Console. Works standalone or as the Play-side companion to [RevenueCat](https://www.revenuecat.com/).
+
+## In-app products (IAP)
+
+```bash
+gplay iap list --package com.example.app
+gplay iap create --package com.example.app --sku premium_upgrade --json @product.json
+gplay iap update --package com.example.app --sku premium_upgrade --json @product.json
+gplay iap batch-update --package com.example.app --json @products.json
+```
+
+## One-time products
+
+```bash
+# Purchase options (batch state management)
+gplay purchase-options batch-update-states --package com.example.app --json @states.json
+gplay purchase-options batch-delete --package com.example.app --json @options.json
+
+# One-time product offers
+gplay otp-offers list --package com.example.app --product-id lifetime
+gplay otp-offers activate --package com.example.app --product-id lifetime --offer <id>
+gplay otp-offers deactivate --package com.example.app --product-id lifetime --offer <id>
+```
+
+## Subscriptions
+
+```bash
+gplay subscriptions list --package com.example.app
+gplay subscriptions create --package com.example.app --json @subscription.json
+
+# Base plans
+gplay baseplans activate --package com.example.app --product-id sub_premium --base-plan monthly
+gplay baseplans deactivate --package com.example.app --product-id sub_premium --base-plan monthly
+
+# Promotional offers
+gplay offers list --package com.example.app --product-id sub_premium --base-plan monthly
+gplay offers create --package com.example.app --product-id sub_premium --base-plan monthly --json @offer.json
+```
+
+## Regional pricing
+
+```bash
+# Convert a base price across all Play regions
+gplay pricing convert --package com.example.app --json @price.json
+```
+
+## Purchase verification & orders
+
+Server-side verification of purchase tokens, acknowledgement, and refunds:
+
+```bash
+# Verify purchases
+gplay purchases products get --package com.example.app --product-id premium --token <token>
+gplay purchases products acknowledge --package com.example.app --product-id premium --token <token>
+gplay purchases subscriptions get --package com.example.app --token <token>
+
+# Orders
+gplay orders get --package com.example.app --order-id <id>
+gplay orders refund --package com.example.app --order-id <id> --revoke
+
+# External transactions (EU compliance)
+gplay external-transactions create --package com.example.app --json @transaction.json
+```
+
+## Real-Time Developer Notifications (RTDN)
+
+Set up and decode Play billing webhooks:
+
+```bash
+gplay rtdn setup --project <gcp-project> --topic play-rtdn
+gplay rtdn status --project <gcp-project>
+gplay rtdn decode --file payload.json      # typed subscription/one-time/voided decoder
+```
+
+## Using gplay with RevenueCat
+
+RevenueCat imports products from Google Play — it doesn't create them. `gplay` covers the Play-side half of the workflow:
+
+1. **Create products in Play** with `gplay subscriptions create` / `gplay iap create` (scriptable, repeatable across apps).
+2. **Import them into RevenueCat** (dashboard, API, or the RevenueCat MCP/CLI tooling) and attach them to entitlements and offerings.
+3. **Verify and debug** live purchases from the terminal with `gplay purchases ...` and `gplay orders ...` when reconciling RevenueCat events against Play.
+4. **Decode RTDN payloads** with `gplay rtdn decode` when debugging RevenueCat's Play Store server notifications.
+
+Because both product catalogs are scriptable, an AI agent can set up the full monetization stack — Play products + RevenueCat offerings — in one session.

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,89 @@
+# Monitoring & Operations
+
+Vitals, reviews, reports, team management, and observability.
+
+## Vitals & quality
+
+```bash
+# Crash reports
+gplay vitals crashes clusters --package com.example.app
+gplay vitals crashes reports --package com.example.app
+
+# Performance metrics
+gplay vitals performance startup --package com.example.app
+gplay vitals performance rendering --package com.example.app
+gplay vitals performance battery --package com.example.app
+
+# ANR / error tracking
+gplay vitals errors issues --package com.example.app
+gplay vitals errors reports --package com.example.app
+```
+
+## Reviews
+
+```bash
+# List and filter reviews
+gplay reviews list --package com.example.app
+gplay reviews list --package com.example.app --paginate
+
+# Reply to reviews
+gplay reviews get --package com.example.app --review-id <id>
+gplay reviews reply --package com.example.app --review-id <id> --text "Thank you!"
+```
+
+## Financial & statistics reports
+
+Reports are stored as CSV/ZIP files in Google Cloud Storage buckets (`pubsite_prod_rev_<developer_id>`). The service account must have access to the GCS bucket (granted automatically when added to Play Console).
+
+> **Important:** The `--developer` ID for reports is **not** the developer ID in your Play Console URL. To find the correct ID, go to **Play Console > Download reports > Copy Cloud Storage URI**. The URI looks like `gs://pubsite_prod_rev_XXXX/` — the number after `pubsite_prod_rev_` is your developer ID.
+
+```bash
+# Financial reports (earnings, sales, payouts)
+gplay reports financial list --developer <id>
+gplay reports financial list --developer <id> --type earnings --from 2026-01 --to 2026-06
+gplay reports financial download --developer <id> --from 2026-01 --type earnings --dir ./reports
+
+# Statistics reports (installs, ratings, crashes, store_performance, subscriptions)
+gplay reports stats list --developer <id>
+gplay reports stats list --developer <id> --package com.example.app --type installs
+gplay reports stats download --developer <id> --package com.example.app --from 2026-01 --type installs --dir ./reports
+```
+
+## Team & permissions
+
+```bash
+# Manage developer account users
+gplay users list --developer <id>
+gplay users create --developer <id> --email user@example.com --json @permissions.json
+gplay users delete --developer <id> --email user@example.com --confirm
+
+# Manage per-app grants
+gplay grants create --developer <id> --email user@example.com --package com.example.app --json @grant.json
+gplay grants update --developer <id> --email user@example.com --package com.example.app --json @grant.json
+gplay grants delete --developer <id> --email user@example.com --package com.example.app --confirm
+```
+
+## Notifications
+
+```bash
+# Send webhook notifications (Slack, Discord, generic)
+gplay notify send --webhook-url https://hooks.slack.com/... --message "Deploy complete" --format slack
+gplay notify send --webhook-url https://discord.com/... --message "New release" --format discord
+```
+
+## Diagnostics & observability
+
+```bash
+# Full environment health check (16 checks: gcloud, config, SA, DNS, disk, clock, ...)
+gplay doctor
+gplay doctor --output json --pretty
+
+# Local audit log of every invocation (auto-written to ~/.gplay/audit.log)
+gplay audit list --limit 50
+gplay audit search --command vitals --status error
+gplay audit clear --confirm
+
+# API quota usage (derived from audit log)
+gplay quota status                 # daily + per-minute windows
+gplay quota status --top 10
+```

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,140 @@
+# Releasing
+
+Everything for shipping builds: uploads, tracks, staged rollouts, promotions, and store listing metadata.
+
+## One-command release
+
+```bash
+# Creates edit, uploads, updates track, commits — in one step
+gplay release --package com.example.app --track internal --bundle app.aab
+
+# With release notes and staged rollout
+gplay release --package com.example.app --track production --bundle app.aab \
+  --release-notes @notes.json --rollout 10
+
+# With metadata and screenshots
+gplay release --package com.example.app --track production --bundle app.aab \
+  --listings-dir ./metadata --screenshots-dir ./screenshots
+
+# Dry-run any command (intercepts write operations)
+gplay --dry-run release --package com.example.app --track internal --bundle app.aab
+
+# Generate release notes from git history
+gplay release-notes generate
+```
+
+## Promote & rollout
+
+```bash
+# Promote between tracks (internal → beta → production)
+gplay promote --package com.example.app --from internal --to beta
+
+# Manage staged rollout
+gplay rollout update --package com.example.app --track production --rollout 50
+gplay rollout halt --package com.example.app --track production
+gplay rollout resume --package com.example.app --track production
+gplay rollout complete --package com.example.app --track production
+```
+
+## Low-level edit lifecycle
+
+```bash
+gplay edits create --package com.example.app
+gplay edits list --package com.example.app
+gplay edits validate --package com.example.app --edit <id>
+gplay edits commit --package com.example.app --edit <id>
+
+# Upload artifacts
+gplay bundles upload --package com.example.app --edit <id> --file app.aab
+gplay apks upload --package com.example.app --edit <id> --file app.apk
+
+# Manage tracks
+gplay tracks list --package com.example.app --edit <id>
+gplay tracks get --package com.example.app --edit <id> --track production
+gplay tracks update --package com.example.app --edit <id> --track internal --json @release.json
+```
+
+## Store listing
+
+```bash
+# Listings
+gplay listings list --package com.example.app --edit <id>
+gplay listings get --package com.example.app --edit <id> --locale en-US
+gplay listings update --package com.example.app --edit <id> --locale en-US --json @listing.json
+gplay listings locales      # available locales with validation
+
+# Images
+gplay images list --package com.example.app --edit <id> --locale en-US --type phoneScreenshots
+gplay images upload --package com.example.app --edit <id> --locale en-US --type phoneScreenshots --file screenshot.png
+
+# App details
+gplay details get --package com.example.app --edit <id>
+gplay details update --package com.example.app --edit <id> --contact-email dev@example.com
+```
+
+## Fastlane interop
+
+```bash
+# Export metadata to Fastlane format
+gplay sync export-listings --package com.example.app --dir ./fastlane/metadata/android
+
+# Import metadata from Fastlane format
+gplay sync import-listings --package com.example.app --dir ./fastlane/metadata/android
+
+# Compare local metadata with Play Store
+gplay sync diff-listings --package com.example.app --dir ./fastlane/metadata/android
+
+# One-shot migration from Fastlane
+gplay migrate fastlane
+
+# Validate before upload
+gplay validate listing --dir ./fastlane/metadata/android --locale en-US
+gplay validate screenshots --dir ./fastlane/metadata/android/en-US/images
+gplay validate bundle --file app.aab
+```
+
+## Testing & distribution
+
+```bash
+# Manage testers on closed tracks
+gplay testers list --package com.example.app --edit <id> --track internal
+gplay testers update --package com.example.app --edit <id> --track internal --emails user@example.com
+
+# Internal app sharing (quick sharing without review)
+gplay internal-sharing upload-bundle --package com.example.app --file app.aab
+gplay internal-sharing upload-apk --package com.example.app --file app.apk
+```
+
+## Pre-submission checks
+
+```bash
+# Offline compliance scan on an AAB or APK (no API calls)
+# Checks: manifest, bundle size, native ABIs, dex, debuggable, testOnly,
+# cleartext traffic, dangerous permissions, secret scan, misplaced files.
+gplay preflight --file app.aab
+gplay preflight --file app.aab --max-size 100M --fail-on warning   # CI gate
+
+# Bundle size analysis (offline)
+gplay bundles analyze --file app.aab --top-files 20
+gplay bundles compare --base old.aab --candidate new.aab --threshold 2M
+```
+
+## Google Checks (privacy & compliance)
+
+```bash
+# Upload an AAB/APK to Google Checks for privacy & policy analysis (async)
+# Requires a Checks account: pass --account, or set GPLAY_CHECKS_ACCOUNT / checks_account.
+gplay checks apps list --account <account-id>
+gplay checks analyze --account <account-id> --app <app-id> --binary app.aab
+
+# CI/CD gate: analyze, wait for the report, exit non-zero on high-priority failures
+gplay checks analyze --account <account-id> --app <app-id> --binary app.aab \
+  --code-ref "$GIT_SHA" --severity-threshold PRIORITY --checks-filter "state = FAILED"
+
+# Browse compliance reports (what the app *does* vs. what data-safety *declares*)
+gplay checks reports list --account <account-id> --app <app-id> --checks-filter "state = FAILED"
+gplay checks reports get --account <account-id> --app <app-id> --report <report-id>
+
+# AI safety content classification (moderate app/generated text against policies)
+gplay checks classify --text @content.txt --policies all --severity-threshold
+```

--- a/internal/checksclient/client.go
+++ b/internal/checksclient/client.go
@@ -1,0 +1,257 @@
+package checksclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/checks/v1alpha"
+	"google.golang.org/api/option"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/config"
+)
+
+const (
+	Scope = "https://www.googleapis.com/auth/checks"
+
+	serviceAccountEnvVar       = "GPLAY_SERVICE_ACCOUNT_JSON"
+	serviceAccountPathEnvVar   = "GPLAY_SERVICE_ACCOUNT"
+	oauthTokenEnvVar           = "GPLAY_OAUTH_TOKEN_PATH"
+	oauthClientIDEnvVar        = "GPLAY_OAUTH_CLIENT_ID"
+	oauthClientSecretEnvVar    = "GPLAY_OAUTH_CLIENT_SECRET"
+	oauthRedirectEnvVar        = "GPLAY_OAUTH_REDIRECT_URI"
+	checksAccountEnvVar        = "GPLAY_CHECKS_ACCOUNT"
+	defaultOAuthRedirectURI    = "urn:ietf:wg:oauth:2.0:oob"
+	serviceAccountProfileTypes = "service_account, service-account, serviceaccount"
+)
+
+// Service wraps the Checks API service and config.
+type Service struct {
+	API *checks.Service
+	Cfg *config.Config
+}
+
+// NewService creates an authenticated Checks API service.
+func NewService(ctx context.Context) (*Service, error) {
+	cfg, err := config.Load()
+	if err != nil && !errors.Is(err, config.ErrNotFound) {
+		return nil, shared.NewActionableError(
+			"failed to load config",
+			err,
+			"Check that your config file is valid JSON and readable. Use `gplay auth login` to recreate it.",
+		)
+	}
+	client, err := newHTTPClient(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	if shared.IsDryRun(ctx) {
+		client.Transport = &shared.DryRunTransport{
+			Base:   client.Transport,
+			Writer: os.Stderr,
+		}
+	}
+	api, err := checks.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	return &Service{API: api, Cfg: cfg}, nil
+}
+
+// ResolveAccount returns the Checks account ID from flag, env, or config.
+func ResolveAccount(flagValue string, cfg *config.Config) string {
+	if v := strings.TrimSpace(flagValue); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv(checksAccountEnvVar)); v != "" {
+		return v
+	}
+	if cfg != nil && strings.TrimSpace(cfg.ChecksAccount) != "" {
+		return strings.TrimSpace(cfg.ChecksAccount)
+	}
+	return ""
+}
+
+func newHTTPClient(ctx context.Context, cfg *config.Config) (*http.Client, error) {
+	tokenSource, err := resolveTokenSource(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return oauth2.NewClient(ctx, tokenSource), nil
+}
+
+func resolveTokenSource(ctx context.Context, cfg *config.Config) (oauth2.TokenSource, error) {
+	profileName := shared.ResolveProfileName(cfg)
+	if profileName != "" && cfg != nil {
+		if profile, ok := findProfile(cfg, profileName); ok {
+			tokenSource, err := tokenSourceFromProfile(ctx, profile)
+			if err != nil {
+				return nil, err
+			}
+			if shared.StrictAuthEnabled() && envAuthPresent() {
+				return nil, shared.NewAuthError(
+					"authentication failed",
+					fmt.Errorf("strict auth: profile selected but environment credentials also present"),
+					"Unset environment credentials or set GPLAY_STRICT_AUTH=false.",
+				)
+			}
+			return tokenSource, nil
+		}
+		return nil, shared.NewAuthError(
+			"authentication failed",
+			fmt.Errorf("profile not found: %s", profileName),
+			"Run `gplay auth login --profile <name>` or set GPLAY_PROFILE to an existing profile.",
+		)
+	}
+
+	if envAuthPresent() {
+		return tokenSourceFromEnv(ctx)
+	}
+
+	return nil, shared.NewAuthError(
+		"authentication failed",
+		errors.New("no credentials found"),
+		"Run `gplay auth login` or set GPLAY_SERVICE_ACCOUNT_JSON / GPLAY_OAUTH_TOKEN_PATH.",
+	)
+}
+
+func tokenSourceFromProfile(ctx context.Context, profile config.Profile) (oauth2.TokenSource, error) {
+	switch strings.ToLower(strings.TrimSpace(profile.Type)) {
+	case "service_account", "service-account", "serviceaccount":
+		if strings.TrimSpace(profile.KeyPath) == "" {
+			return nil, shared.NewAuthError(
+				"invalid auth profile",
+				errors.New("service account profile missing key_path"),
+				"Set key_path in config.json or re-run `gplay auth login` with --service-account.",
+			)
+		}
+		return tokenSourceFromServiceAccount(ctx, profile.KeyPath)
+	case "oauth":
+		if strings.TrimSpace(profile.TokenPath) == "" {
+			return nil, shared.NewAuthError(
+				"invalid auth profile",
+				errors.New("oauth profile missing token_path"),
+				"Set token_path in config.json or re-run `gplay auth login` with --oauth-token.",
+			)
+		}
+		clientID := strings.TrimSpace(profile.ClientID)
+		clientSecret := strings.TrimSpace(profile.ClientSecret)
+		if clientID == "" || clientSecret == "" {
+			return nil, shared.NewAuthError(
+				"invalid auth profile",
+				errors.New("oauth profile missing client_id or client_secret"),
+				"Set client_id/client_secret in config.json or re-run `gplay auth login` with --client-id/--client-secret.",
+			)
+		}
+		return tokenSourceFromOAuth(ctx, profile.TokenPath, clientID, clientSecret, redirectURIFromEnv())
+	default:
+		return nil, shared.NewAuthError(
+			"invalid auth profile",
+			fmt.Errorf("unknown profile type: %s", profile.Type),
+			fmt.Sprintf("Use one of: %s.", serviceAccountProfileTypes),
+		)
+	}
+}
+
+func tokenSourceFromEnv(ctx context.Context) (oauth2.TokenSource, error) {
+	if keyPath := serviceAccountPathFromEnv(); keyPath != "" {
+		return tokenSourceFromServiceAccount(ctx, keyPath)
+	}
+
+	tokenPath := strings.TrimSpace(os.Getenv(oauthTokenEnvVar))
+	clientID := strings.TrimSpace(os.Getenv(oauthClientIDEnvVar))
+	clientSecret := strings.TrimSpace(os.Getenv(oauthClientSecretEnvVar))
+	if tokenPath != "" {
+		if clientID == "" || clientSecret == "" {
+			return nil, shared.NewAuthError(
+				"oauth env vars incomplete",
+				fmt.Errorf("missing %s or %s", oauthClientIDEnvVar, oauthClientSecretEnvVar),
+				"Set both env vars or use `gplay auth login` to create a profile.",
+			)
+		}
+		return tokenSourceFromOAuth(ctx, tokenPath, clientID, clientSecret, redirectURIFromEnv())
+	}
+
+	return nil, errors.New("no credentials found")
+}
+
+func tokenSourceFromServiceAccount(ctx context.Context, keyPath string) (oauth2.TokenSource, error) {
+	data, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, shared.NewAuthError(
+			"failed to read service account file",
+			err,
+			fmt.Sprintf("Check that %s exists and is readable.", keyPath),
+		)
+	}
+	creds, err := google.CredentialsFromJSON(ctx, data, Scope) //nolint:staticcheck // no replacement available yet
+	if err != nil {
+		return nil, shared.NewAuthError(
+			"failed to parse service account JSON",
+			err,
+			"Ensure the file is a valid service account JSON with Checks API access.",
+		)
+	}
+	return creds.TokenSource, nil
+}
+
+func tokenSourceFromOAuth(ctx context.Context, tokenPath, clientID, clientSecret, redirectURI string) (oauth2.TokenSource, error) {
+	data, err := os.ReadFile(tokenPath)
+	if err != nil {
+		return nil, shared.NewAuthError(
+			"failed to read OAuth token file",
+			err,
+			fmt.Sprintf("Check that %s exists and is readable.", tokenPath),
+		)
+	}
+	var token oauth2.Token
+	if err := json.Unmarshal(data, &token); err != nil {
+		return nil, shared.NewAuthError(
+			"failed to parse OAuth token JSON",
+			err,
+			"Ensure the OAuth token file contains valid JSON.",
+		)
+	}
+	cfg := &oauth2.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		Endpoint:     google.Endpoint,
+		Scopes:       []string{Scope},
+		RedirectURL:  redirectURI,
+	}
+	return cfg.TokenSource(ctx, &token), nil
+}
+
+func envAuthPresent() bool {
+	return serviceAccountPathFromEnv() != "" || strings.TrimSpace(os.Getenv(oauthTokenEnvVar)) != ""
+}
+
+func serviceAccountPathFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv(serviceAccountEnvVar)); v != "" {
+		return v
+	}
+	return strings.TrimSpace(os.Getenv(serviceAccountPathEnvVar))
+}
+
+func findProfile(cfg *config.Config, name string) (config.Profile, bool) {
+	for _, p := range cfg.Profiles {
+		if p.Name == name {
+			return p, true
+		}
+	}
+	return config.Profile{}, false
+}
+
+func redirectURIFromEnv() string {
+	if v := strings.TrimSpace(os.Getenv(oauthRedirectEnvVar)); v != "" {
+		return v
+	}
+	return defaultOAuthRedirectURI
+}

--- a/internal/checksclient/client_test.go
+++ b/internal/checksclient/client_test.go
@@ -1,0 +1,22 @@
+package checksclient
+
+import (
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/config"
+)
+
+func TestResolveAccountPrecedence(t *testing.T) {
+	t.Setenv(checksAccountEnvVar, "env-account")
+	cfg := &config.Config{ChecksAccount: "config-account"}
+	if got := ResolveAccount("flag-account", cfg); got != "flag-account" {
+		t.Fatalf("ResolveAccount flag precedence = %q", got)
+	}
+	if got := ResolveAccount("", cfg); got != "env-account" {
+		t.Fatalf("ResolveAccount env precedence = %q", got)
+	}
+	t.Setenv(checksAccountEnvVar, "")
+	if got := ResolveAccount("", cfg); got != "config-account" {
+		t.Fatalf("ResolveAccount config fallback = %q", got)
+	}
+}

--- a/internal/cli/auth/setup.go
+++ b/internal/cli/auth/setup.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -24,16 +25,28 @@ const (
 	defaultProfileName  = "default"
 )
 
-// gcloudRunner is the subset of exec functionality the setup flow uses.
-// It exists so tests can stub out `gcloud` calls without running the real CLI.
+// gcloudRunner is the subset of host functionality the setup flow uses.
+// It exists so tests can stub out `gcloud`, the installer, the browser, and
+// the clipboard without touching the real system.
 type gcloudRunner interface {
 	LookPath(string) (string, error)
+	// Run executes a command and captures its stdout.
 	Run(ctx context.Context, stdin []byte, name string, args ...string) (stdout []byte, err error)
+	// RunInteractive executes a command wired to the user's stdio (for
+	// browser-based flows like `gcloud auth login`).
+	RunInteractive(ctx context.Context, name string, args ...string) error
+	// InstallGcloud installs the gcloud CLI for the current platform.
+	InstallGcloud(ctx context.Context) error
+	// OpenBrowser opens url in the default browser (best-effort).
+	OpenBrowser(url string) error
+	// Copy places text on the system clipboard (best-effort).
+	Copy(text string) error
 }
 
 type realRunner struct{}
 
 func (realRunner) LookPath(name string) (string, error) { return exec.LookPath(name) }
+
 func (realRunner) Run(ctx context.Context, stdin []byte, name string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	if stdin != nil {
@@ -48,9 +61,76 @@ func (realRunner) Run(ctx context.Context, stdin []byte, name string, args ...st
 	return out, nil
 }
 
+func (realRunner) RunInteractive(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (realRunner) InstallGcloud(ctx context.Context) error {
+	switch runtime.GOOS {
+	case "darwin":
+		if _, err := exec.LookPath("brew"); err == nil {
+			return runInherit(ctx, "brew", "install", "--cask", "google-cloud-sdk")
+		}
+		return runInherit(ctx, "bash", "-c", "curl -fsSL https://sdk.cloud.google.com | bash -s -- --disable-prompts")
+	case "linux":
+		return runInherit(ctx, "bash", "-c", "curl -fsSL https://sdk.cloud.google.com | bash -s -- --disable-prompts")
+	default:
+		return fmt.Errorf("automatic gcloud install is not supported on %s", runtime.GOOS)
+	}
+}
+
+func (realRunner) OpenBrowser(url string) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", url).Start()
+	case "linux":
+		return exec.Command("xdg-open", url).Start()
+	case "windows":
+		return exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+}
+
+func (realRunner) Copy(text string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "linux":
+		cmd = exec.Command("xclip", "-selection", "clipboard")
+	case "windows":
+		cmd = exec.Command("clip")
+	default:
+		return fmt.Errorf("unsupported platform")
+	}
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
+}
+
+func runInherit(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// SetupCommand wires the top-level `gplay setup [--auto]`.
+func SetupCommand() *ffcli.Command {
+	return newSetupCommand("setup", "gplay setup --auto [flags]")
+}
+
 // AuthSetupCommand wires `gplay auth setup [--auto]`.
 func AuthSetupCommand() *ffcli.Command {
-	fs := flag.NewFlagSet("auth setup", flag.ExitOnError)
+	return newSetupCommand("auth setup", "gplay auth setup --auto [--project <id>] [flags]")
+}
+
+func newSetupCommand(flagSetName, shortUsage string) *ffcli.Command {
+	fs := flag.NewFlagSet(flagSetName, flag.ExitOnError)
 	auto := fs.Bool("auto", false, "Automate GCP service-account creation using gcloud")
 	project := fs.String("project", "", "GCP project ID (defaults to gcloud default)")
 	saName := fs.String("sa-name", defaultSAName, "Service account name")
@@ -58,29 +138,31 @@ func AuthSetupCommand() *ffcli.Command {
 	keyOut := fs.String("key-out", "", "Path to write the service-account JSON (defaults to ~/.gplay/<sa>.json)")
 	dryRun := fs.Bool("dry-run", false, "Print the gcloud commands without executing them")
 	setDefault := fs.Bool("set-default", true, "Set as default profile in config")
+	noBrowser := fs.Bool("no-browser", false, "Do not open a browser (for login or the Play Console grant step)")
+	noInstall := fs.Bool("no-install", false, "Do not auto-install gcloud when it is missing")
 	output := fs.String("output", "text", "Output format: text (default), json")
 	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
 
 	return &ffcli.Command{
 		Name:       "setup",
-		ShortUsage: "gplay auth setup --auto [--project <id>] [flags]",
-		ShortHelp:  "Create a Google Cloud service account and link it to this CLI.",
-		LongHelp: `Automated setup for Google Play authentication.
+		ShortUsage: shortUsage,
+		ShortHelp:  "Set up Google Play authentication end-to-end.",
+		LongHelp: `One-command setup for Google Play authentication.
 
-With --auto, runs these steps via gcloud:
-  1. Detect/confirm GCP project
-  2. Enable the androidpublisher API
-  3. Create a service account (--sa-name)
-  4. Download a JSON key (--key-out)
+With --auto, gplay drives the whole flow via gcloud:
+  1. Install the gcloud CLI if it is missing (Homebrew on macOS, curl on Linux)
+  2. Log you into Google Cloud (gcloud auth login) if needed
+  3. Enable the androidpublisher API
+  4. Create a service account (--sa-name) and download a JSON key
   5. Store the profile in ~/.gplay/config.json
-
-You still need to link the service account email in Play Console afterwards;
-the URL is printed at the end.
+  6. Open Play Console for the one manual step: granting the account access
 
 Example:
-  gplay auth setup --auto --project my-gcp-project
-  gplay auth setup --auto --dry-run        # preview commands
-  gplay auth setup                          # open a how-to instead (no gcloud)`,
+  gplay setup --auto                        # full automated setup
+  gplay setup --auto --project my-gcp-project
+  gplay setup --auto --dry-run              # preview commands
+  gplay setup --auto --no-browser           # CI/agent friendly (no browser)
+  gplay setup                                # print manual instructions`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
@@ -92,6 +174,8 @@ Example:
 				KeyOut:     strings.TrimSpace(*keyOut),
 				DryRun:     *dryRun,
 				SetDefault: *setDefault,
+				NoBrowser:  *noBrowser,
+				NoInstall:  *noInstall,
 				Output:     *output,
 				Pretty:     *pretty,
 				Runner:     realRunner{},
@@ -103,7 +187,7 @@ Example:
 	}
 }
 
-// SetupOptions holds all flags for AuthSetupCommand, exposed for tests.
+// SetupOptions holds all flags for the setup command, exposed for tests.
 type SetupOptions struct {
 	Auto       bool
 	Project    string
@@ -112,6 +196,8 @@ type SetupOptions struct {
 	KeyOut     string
 	DryRun     bool
 	SetDefault bool
+	NoBrowser  bool
+	NoInstall  bool
 	Output     string
 	Pretty     bool
 
@@ -120,7 +206,7 @@ type SetupOptions struct {
 	HomeDir    func() (string, error)
 }
 
-// SetupResult is what `auth setup --auto` produces.
+// SetupResult is what `setup --auto` produces.
 type SetupResult struct {
 	Project       string   `json:"project,omitempty"`
 	ServiceAcct   string   `json:"service_account_email"`
@@ -128,6 +214,7 @@ type SetupResult struct {
 	ConfigPath    string   `json:"config_path,omitempty"`
 	ProfileName   string   `json:"profile"`
 	PlayLinkURL   string   `json:"play_console_link_url"`
+	BrowserOpened bool     `json:"browser_opened,omitempty"`
 	StepsExecuted []string `json:"steps_executed"`
 	DryRun        bool     `json:"dry_run,omitempty"`
 }
@@ -155,12 +242,19 @@ func RunSetup(ctx context.Context, opts SetupOptions, stdout *os.File) error {
 		))
 	}
 
-	if _, err := opts.Runner.LookPath("gcloud"); err != nil {
-		return shared.NewReportedError(fmt.Errorf(
-			"gcloud CLI is required for --auto; install from https://cloud.google.com/sdk",
-		))
+	var preSteps []string
+
+	// 1. Ensure gcloud is installed.
+	if err := ensureGcloud(ctx, opts, &preSteps); err != nil {
+		return err
 	}
 
+	// 2. Ensure we are logged into gcloud.
+	if err := ensureGcloudAuth(ctx, opts, &preSteps); err != nil {
+		return err
+	}
+
+	// 3. Resolve the project.
 	project := opts.Project
 	if project == "" {
 		out, err := opts.Runner.Run(ctx, nil, "gcloud", "config", "get-value", "project", "--quiet")
@@ -189,12 +283,13 @@ func RunSetup(ctx context.Context, opts SetupOptions, stdout *os.File) error {
 	)
 
 	result := SetupResult{
-		Project:     project,
-		ServiceAcct: saEmail,
-		KeyPath:     keyPath,
-		ProfileName: opts.Profile,
-		PlayLinkURL: linkURL,
-		DryRun:      opts.DryRun,
+		Project:       project,
+		ServiceAcct:   saEmail,
+		KeyPath:       keyPath,
+		ProfileName:   opts.Profile,
+		PlayLinkURL:   linkURL,
+		DryRun:        opts.DryRun,
+		StepsExecuted: preSteps,
 	}
 
 	steps := [][]string{
@@ -263,6 +358,14 @@ func RunSetup(ctx context.Context, opts SetupOptions, stdout *os.File) error {
 			}
 			result.ConfigPath = cfgPath
 		}
+
+		// Final step: open Play Console for the manual grant (best-effort).
+		if !opts.NoBrowser {
+			_ = opts.Runner.Copy(saEmail)
+			if err := opts.Runner.OpenBrowser(linkURL); err == nil {
+				result.BrowserOpened = true
+			}
+		}
 	}
 
 	if strings.ToLower(opts.Output) == "json" {
@@ -270,6 +373,75 @@ func RunSetup(ctx context.Context, opts SetupOptions, stdout *os.File) error {
 	}
 	printSetupText(stdout, result)
 	return nil
+}
+
+// ensureGcloud makes sure the gcloud CLI is available, installing it when
+// missing (unless --no-install or --dry-run).
+func ensureGcloud(ctx context.Context, opts SetupOptions, steps *[]string) error {
+	if _, err := opts.Runner.LookPath("gcloud"); err == nil {
+		return nil
+	}
+
+	if opts.DryRun {
+		*steps = append(*steps, "install gcloud CLI (skipped: dry-run)")
+		return nil
+	}
+	if opts.NoInstall {
+		return shared.NewReportedError(fmt.Errorf(
+			"gcloud CLI not found; install it from https://cloud.google.com/sdk or omit --no-install to auto-install",
+		))
+	}
+
+	if err := opts.Runner.InstallGcloud(ctx); err != nil {
+		return shared.NewReportedError(fmt.Errorf(
+			"install gcloud: %w; install manually from https://cloud.google.com/sdk", err,
+		))
+	}
+	if _, err := opts.Runner.LookPath("gcloud"); err != nil {
+		return shared.NewReportedError(fmt.Errorf(
+			"gcloud was installed but is not on PATH yet; restart your shell and re-run `gplay setup --auto`",
+		))
+	}
+	*steps = append(*steps, "installed gcloud CLI")
+	return nil
+}
+
+// ensureGcloudAuth makes sure there is an active gcloud account, launching
+// `gcloud auth login` when there is not (unless --no-browser or --dry-run).
+func ensureGcloudAuth(ctx context.Context, opts SetupOptions, steps *[]string) error {
+	if opts.DryRun {
+		*steps = append(*steps, "gcloud auth login (if not already authenticated)")
+		return nil
+	}
+
+	if activeGcloudAccount(ctx, opts.Runner) != "" {
+		*steps = append(*steps, "gcloud account: "+activeGcloudAccount(ctx, opts.Runner))
+		return nil
+	}
+
+	if opts.NoBrowser {
+		return shared.NewReportedError(fmt.Errorf(
+			"not logged into gcloud; run `gcloud auth login` first (or omit --no-browser to launch it)",
+		))
+	}
+
+	if err := opts.Runner.RunInteractive(ctx, "gcloud", "auth", "login"); err != nil {
+		return shared.NewReportedError(fmt.Errorf("gcloud auth login: %w", err))
+	}
+	account := activeGcloudAccount(ctx, opts.Runner)
+	if account == "" {
+		return shared.NewReportedError(fmt.Errorf("gcloud login did not complete; re-run `gplay setup --auto`"))
+	}
+	*steps = append(*steps, "logged into gcloud: "+account)
+	return nil
+}
+
+func activeGcloudAccount(ctx context.Context, runner gcloudRunner) string {
+	out, err := runner.Run(ctx, nil, "gcloud", "auth", "list", "--filter=status:ACTIVE", "--format=value(account)")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 func maybeRun(ctx context.Context, opts SetupOptions, args []string, result *SetupResult) error {
@@ -293,8 +465,8 @@ func printSetupText(w *os.File, r SetupResult) {
 	if w == nil {
 		w = os.Stdout
 	}
-	fmt.Fprintln(w, "gplay auth setup")
-	fmt.Fprintln(w, "================")
+	fmt.Fprintln(w, "gplay setup")
+	fmt.Fprintln(w, "===========")
 	fmt.Fprintf(w, "  Project:          %s\n", r.Project)
 	fmt.Fprintf(w, "  Service account:  %s\n", r.ServiceAcct)
 	fmt.Fprintf(w, "  Key path:         %s\n", r.KeyPath)
@@ -306,8 +478,12 @@ func printSetupText(w *os.File, r SetupResult) {
 	for _, s := range r.StepsExecuted {
 		fmt.Fprintf(w, "  - %s\n", s)
 	}
-	fmt.Fprintln(w, "\nNext step (manual):")
-	fmt.Fprintf(w, "  Open %s and grant the service account access in Play Console.\n", r.PlayLinkURL)
+	fmt.Fprintln(w, "\nLast step — grant access in Play Console:")
+	if r.BrowserOpened {
+		fmt.Fprintln(w, "  Opened Play Console in your browser (service account email copied to clipboard).")
+	}
+	fmt.Fprintf(w, "  %s\n", r.PlayLinkURL)
+	fmt.Fprintf(w, "  Grant %s access, then verify with `gplay auth doctor`.\n", r.ServiceAcct)
 }
 
 // validateServiceAccountKey sanity-checks that the downloaded file is a
@@ -333,7 +509,7 @@ func validateServiceAccountKey(path string) error {
 	return nil
 }
 
-// saveProfileToConfig is the real SaveConfig hook for AuthSetupCommand.
+// saveProfileToConfig is the real SaveConfig hook for the setup command.
 func saveProfileToConfig(profile config.Profile, setDefault bool) (string, error) {
 	cfg, err := config.Load()
 	if err != nil && !errors.Is(err, config.ErrNotFound) {

--- a/internal/cli/auth/setup_test.go
+++ b/internal/cli/auth/setup_test.go
@@ -17,6 +17,20 @@ type fakeRunner struct {
 	calls       [][]string
 	// responses keyed by first two args joined by space (e.g. "gcloud config").
 	responses map[string]runResponse
+
+	// Install/browser/clipboard stubs.
+	installErr       error
+	installFixesPath bool // when true, LookPath succeeds after InstallGcloud ran
+	installed        bool
+	interactiveErr   error
+	interactiveCalls [][]string
+	openedURL        string
+	copiedText       string
+
+	// authListSeq, when set, is consumed one entry per `gcloud auth list` call
+	// (falls back to the responses map once exhausted). Lets a test simulate
+	// "unauthenticated, then authenticated after login".
+	authListSeq []runResponse
 }
 
 type runResponse struct {
@@ -25,7 +39,7 @@ type runResponse struct {
 }
 
 func (f *fakeRunner) LookPath(name string) (string, error) {
-	if f.lookPathErr != nil {
+	if f.lookPathErr != nil && (!f.installFixesPath || !f.installed) {
 		return "", f.lookPathErr
 	}
 	return "/usr/local/bin/" + name, nil
@@ -34,6 +48,11 @@ func (f *fakeRunner) LookPath(name string) (string, error) {
 func (f *fakeRunner) Run(ctx context.Context, stdin []byte, name string, args ...string) ([]byte, error) {
 	argv := append([]string{name}, args...)
 	f.calls = append(f.calls, argv)
+	if len(f.authListSeq) > 0 && matchesPrefix(argv, []string{"gcloud", "auth", "list"}) {
+		resp := f.authListSeq[0]
+		f.authListSeq = f.authListSeq[1:]
+		return resp.stdout, resp.err
+	}
 	for key, resp := range f.responses {
 		parts := strings.Fields(key)
 		if matchesPrefix(argv, parts) {
@@ -42,6 +61,29 @@ func (f *fakeRunner) Run(ctx context.Context, stdin []byte, name string, args ..
 	}
 	return nil, nil
 }
+
+func (f *fakeRunner) RunInteractive(ctx context.Context, name string, args ...string) error {
+	f.interactiveCalls = append(f.interactiveCalls, append([]string{name}, args...))
+	return f.interactiveErr
+}
+
+func (f *fakeRunner) InstallGcloud(ctx context.Context) error {
+	f.installed = true
+	return f.installErr
+}
+
+func (f *fakeRunner) OpenBrowser(url string) error {
+	f.openedURL = url
+	return nil
+}
+
+func (f *fakeRunner) Copy(text string) error {
+	f.copiedText = text
+	return nil
+}
+
+// activeAccount is the canned response that marks gcloud as authenticated.
+var activeAccount = runResponse{stdout: []byte("dev@example.com\n")}
 
 func matchesPrefix(argv, prefix []string) bool {
 	if len(prefix) > len(argv) {
@@ -76,17 +118,108 @@ func TestRunSetupRequiresAuto(t *testing.T) {
 	}
 }
 
-func TestRunSetupRequiresGcloud(t *testing.T) {
+func TestRunSetupRequiresGcloudWhenNoInstall(t *testing.T) {
 	runner := &fakeRunner{lookPathErr: errors.New("not found")}
-	err := RunSetup(context.Background(), SetupOptions{Auto: true, Runner: runner}, os.Stdout)
+	err := RunSetup(context.Background(), SetupOptions{Auto: true, NoInstall: true, Runner: runner}, os.Stdout)
 	if err == nil || !strings.Contains(err.Error(), "gcloud") {
 		t.Fatalf("expected gcloud error, got %v", err)
+	}
+	if runner.installed {
+		t.Error("should not attempt install when --no-install is set")
+	}
+}
+
+func TestRunSetupInstallsGcloudWhenMissing(t *testing.T) {
+	tmp := t.TempDir()
+	keyOut := filepath.Join(tmp, "sa.json")
+	runner := &fakeRunner{
+		lookPathErr:      errors.New("not found"),
+		installFixesPath: true,
+		responses: map[string]runResponse{
+			"gcloud auth list":                        activeAccount,
+			"gcloud config get-value project":         {stdout: []byte("my-proj\n")},
+			"gcloud iam service-accounts describe":    {err: errors.New("not found")},
+			"gcloud iam service-accounts keys create": {},
+		},
+	}
+	writeFakeKey(t, keyOut)
+	opts := SetupOptions{
+		Auto:       true,
+		Project:    "my-proj",
+		Runner:     runner,
+		KeyOut:     keyOut,
+		NoBrowser:  true,
+		HomeDir:    func() (string, error) { return tmp, nil },
+		SaveConfig: func(config.Profile, bool) (string, error) { return "", nil },
+		Output:     "json",
+	}
+	if err := RunSetup(context.Background(), opts, os.Stdout); err != nil {
+		t.Fatalf("RunSetup: %v", err)
+	}
+	if !runner.installed {
+		t.Error("expected InstallGcloud to be called when gcloud is missing")
+	}
+}
+
+func TestRunSetupLogsInWhenNotAuthenticated(t *testing.T) {
+	tmp := t.TempDir()
+	keyOut := filepath.Join(tmp, "sa.json")
+	runner := &fakeRunner{
+		// Empty first (unauthenticated), active after login runs.
+		authListSeq: []runResponse{{}, activeAccount},
+		responses: map[string]runResponse{
+			"gcloud config get-value project":         {stdout: []byte("my-proj\n")},
+			"gcloud iam service-accounts describe":    {err: errors.New("not found")},
+			"gcloud iam service-accounts keys create": {},
+		},
+	}
+	writeFakeKey(t, keyOut)
+	opts := SetupOptions{
+		Auto:       true,
+		Project:    "my-proj",
+		Runner:     runner,
+		KeyOut:     keyOut,
+		HomeDir:    func() (string, error) { return tmp, nil },
+		SaveConfig: func(config.Profile, bool) (string, error) { return "", nil },
+		Output:     "json",
+	}
+	if err := RunSetup(context.Background(), opts, os.Stdout); err != nil {
+		t.Fatalf("RunSetup: %v", err)
+	}
+	if len(runner.interactiveCalls) != 1 {
+		t.Fatalf("expected one interactive login call, got %v", runner.interactiveCalls)
+	}
+	got := strings.Join(runner.interactiveCalls[0], " ")
+	if got != "gcloud auth login" {
+		t.Errorf("expected `gcloud auth login`, got %q", got)
+	}
+}
+
+func TestRunSetupNoBrowserFailsWhenUnauthenticated(t *testing.T) {
+	runner := &fakeRunner{
+		responses: map[string]runResponse{
+			// no "gcloud auth list" response -> empty -> unauthenticated
+			"gcloud config get-value project": {stdout: []byte("my-proj\n")},
+		},
+	}
+	err := RunSetup(context.Background(), SetupOptions{
+		Auto:      true,
+		Project:   "my-proj",
+		NoBrowser: true,
+		Runner:    runner,
+	}, os.Stdout)
+	if err == nil || !strings.Contains(err.Error(), "gcloud auth login") {
+		t.Fatalf("expected auth login guidance, got %v", err)
+	}
+	if len(runner.interactiveCalls) != 0 {
+		t.Error("should not launch interactive login with --no-browser")
 	}
 }
 
 func TestRunSetupRequiresProject(t *testing.T) {
 	runner := &fakeRunner{
 		responses: map[string]runResponse{
+			"gcloud auth list":                activeAccount,
 			"gcloud config get-value project": {stdout: []byte("(unset)\n")},
 		},
 	}
@@ -125,6 +258,7 @@ func TestRunSetupHappyPathCreatesKeyAndConfig(t *testing.T) {
 	keyOut := filepath.Join(tmp, "sa.json")
 	runner := &fakeRunner{
 		responses: map[string]runResponse{
+			"gcloud auth list":                activeAccount,
 			"gcloud config get-value project": {stdout: []byte("my-proj\n")},
 			// describe returns error -> triggers create
 			"gcloud iam service-accounts describe": {err: errors.New("not found")},
@@ -160,6 +294,42 @@ func TestRunSetupHappyPathCreatesKeyAndConfig(t *testing.T) {
 	// gcloud should have been invoked at least 4 times.
 	if len(runner.calls) < 4 {
 		t.Errorf("expected >=4 gcloud calls, got %d", len(runner.calls))
+	}
+	// Final step opens Play Console and copies the SA email to the clipboard.
+	if runner.openedURL == "" {
+		t.Error("expected Play Console to be opened in the browser")
+	}
+	if !strings.Contains(runner.copiedText, "@my-proj.iam.gserviceaccount.com") {
+		t.Errorf("expected SA email copied to clipboard, got %q", runner.copiedText)
+	}
+}
+
+func TestRunSetupNoBrowserSkipsOpen(t *testing.T) {
+	tmp := t.TempDir()
+	keyOut := filepath.Join(tmp, "sa.json")
+	runner := &fakeRunner{
+		responses: map[string]runResponse{
+			"gcloud auth list":                        activeAccount,
+			"gcloud iam service-accounts describe":    {err: errors.New("not found")},
+			"gcloud iam service-accounts keys create": {},
+		},
+	}
+	writeFakeKey(t, keyOut)
+	opts := SetupOptions{
+		Auto:       true,
+		Project:    "my-proj",
+		Runner:     runner,
+		KeyOut:     keyOut,
+		NoBrowser:  true,
+		HomeDir:    func() (string, error) { return tmp, nil },
+		SaveConfig: func(config.Profile, bool) (string, error) { return "", nil },
+		Output:     "json",
+	}
+	if err := RunSetup(context.Background(), opts, os.Stdout); err != nil {
+		t.Fatalf("RunSetup: %v", err)
+	}
+	if runner.openedURL != "" {
+		t.Errorf("expected no browser open with --no-browser, got %q", runner.openedURL)
 	}
 }
 
@@ -202,5 +372,18 @@ func TestAuthSetupCommandRegistered(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected setup subcommand registered on auth")
+	}
+}
+
+func TestTopLevelSetupCommand(t *testing.T) {
+	cmd := SetupCommand()
+	if cmd.Name != "setup" {
+		t.Errorf("expected top-level command name 'setup', got %q", cmd.Name)
+	}
+	if !strings.Contains(cmd.ShortUsage, "gplay setup") {
+		t.Errorf("expected usage to mention `gplay setup`, got %q", cmd.ShortUsage)
+	}
+	if cmd.FlagSet.Lookup("auto") == nil {
+		t.Error("expected --auto flag on top-level setup command")
 	}
 }

--- a/internal/cli/checks/apps.go
+++ b/internal/cli/checks/apps.go
@@ -1,0 +1,130 @@
+package checks
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	checksapi "google.golang.org/api/checks/v1alpha"
+
+	"github.com/tamtom/play-console-cli/internal/checksclient"
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+func AppsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks apps", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "apps",
+		ShortUsage: "gplay checks apps <subcommand> [flags]",
+		ShortHelp:  "List and inspect apps connected to Checks.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			AppsListCommand(),
+			AppsGetCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func AppsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks apps list", flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	pageSize := fs.Int("page-size", 10, "Results per page (1-50)")
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "gplay checks apps list --account <account-id> [flags]",
+		ShortHelp:  "List apps under a Checks account.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if err := validatePageSize(*pageSize); err != nil {
+				return err
+			}
+			resolvedAccount, err := resolveAccountForCommand(*account)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(resolvedAccount) == "" {
+				return shared.UsageError("--account is required (or set GPLAY_CHECKS_ACCOUNT/checks_account)")
+			}
+			service, err := checksclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			call := service.API.Accounts.Apps.List(accountResource(resolvedAccount)).Context(ctx).PageSize(int64(*pageSize))
+			if !*paginate {
+				resp, err := call.Do()
+				if err != nil {
+					return shared.WrapGoogleAPIError("list Checks apps", err)
+				}
+				return shared.PrintOutput(resp, *outputFlag, *pretty)
+			}
+			var all []*checksapi.GoogleChecksAccountV1alphaApp
+			err = call.Pages(ctx, func(resp *checksapi.GoogleChecksAccountV1alphaListAppsResponse) error {
+				all = append(all, resp.Apps...)
+				return nil
+			})
+			if err != nil {
+				return shared.WrapGoogleAPIError("list Checks apps", err)
+			}
+			return shared.PrintOutput(all, *outputFlag, *pretty)
+		},
+	}
+}
+
+func AppsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks apps get", flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	app := fs.String("app", "", "Checks app ID or resource name")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "gplay checks apps get --account <account-id> --app <app-id> [flags]",
+		ShortHelp:  "Get a Checks app.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*app) == "" {
+				return shared.UsageError("--app is required")
+			}
+			resolvedAccount, err := resolveAccountForCommand(*account)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(resolvedAccount) == "" {
+				return shared.UsageError("--account is required (or set GPLAY_CHECKS_ACCOUNT/checks_account)")
+			}
+			service, err := checksclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.API.Accounts.Apps.Get(appResource(resolvedAccount, *app)).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("get Checks app", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}

--- a/internal/cli/checks/checks.go
+++ b/internal/cli/checks/checks.go
@@ -1,0 +1,45 @@
+package checks
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+// ChecksCommand returns the Checks API command group.
+func ChecksCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "checks",
+		ShortUsage: "gplay checks <subcommand> [flags]",
+		ShortHelp:  "Analyze app privacy, compliance, and AI safety with the Google Checks API.",
+		LongHelp: `Analyze app privacy, compliance, and AI safety with the Google Checks API.
+
+Checks commands use the https://www.googleapis.com/auth/checks OAuth scope and
+the https://checks.googleapis.com/v1alpha API surface. App bundle analysis uses
+the current media upload endpoint, /upload/v1alpha/{parent=accounts/*/apps/*}/reports:analyzeUpload.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			AppsCommand(),
+			ReportsCommand(),
+			OperationsCommand(),
+			UploadCommand("upload"),
+			UploadCommand("analyze"),
+			ContentCommand(),
+			ClassifyCommand("classify"),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) == 0 {
+				return flag.ErrHelp
+			}
+			fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n", args[0])
+			return flag.ErrHelp
+		},
+	}
+}

--- a/internal/cli/checks/content.go
+++ b/internal/cli/checks/content.go
@@ -1,0 +1,110 @@
+package checks
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	checksapi "google.golang.org/api/checks/v1alpha"
+
+	"github.com/tamtom/play-console-cli/internal/checksclient"
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+func ContentCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks content", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "content",
+		ShortUsage: "gplay checks content <subcommand> [flags]",
+		ShortHelp:  "Classify app content with Checks AI safety policies.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			ClassifyCommand("classify", "gplay checks content classify --text <content> [flags]"),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func ClassifyCommand(name string, usageOverride ...string) *ffcli.Command {
+	fs := flag.NewFlagSet("checks "+name, flag.ExitOnError)
+	text := fs.String("text", "", "Text content to classify, or @file")
+	language := fs.String("language", "", "ISO 639-1 language code")
+	policies := fs.String("policies", "all", "Comma-separated policies, or all")
+	contextPrompt := fs.String("context", "", "Prompt or context that generated the content")
+	classifierVersion := fs.String("classifier-version", "", "Classifier version: STABLE or LATEST")
+	severityThreshold := fs.Bool("severity-threshold", false, "Fail if any policy result is VIOLATIVE")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	usage := "gplay checks content classify --text <content> [flags]"
+	if name == "classify" {
+		usage = "gplay checks classify --text <content> [flags]"
+	}
+	if len(usageOverride) > 0 && strings.TrimSpace(usageOverride[0]) != "" {
+		usage = usageOverride[0]
+	}
+
+	return &ffcli.Command{
+		Name:       name,
+		ShortUsage: usage,
+		ShortHelp:  "Classify text content against Checks AI safety policies.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*text) == "" {
+				return shared.UsageError("--text is required")
+			}
+			if v := strings.ToUpper(strings.TrimSpace(*classifierVersion)); v != "" && v != "STABLE" && v != "LATEST" {
+				return shared.UsageError("--classifier-version must be STABLE or LATEST")
+			}
+			policyConfigs, err := parsePolicies(*policies)
+			if err != nil {
+				return err
+			}
+			inputText, err := readTextArg(*text)
+			if err != nil {
+				return err
+			}
+			service, err := checksclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			reqCtx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			req := &checksapi.GoogleChecksAisafetyV1alphaClassifyContentRequest{
+				Input: &checksapi.GoogleChecksAisafetyV1alphaClassifyContentRequestInputContent{
+					TextInput: &checksapi.GoogleChecksAisafetyV1alphaTextInput{
+						Content:      inputText,
+						LanguageCode: strings.TrimSpace(*language),
+					},
+				},
+				Policies:          policyConfigs,
+				ClassifierVersion: strings.ToUpper(strings.TrimSpace(*classifierVersion)),
+			}
+			if strings.TrimSpace(*contextPrompt) != "" {
+				req.Context = &checksapi.GoogleChecksAisafetyV1alphaClassifyContentRequestContext{
+					Prompt: strings.TrimSpace(*contextPrompt),
+				}
+			}
+			resp, err := service.API.Aisafety.ClassifyContent(req).Context(reqCtx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("classify content with Checks", err)
+			}
+			if *severityThreshold && classificationViolates(resp) {
+				if printErr := shared.PrintOutput(resp, *outputFlag, *pretty); printErr != nil {
+					return printErr
+				}
+				return errThresholdExceeded
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}

--- a/internal/cli/checks/helpers.go
+++ b/internal/cli/checks/helpers.go
@@ -1,0 +1,230 @@
+package checks
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	checksapi "google.golang.org/api/checks/v1alpha"
+
+	"github.com/tamtom/play-console-cli/internal/checksclient"
+	"github.com/tamtom/play-console-cli/internal/config"
+)
+
+var errThresholdExceeded = errors.New("checks severity threshold exceeded")
+
+var severityRank = map[string]int{
+	"OPPORTUNITY": 1,
+	"POTENTIAL":   2,
+	"PRIORITY":    3,
+}
+
+var policyTypes = []string{
+	"DANGEROUS_CONTENT",
+	"PII_SOLICITING_RECITING",
+	"HARASSMENT",
+	"SEXUALLY_EXPLICIT",
+	"HATE_SPEECH",
+	"MEDICAL_INFO",
+	"VIOLENCE_AND_GORE",
+	"OBSCENITY_AND_PROFANITY",
+}
+
+func accountResource(account string) string {
+	account = strings.Trim(strings.TrimSpace(account), "/")
+	if strings.HasPrefix(account, "accounts/") {
+		return account
+	}
+	return "accounts/" + account
+}
+
+func appResource(account, app string) string {
+	app = strings.Trim(strings.TrimSpace(app), "/")
+	if strings.HasPrefix(app, "accounts/") {
+		return app
+	}
+	if strings.HasPrefix(app, "apps/") {
+		return accountResource(account) + "/" + app
+	}
+	return accountResource(account) + "/apps/" + app
+}
+
+func reportResource(account, app, report string) string {
+	report = strings.Trim(strings.TrimSpace(report), "/")
+	if strings.HasPrefix(report, "accounts/") {
+		return report
+	}
+	if strings.HasPrefix(report, "reports/") {
+		return appResource(account, app) + "/" + report
+	}
+	return appResource(account, app) + "/reports/" + report
+}
+
+func operationResource(account, app, operation string) string {
+	operation = strings.Trim(strings.TrimSpace(operation), "/")
+	if strings.HasPrefix(operation, "accounts/") {
+		return operation
+	}
+	if strings.HasPrefix(operation, "operations/") {
+		return appResource(account, app) + "/" + operation
+	}
+	return appResource(account, app) + "/operations/" + operation
+}
+
+func validatePageSize(pageSize int) error {
+	if pageSize < 1 || pageSize > 50 {
+		return fmt.Errorf("--page-size must be between 1 and 50")
+	}
+	return nil
+}
+
+func validateAppBinaryFileType(value string) error {
+	switch strings.TrimSpace(value) {
+	case "", "APP_BINARY_FILE_TYPE_UNSPECIFIED", "ANDROID_APK", "ANDROID_AAB", "IOS_IPA":
+		return nil
+	default:
+		return fmt.Errorf("--binary-type must be one of ANDROID_APK, ANDROID_AAB, IOS_IPA")
+	}
+}
+
+func validateSeverityThreshold(value string) error {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	if value == "" {
+		return nil
+	}
+	if _, ok := severityRank[value]; !ok {
+		return fmt.Errorf("--severity-threshold must be one of PRIORITY, POTENTIAL, OPPORTUNITY")
+	}
+	return nil
+}
+
+func reportExceedsThreshold(report *checksapi.GoogleChecksReportV1alphaReport, threshold string) bool {
+	threshold = strings.ToUpper(strings.TrimSpace(threshold))
+	if threshold == "" || report == nil {
+		return false
+	}
+	minRank, ok := severityRank[threshold]
+	if !ok {
+		return false
+	}
+	for _, check := range report.Checks {
+		if check == nil || check.State != "FAILED" {
+			continue
+		}
+		if severityRank[strings.ToUpper(check.Severity)] >= minRank {
+			return true
+		}
+	}
+	return false
+}
+
+func classificationViolates(resp *checksapi.GoogleChecksAisafetyV1alphaClassifyContentResponse) bool {
+	if resp == nil {
+		return false
+	}
+	for _, result := range resp.PolicyResults {
+		if result != nil && result.ViolationResult == "VIOLATIVE" {
+			return true
+		}
+	}
+	return false
+}
+
+func reportFromOperation(op *checksapi.Operation) (*checksapi.GoogleChecksReportV1alphaReport, error) {
+	if op == nil || len(op.Response) == 0 {
+		return nil, nil
+	}
+	var report checksapi.GoogleChecksReportV1alphaReport
+	if err := json.Unmarshal(op.Response, &report); err != nil {
+		return nil, fmt.Errorf("decode operation response as report: %w", err)
+	}
+	return &report, nil
+}
+
+func requireOperationDone(op *checksapi.Operation) error {
+	if op == nil {
+		return fmt.Errorf("operation response was empty")
+	}
+	if op.Error != nil {
+		return fmt.Errorf("operation failed: %s", op.Error.Message)
+	}
+	if !op.Done {
+		return fmt.Errorf("operation is still running")
+	}
+	return nil
+}
+
+func readTextArg(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "@") {
+		path := strings.TrimPrefix(value, "@")
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", fmt.Errorf("read text file: %w", err)
+		}
+		return string(data), nil
+	}
+	return value, nil
+}
+
+func mediaTypeForPath(path string) string {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".apk":
+		return "application/vnd.android.package-archive"
+	case ".aab":
+		return "application/octet-stream"
+	case ".ipa":
+		return "application/octet-stream"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func parsePolicies(value string) ([]*checksapi.GoogleChecksAisafetyV1alphaClassifyContentRequestPolicyConfig, error) {
+	var values []string
+	if strings.TrimSpace(value) == "" || strings.EqualFold(strings.TrimSpace(value), "all") {
+		values = policyTypes
+	} else {
+		values = strings.Split(value, ",")
+	}
+	allowed := make(map[string]bool, len(policyTypes))
+	for _, policy := range policyTypes {
+		allowed[policy] = true
+	}
+	policies := make([]*checksapi.GoogleChecksAisafetyV1alphaClassifyContentRequestPolicyConfig, 0, len(values))
+	for _, raw := range values {
+		policy := strings.ToUpper(strings.TrimSpace(raw))
+		if policy == "" {
+			continue
+		}
+		if !allowed[policy] {
+			return nil, fmt.Errorf("unsupported policy %q", policy)
+		}
+		policies = append(policies, &checksapi.GoogleChecksAisafetyV1alphaClassifyContentRequestPolicyConfig{
+			PolicyType: policy,
+		})
+	}
+	if len(policies) == 0 {
+		return nil, fmt.Errorf("--policies must include at least one policy")
+	}
+	return policies, nil
+}
+
+func formatWaitTimeout(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.0fs", d.Seconds())
+}
+
+func resolveAccountForCommand(flagValue string) (string, error) {
+	cfg, err := config.Load()
+	if err != nil && !errors.Is(err, config.ErrNotFound) {
+		return "", fmt.Errorf("load config: %w", err)
+	}
+	return checksclient.ResolveAccount(flagValue, cfg), nil
+}

--- a/internal/cli/checks/helpers_test.go
+++ b/internal/cli/checks/helpers_test.go
@@ -1,0 +1,69 @@
+package checks
+
+import (
+	"errors"
+	"testing"
+
+	checksapi "google.golang.org/api/checks/v1alpha"
+)
+
+func TestReportExceedsThreshold(t *testing.T) {
+	report := &checksapi.GoogleChecksReportV1alphaReport{
+		Checks: []*checksapi.GoogleChecksReportV1alphaCheck{
+			{State: "FAILED", Severity: "POTENTIAL"},
+			{State: "PASSED", Severity: "PRIORITY"},
+		},
+	}
+	if !reportExceedsThreshold(report, "OPPORTUNITY") {
+		t.Fatal("expected failed POTENTIAL check to exceed OPPORTUNITY")
+	}
+	if !reportExceedsThreshold(report, "POTENTIAL") {
+		t.Fatal("expected failed POTENTIAL check to exceed POTENTIAL")
+	}
+	if reportExceedsThreshold(report, "PRIORITY") {
+		t.Fatal("did not expect failed POTENTIAL check to exceed PRIORITY")
+	}
+}
+
+func TestClassificationViolates(t *testing.T) {
+	resp := &checksapi.GoogleChecksAisafetyV1alphaClassifyContentResponse{
+		PolicyResults: []*checksapi.GoogleChecksAisafetyV1alphaClassifyContentResponsePolicyResult{
+			{ViolationResult: "NON_VIOLATIVE"},
+			{ViolationResult: "VIOLATIVE"},
+		},
+	}
+	if !classificationViolates(resp) {
+		t.Fatal("expected VIOLATIVE result to fail classification threshold")
+	}
+}
+
+func TestParsePolicies_All(t *testing.T) {
+	policies, err := parsePolicies("all")
+	if err != nil {
+		t.Fatalf("parsePolicies returned error: %v", err)
+	}
+	if len(policies) != len(policyTypes) {
+		t.Fatalf("got %d policies, want %d", len(policies), len(policyTypes))
+	}
+}
+
+func TestParsePolicies_Invalid(t *testing.T) {
+	_, err := parsePolicies("BAD_POLICY")
+	if err == nil {
+		t.Fatal("expected invalid policy error")
+	}
+}
+
+func TestUploadCommandHasChecksFilter(t *testing.T) {
+	for _, name := range []string{"upload", "analyze"} {
+		if UploadCommand(name).FlagSet.Lookup("checks-filter") == nil {
+			t.Fatalf("%q command should define --checks-filter", name)
+		}
+	}
+}
+
+func TestThresholdErrorIsStable(t *testing.T) {
+	if !errors.Is(errThresholdExceeded, errThresholdExceeded) {
+		t.Fatal("threshold sentinel should be comparable through errors.Is")
+	}
+}

--- a/internal/cli/checks/operations.go
+++ b/internal/cli/checks/operations.go
@@ -1,0 +1,202 @@
+package checks
+
+import (
+	"context"
+	"flag"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	checksapi "google.golang.org/api/checks/v1alpha"
+
+	"github.com/tamtom/play-console-cli/internal/checksclient"
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+func OperationsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks operations", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "operations",
+		ShortUsage: "gplay checks operations <subcommand> [flags]",
+		ShortHelp:  "Manage Checks app analysis operations.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			OperationsGetCommand(),
+			OperationsWaitCommand(),
+			OperationsCancelCommand(),
+			OperationsListCommand(),
+			OperationsDeleteCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func OperationsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks operations get", flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	app := fs.String("app", "", "Checks app ID or resource name")
+	operation := fs.String("operation", "", "Operation ID or resource name")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return operationCommand("get", "gplay checks operations get --account <account-id> --app <app-id> --operation <operation-id> [flags]", "Get a Checks operation.", fs, outputFlag, pretty, account, app, operation, func(ctx context.Context, service *checksclient.Service, name string) (any, error) {
+		return service.API.Accounts.Apps.Operations.Get(name).Context(ctx).Do()
+	})
+}
+
+func OperationsWaitCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks operations wait", flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	app := fs.String("app", "", "Checks app ID or resource name")
+	operation := fs.String("operation", "", "Operation ID or resource name")
+	timeout := fs.Duration("timeout", 10*time.Minute, "Maximum time to wait")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return operationCommand("wait", "gplay checks operations wait --account <account-id> --app <app-id> --operation <operation-id> [flags]", "Wait for a Checks operation.", fs, outputFlag, pretty, account, app, operation, func(ctx context.Context, service *checksclient.Service, name string) (any, error) {
+		return service.API.Accounts.Apps.Operations.Wait(name, &checksapi.WaitOperationRequest{
+			Timeout: formatWaitTimeout(*timeout),
+		}).Context(ctx).Do()
+	})
+}
+
+func OperationsCancelCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks operations cancel", flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	app := fs.String("app", "", "Checks app ID or resource name")
+	operation := fs.String("operation", "", "Operation ID or resource name")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return operationCommand("cancel", "gplay checks operations cancel --account <account-id> --app <app-id> --operation <operation-id> [flags]", "Cancel a Checks operation.", fs, outputFlag, pretty, account, app, operation, func(ctx context.Context, service *checksclient.Service, name string) (any, error) {
+		resp, err := service.API.Accounts.Apps.Operations.Cancel(name, &checksapi.CancelOperationRequest{}).Context(ctx).Do()
+		if err != nil {
+			return nil, err
+		}
+		return resp, nil
+	})
+}
+
+func OperationsDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks operations delete", flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	app := fs.String("app", "", "Checks app ID or resource name")
+	operation := fs.String("operation", "", "Operation ID or resource name")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return operationCommand("delete", "gplay checks operations delete --account <account-id> --app <app-id> --operation <operation-id> [flags]", "Delete a Checks operation.", fs, outputFlag, pretty, account, app, operation, func(ctx context.Context, service *checksclient.Service, name string) (any, error) {
+		resp, err := service.API.Accounts.Apps.Operations.Delete(name).Context(ctx).Do()
+		if err != nil {
+			return nil, err
+		}
+		return resp, nil
+	})
+}
+
+func OperationsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks operations list", flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	app := fs.String("app", "", "Checks app ID or resource name")
+	filter := fs.String("filter", "", "AIP-160 filter for operations")
+	pageSize := fs.Int("page-size", 10, "Results per page (1-50)")
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "gplay checks operations list --account <account-id> --app <app-id> [flags]",
+		ShortHelp:  "List Checks operations for an app.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if err := validatePageSize(*pageSize); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*app) == "" {
+				return shared.UsageError("--app is required")
+			}
+			resolvedAccount, err := resolveAccountForCommand(*account)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(resolvedAccount) == "" {
+				return shared.UsageError("--account is required (or set GPLAY_CHECKS_ACCOUNT/checks_account)")
+			}
+			service, err := checksclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			call := service.API.Accounts.Apps.Operations.List(appResource(resolvedAccount, *app)).Context(ctx).PageSize(int64(*pageSize))
+			if strings.TrimSpace(*filter) != "" {
+				call.Filter(*filter)
+			}
+			if !*paginate {
+				resp, err := call.Do()
+				if err != nil {
+					return shared.WrapGoogleAPIError("list Checks operations", err)
+				}
+				return shared.PrintOutput(resp, *outputFlag, *pretty)
+			}
+			var all []*checksapi.Operation
+			err = call.Pages(ctx, func(resp *checksapi.ListOperationsResponse) error {
+				all = append(all, resp.Operations...)
+				return nil
+			})
+			if err != nil {
+				return shared.WrapGoogleAPIError("list Checks operations", err)
+			}
+			return shared.PrintOutput(all, *outputFlag, *pretty)
+		},
+	}
+}
+
+func operationCommand(name, usage, help string, fs *flag.FlagSet, outputFlag *string, pretty *bool, account *string, app *string, operation *string, run func(context.Context, *checksclient.Service, string) (any, error)) *ffcli.Command {
+	return &ffcli.Command{
+		Name:       name,
+		ShortUsage: usage,
+		ShortHelp:  help,
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*app) == "" {
+				return shared.UsageError("--app is required")
+			}
+			if strings.TrimSpace(*operation) == "" {
+				return shared.UsageError("--operation is required")
+			}
+			resolvedAccount, err := resolveAccountForCommand(*account)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(resolvedAccount) == "" {
+				return shared.UsageError("--account is required (or set GPLAY_CHECKS_ACCOUNT/checks_account)")
+			}
+			service, err := checksclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := run(ctx, service, operationResource(resolvedAccount, *app, *operation))
+			if err != nil {
+				return shared.WrapGoogleAPIError(name+" Checks operation", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}

--- a/internal/cli/checks/reports.go
+++ b/internal/cli/checks/reports.go
@@ -1,0 +1,151 @@
+package checks
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	checksapi "google.golang.org/api/checks/v1alpha"
+
+	"github.com/tamtom/play-console-cli/internal/checksclient"
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+func ReportsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks reports", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "reports",
+		ShortUsage: "gplay checks reports <subcommand> [flags]",
+		ShortHelp:  "List and inspect Checks compliance reports.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			ReportsListCommand(),
+			ReportsGetCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func ReportsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks reports list", flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	app := fs.String("app", "", "Checks app ID or resource name")
+	filter := fs.String("filter", "", "AIP-160 filter for reports")
+	checksFilter := fs.String("checks-filter", "", "AIP-160 filter for checks within reports")
+	pageSize := fs.Int("page-size", 10, "Results per page (1-50)")
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "gplay checks reports list --account <account-id> --app <app-id> [flags]",
+		ShortHelp:  "List Checks reports for an app.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if err := validatePageSize(*pageSize); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*app) == "" {
+				return shared.UsageError("--app is required")
+			}
+			resolvedAccount, err := resolveAccountForCommand(*account)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(resolvedAccount) == "" {
+				return shared.UsageError("--account is required (or set GPLAY_CHECKS_ACCOUNT/checks_account)")
+			}
+			service, err := checksclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			call := service.API.Accounts.Apps.Reports.List(appResource(resolvedAccount, *app)).Context(ctx).PageSize(int64(*pageSize))
+			if strings.TrimSpace(*filter) != "" {
+				call.Filter(*filter)
+			}
+			if strings.TrimSpace(*checksFilter) != "" {
+				call.ChecksFilter(*checksFilter)
+			}
+			if !*paginate {
+				resp, err := call.Do()
+				if err != nil {
+					return shared.WrapGoogleAPIError("list Checks reports", err)
+				}
+				return shared.PrintOutput(resp, *outputFlag, *pretty)
+			}
+			var all []*checksapi.GoogleChecksReportV1alphaReport
+			err = call.Pages(ctx, func(resp *checksapi.GoogleChecksReportV1alphaListReportsResponse) error {
+				all = append(all, resp.Reports...)
+				return nil
+			})
+			if err != nil {
+				return shared.WrapGoogleAPIError("list Checks reports", err)
+			}
+			return shared.PrintOutput(all, *outputFlag, *pretty)
+		},
+	}
+}
+
+func ReportsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("checks reports get", flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	app := fs.String("app", "", "Checks app ID or resource name")
+	report := fs.String("report", "", "Checks report ID or resource name")
+	checksFilter := fs.String("checks-filter", "", "AIP-160 filter for checks within the report")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "gplay checks reports get --account <account-id> --app <app-id> --report <report-id> [flags]",
+		ShortHelp:  "Get a Checks report.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*app) == "" {
+				return shared.UsageError("--app is required")
+			}
+			if strings.TrimSpace(*report) == "" {
+				return shared.UsageError("--report is required")
+			}
+			resolvedAccount, err := resolveAccountForCommand(*account)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(resolvedAccount) == "" {
+				return shared.UsageError("--account is required (or set GPLAY_CHECKS_ACCOUNT/checks_account)")
+			}
+			service, err := checksclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			call := service.API.Accounts.Apps.Reports.Get(reportResource(resolvedAccount, *app, *report)).Context(ctx)
+			if strings.TrimSpace(*checksFilter) != "" {
+				call.ChecksFilter(*checksFilter)
+			}
+			resp, err := call.Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("get Checks report", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}

--- a/internal/cli/checks/upload.go
+++ b/internal/cli/checks/upload.go
@@ -1,0 +1,180 @@
+package checks
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	checksapi "google.golang.org/api/checks/v1alpha"
+	"google.golang.org/api/googleapi"
+
+	"github.com/tamtom/play-console-cli/internal/checksclient"
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+func UploadCommand(name string) *ffcli.Command {
+	fs := flag.NewFlagSet("checks "+name, flag.ExitOnError)
+	account := fs.String("account", "", "Checks account ID (overrides GPLAY_CHECKS_ACCOUNT/checks_account)")
+	app := fs.String("app", "", "Checks app ID or resource name")
+	binaryPath := fs.String("binary", "", "Path to APK, AAB, or IPA file")
+	binaryType := fs.String("binary-type", "ANDROID_APK", "App binary file type: ANDROID_APK, ANDROID_AAB, IOS_IPA")
+	codeRef := fs.String("code-ref", "", "Git commit hash or changelist number for the upload")
+	checksFilter := fs.String("checks-filter", "", "AIP-160 filter for checks in the resulting report (e.g. state = FAILED)")
+	wait := fs.Bool("wait", true, "Wait for analysis to complete and print the report")
+	waitTimeout := fs.Duration("wait-timeout", 10*time.Minute, "Maximum time to wait for analysis")
+	severityThreshold := fs.String("severity-threshold", "", "Fail if a failed check meets severity: PRIORITY, POTENTIAL, OPPORTUNITY")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	shortUsage := "gplay checks " + name + " --account <account-id> --app <app-id> --binary <path> [flags]"
+	shortHelp := "Upload an app binary for Checks compliance analysis."
+	if name == "analyze" {
+		shortHelp = "Alias for `gplay checks upload`."
+	}
+
+	return &ffcli.Command{
+		Name:       name,
+		ShortUsage: shortUsage,
+		ShortHelp:  shortHelp,
+		LongHelp: `Upload an APK, AAB, or IPA to the Checks media upload endpoint and start
+an asynchronous compliance analysis.
+
+Use --severity-threshold PRIORITY in CI before release commands to fail the
+pipeline when high-priority failed checks are present. The command polls
+operations.get when --wait is true and prints progress to stderr.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*app) == "" {
+				return shared.UsageError("--app is required")
+			}
+			if strings.TrimSpace(*binaryPath) == "" {
+				return shared.UsageError("--binary is required")
+			}
+			if err := validateAppBinaryFileType(*binaryType); err != nil {
+				return err
+			}
+			if err := validateSeverityThreshold(*severityThreshold); err != nil {
+				return err
+			}
+			if *waitTimeout <= 0 {
+				return fmt.Errorf("--wait-timeout must be positive")
+			}
+			resolvedAccount, err := resolveAccountForCommand(*account)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(resolvedAccount) == "" {
+				return shared.UsageError("--account is required (or set GPLAY_CHECKS_ACCOUNT/checks_account)")
+			}
+			file, err := os.Open(*binaryPath)
+			if err != nil {
+				return fmt.Errorf("open binary: %w", err)
+			}
+			defer file.Close()
+
+			service, err := checksclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+
+			uploadCtx, cancel := shared.ContextWithUploadTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			req := &checksapi.GoogleChecksReportV1alphaAnalyzeUploadRequest{
+				AppBinaryFileType: strings.TrimSpace(*binaryType),
+				CodeReferenceId:   strings.TrimSpace(*codeRef),
+			}
+			parent := appResource(resolvedAccount, *app)
+			op, err := service.API.Media.Upload(parent, req).
+				Media(file, googleapi.ContentType(mediaTypeForPath(*binaryPath))).
+				Context(uploadCtx).
+				Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("upload app binary to Checks", err)
+			}
+			if shared.IsDryRun(ctx) || !*wait {
+				return shared.PrintOutput(op, *outputFlag, *pretty)
+			}
+
+			report, err := pollOperation(ctx, service, op, *waitTimeout)
+			if err != nil {
+				return err
+			}
+			if filter := strings.TrimSpace(*checksFilter); filter != "" && strings.TrimSpace(report.Name) != "" {
+				reqCtx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+				filtered, err := service.API.Accounts.Apps.Reports.Get(report.Name).ChecksFilter(filter).Context(reqCtx).Do()
+				cancel()
+				if err != nil {
+					return shared.WrapGoogleAPIError("get filtered Checks report", err)
+				}
+				report = filtered
+			}
+			if reportExceedsThreshold(report, *severityThreshold) {
+				if printErr := shared.PrintOutput(report, *outputFlag, *pretty); printErr != nil {
+					return printErr
+				}
+				return errThresholdExceeded
+			}
+			return shared.PrintOutput(report, *outputFlag, *pretty)
+		},
+	}
+}
+
+func pollOperation(ctx context.Context, service *checksclient.Service, op *checksapi.Operation, timeout time.Duration) (*checksapi.GoogleChecksReportV1alphaReport, error) {
+	if op == nil || strings.TrimSpace(op.Name) == "" {
+		return nil, fmt.Errorf("upload did not return an operation name")
+	}
+	deadline := time.Now().Add(timeout)
+	delay := 5 * time.Second
+	for {
+		if op.Done {
+			if err := requireOperationDone(op); err != nil {
+				return nil, err
+			}
+			report, err := reportFromOperation(op)
+			if err != nil {
+				return nil, err
+			}
+			if report == nil {
+				return nil, fmt.Errorf("operation completed without a report response")
+			}
+			return report, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("timed out waiting for Checks analysis after %s", timeout)
+		}
+		fmt.Fprintf(os.Stderr, "Analyzing... (operation: %s)\n", op.Name)
+		sleep := delay
+		if remaining := time.Until(deadline); sleep > remaining {
+			sleep = remaining
+		}
+		timer := time.NewTimer(sleep)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+		if delay < 30*time.Second {
+			delay *= 2
+			if delay > 30*time.Second {
+				delay = 30 * time.Second
+			}
+		}
+		reqCtx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+		next, err := service.API.Accounts.Apps.Operations.Get(op.Name).Context(reqCtx).Do()
+		cancel()
+		if err != nil {
+			return nil, shared.WrapGoogleAPIError("poll Checks analysis operation", err)
+		}
+		op = next
+	}
+}

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -93,6 +93,7 @@ func Subcommands(version string) []*ffcli.Command {
 func SubcommandsWithRuntime(version string, rt *cliruntime.Runtime) []*ffcli.Command {
 	return []*ffcli.Command{
 		auth.AuthCommand(),
+		auth.SetupCommand(),
 		apps.AppsCommand(rt),
 		auditcmd.AuditCommand(),
 		quota.QuotaCommand(),

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tamtom/play-console-cli/internal/cli/availability"
 	"github.com/tamtom/play-console-cli/internal/cli/baseplans"
 	"github.com/tamtom/play-console-cli/internal/cli/bundles"
+	"github.com/tamtom/play-console-cli/internal/cli/checks"
 	"github.com/tamtom/play-console-cli/internal/cli/completion"
 	"github.com/tamtom/play-console-cli/internal/cli/datasafety"
 	"github.com/tamtom/play-console-cli/internal/cli/deobfuscation"
@@ -100,6 +101,7 @@ func SubcommandsWithRuntime(version string, rt *cliruntime.Runtime) []*ffcli.Com
 		rtdncmd.RtdnCommand(),
 		edits.EditsCommand(),
 		bundles.BundlesCommand(),
+		checks.ChecksCommand(),
 		apks.APKsCommand(),
 		tracks.TracksCommand(),
 		users.UsersCommand(),

--- a/internal/cmdtest/checks_test.go
+++ b/internal/cmdtest/checks_test.go
@@ -1,0 +1,48 @@
+package cmdtest_test
+
+import (
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestChecks_Help(t *testing.T) {
+	stdout, stderr, err := runCommand(t, "checks")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected help error, got %v", err)
+	}
+	combined := stdout + stderr
+	for _, want := range []string{"checks", "apps", "reports", "operations", "upload", "analyze", "content", "classify"} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("help should mention %q, got: %q", want, combined)
+		}
+	}
+}
+
+func TestChecksAppsList_MissingAccount(t *testing.T) {
+	_, stderr, err := runCommand(t, "checks", "apps", "list")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--account is required") {
+		t.Fatalf("stderr should mention missing account, got: %q", stderr)
+	}
+}
+
+func TestChecksUpload_InvalidBinaryType(t *testing.T) {
+	_, _, err := runCommand(t, "checks", "upload", "--account", "123", "--app", "456", "--binary", "app.apk", "--binary-type", "BAD")
+	if err == nil || !strings.Contains(err.Error(), "--binary-type must be one of") {
+		t.Fatalf("expected binary type validation error, got %v", err)
+	}
+}
+
+func TestChecksContentClassify_MissingText(t *testing.T) {
+	_, stderr, err := runCommand(t, "checks", "content", "classify")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--text is required") {
+		t.Fatalf("stderr should mention missing text, got: %q", stderr)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,7 @@ type Config struct {
 	MaxRetries           int           `json:"max_retries,omitempty"`
 	RetryDelay           string        `json:"retry_delay,omitempty"`
 	Debug                string        `json:"debug"`
+	ChecksAccount        string        `json:"checks_account,omitempty"`
 }
 
 const maxConfigRetries = 30


### PR DESCRIPTION
Closes #200.

## Summary

Adds a `gplay checks` command group backed by a new `checksclient` package, integrating the Google Checks API (`checks/v1alpha`) for automated app privacy/compliance analysis and AI safety content classification. This complements `gplay data-safety` by *verifying* what an app actually does versus what it declares, and enables pre-submission compliance gating in CI/CD.

No new module dependencies — uses the already-vendored `google.golang.org/api`.

## Commands

| Command | Purpose |
|---|---|
| `checks apps list/get` | List/inspect Checks-connected apps |
| `checks analyze` / `checks upload` | Media-upload an APK/AAB/IPA, poll the async operation, print the report |
| `checks reports list/get` | Browse compliance reports (`--filter`, `--checks-filter`) |
| `checks operations get/wait/cancel/list/delete` | Manage long-running analysis operations |
| `checks classify` / `checks content classify` | AI safety content classification |

### CI/CD gating
`checks analyze --severity-threshold PRIORITY --checks-filter "state = FAILED"` polls to completion and **exits non-zero** when a failed check meets the threshold — chain it before `gplay publish`/`release` to block non-compliant builds. `checks classify --severity-threshold` exits non-zero on `VIOLATIVE` content.

## Implementation notes

- **Auth**: dedicated `checksclient` using the `https://www.googleapis.com/auth/checks` OAuth scope; account resolves flag > `GPLAY_CHECKS_ACCOUNT` env > `checks_account` config field.
- **Async polling**: exponential backoff (5s→30s), stderr progress, `--wait-timeout`, decodes the operation response as a `Report`.
- **`--checks-filter` on analyze**: implemented as a server-side re-fetch via `reports.get(...).ChecksFilter(...)` (reuses real AIP-160 filtering, not a client-side parser).
- Uses `shared.ContextWithTimeout` / `shared.ContextWithUploadTimeout`, `shared.DefaultUsageFunc`, and honors `--dry-run` for writes.
- Every API enum string (severities, states, policy types, classifier versions, binary types) cross-checked against the generated `checks-gen.go`.

## Validation

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt` + `gofumpt` clean
- [x] `make check-docs` passes (GPLAY.md regenerated from code)
- [x] `go test ./internal/checksclient/... ./internal/cli/checks/... ./internal/cmdtest/...` green
- [x] Repo pre-commit hook passed (credential scan, format, lint 0 issues, docs gate)

## Acceptance criteria (#200)

- [x] `checks --help` lists all subcommands
- [x] `apps list/get`, `reports list/get` with pagination + AIP-160 filters
- [x] `analyze` upload + `--wait` polling with stderr progress
- [x] `analyze --severity-threshold PRIORITY` exits 1 on critical failures
- [x] `operations get/wait/cancel` (plus `list`/`delete`)
- [x] `classify` + `classify --severity-threshold` exits 1 on violative content
- [x] `--output json/table/markdown` + `--pretty` on all commands
- [x] `checksclient` uses the checks OAuth scope; account flag > env > config
- [x] `--dry-run` for write operations
- [x] CLI-level tests for flag validation, error messages, output
- [x] Registered in `internal/cli/registry/registry.go`
- [x] CI/CD gating workflow documented (README + LongHelp + API_NOTES)
- [x] No new dependencies

## Docs

- `README.md`: new **Compliance (Google Checks)** section with the CI/CD gating example.
- `docs/API_NOTES.md`: Checks API resource/endpoint/enum reference.
- `GPLAY.md`: regenerated command reference (all `checks` subcommands + flags).

https://claude.ai/code/session_01LAPLzpiBYGLwHSLVkr6cXb