### PR TITLE
feat(games): Play Games Services management (achievements, leaderboards, players)

### DIFF
--- a/GPLAY.md
+++ b/GPLAY.md
@@ -232,6 +232,34 @@
 - [external-transactions create](#external-transactions-create)
 - [external-transactions get](#external-transactions-get)
 - [external-transactions refund](#external-transactions-refund)
+- [games](#games)
+- [games achievements](#games-achievements)
+- [games achievements list](#games-achievements-list)
+- [games achievements get](#games-achievements-get)
+- [games achievements create](#games-achievements-create)
+- [games achievements update](#games-achievements-update)
+- [games achievements delete](#games-achievements-delete)
+- [games achievements reset](#games-achievements-reset)
+- [games achievements reset-all](#games-achievements-reset-all)
+- [games achievements reset-for-all-players](#games-achievements-reset-for-all-players)
+- [games leaderboards](#games-leaderboards)
+- [games leaderboards list](#games-leaderboards-list)
+- [games leaderboards get](#games-leaderboards-get)
+- [games leaderboards create](#games-leaderboards-create)
+- [games leaderboards update](#games-leaderboards-update)
+- [games leaderboards delete](#games-leaderboards-delete)
+- [games scores](#games-scores)
+- [games scores reset](#games-scores-reset)
+- [games scores reset-all](#games-scores-reset-all)
+- [games scores reset-for-all-players](#games-scores-reset-for-all-players)
+- [games events](#games-events)
+- [games events reset](#games-events-reset)
+- [games events reset-all](#games-events-reset-all)
+- [games events reset-for-all-players](#games-events-reset-for-all-players)
+- [games players](#games-players)
+- [games players hide](#games-players-hide)
+- [games players unhide](#games-players-unhide)
+- [games players list-hidden](#games-players-list-hidden)
 - [generated-apks](#generated-apks)
 - [generated-apks list](#generated-apks-list)
 - [generated-apks download](#generated-apks-download)
@@ -5819,6 +5847,437 @@ JSON format for partial refund:
 | `--json` | Refund JSON (or @file) | `` |
 | `--output` | Output format: json (default), table, markdown | `json` |
 | `--package` | Package name (applicationId) | `` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games
+
+Manage Play Games Services achievements, leaderboards, and player progress.
+
+```
+gplay games <subcommand> [flags]
+```
+
+Manage Play Games Services achievements, leaderboards, and player progress.
+
+Games commands use the https://www.googleapis.com/auth/androidpublisher OAuth
+scope (the same service account credentials as the rest of gplay) across two
+API surfaces:
+
+  - gamesConfiguration (https://gamesconfiguration.googleapis.com) manages the
+    achievement and leaderboard definitions shown in the Play Games section of
+    Play Console.
+  - gamesManagement (https://gamesmanagement.googleapis.com) resets player
+    progress and hides/unhides players. These operations target testers only.
+
+Identifiers differ from the rest of gplay: list/create operations take the
+numeric Play Games application ID (--application-id, or GPLAY_GAMES_APP_ID /
+games_application_id in config), NOT the Android package name. Individual
+resources are addressed by their string achievement/leaderboard/event IDs.
+
+The service account must be linked in the Play Games Services setup for the
+game; a normal Play Console grant is not sufficient.
+
+---
+
+## gplay games achievements
+
+Manage achievement definitions and reset achievement progress.
+
+```
+gplay games achievements <subcommand> [flags]
+```
+
+---
+
+## gplay games achievements list
+
+List achievement configurations for an application.
+
+```
+gplay games achievements list --application-id <id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--application-id` | Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id) | `` |
+| `--max-results` | Maximum achievements per page (server default when 0) | `0` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--paginate` | Fetch all pages | `false` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games achievements get
+
+Get a single achievement configuration.
+
+```
+gplay games achievements get --achievement-id <id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--achievement-id` | Achievement ID | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games achievements create
+
+Create (insert) an achievement configuration.
+
+```
+gplay games achievements create --application-id <id> --data <json> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--application-id` | Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id) | `` |
+| `--data` | Achievement configuration JSON (inline or @file) | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games achievements update
+
+Update an achievement configuration (full replace).
+
+```
+gplay games achievements update --achievement-id <id> --data <json> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--achievement-id` | Achievement ID | `` |
+| `--data` | Achievement configuration JSON (inline or @file) | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games achievements delete
+
+Delete an achievement configuration.
+
+```
+gplay games achievements delete --achievement-id <id> --confirm
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--achievement-id` | Achievement ID | `` |
+| `--confirm` | Confirm deletion | `false` |
+
+---
+
+## gplay games achievements reset
+
+Reset the calling tester's progress for an achievement.
+
+```
+gplay games achievements reset --achievement-id <id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--achievement-id` | Achievement ID | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games achievements reset-all
+
+Reset the calling tester's progress for all achievements.
+
+```
+gplay games achievements reset-all --confirm [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--confirm` | Confirm resetting all achievements for the calling tester | `false` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games achievements reset-for-all-players
+
+Reset an achievement for all testers of the application.
+
+```
+gplay games achievements reset-for-all-players --achievement-id <id> --confirm
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--achievement-id` | Achievement ID | `` |
+| `--confirm` | Confirm resetting this achievement for ALL testers | `false` |
+
+---
+
+## gplay games leaderboards
+
+Manage leaderboard definitions.
+
+```
+gplay games leaderboards <subcommand> [flags]
+```
+
+---
+
+## gplay games leaderboards list
+
+List leaderboard configurations for an application.
+
+```
+gplay games leaderboards list --application-id <id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--application-id` | Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id) | `` |
+| `--max-results` | Maximum leaderboards per page (server default when 0) | `0` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--paginate` | Fetch all pages | `false` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games leaderboards get
+
+Get a single leaderboard configuration.
+
+```
+gplay games leaderboards get --leaderboard-id <id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--leaderboard-id` | Leaderboard ID | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games leaderboards create
+
+Create (insert) a leaderboard configuration.
+
+```
+gplay games leaderboards create --application-id <id> --data <json> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--application-id` | Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id) | `` |
+| `--data` | Leaderboard configuration JSON (inline or @file) | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games leaderboards update
+
+Update a leaderboard configuration (full replace).
+
+```
+gplay games leaderboards update --leaderboard-id <id> --data <json> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--data` | Leaderboard configuration JSON (inline or @file) | `` |
+| `--leaderboard-id` | Leaderboard ID | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games leaderboards delete
+
+Delete a leaderboard configuration.
+
+```
+gplay games leaderboards delete --leaderboard-id <id> --confirm
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--confirm` | Confirm deletion | `false` |
+| `--leaderboard-id` | Leaderboard ID | `` |
+
+---
+
+## gplay games scores
+
+Reset leaderboard scores for testers.
+
+```
+gplay games scores <subcommand> [flags]
+```
+
+---
+
+## gplay games scores reset
+
+Reset the calling tester's scores for a leaderboard.
+
+```
+gplay games scores reset --leaderboard-id <id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--leaderboard-id` | Leaderboard ID | `` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games scores reset-all
+
+Reset the calling tester's scores for all leaderboards.
+
+```
+gplay games scores reset-all --confirm [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--confirm` | Confirm resetting all leaderboard scores for the calling tester | `false` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--pretty` | Pretty-print JSON output | `false` |
+
+---
+
+## gplay games scores reset-for-all-players
+
+Reset a leaderboard's scores for all testers of the application.
+
+```
+gplay games scores reset-for-all-players --leaderboard-id <id> --confirm
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--confirm` | Confirm resetting this leaderboard for ALL testers | `false` |
+| `--leaderboard-id` | Leaderboard ID | `` |
+
+---
+
+## gplay games events
+
+Reset event progress for testers.
+
+```
+gplay games events <subcommand> [flags]
+```
+
+---
+
+## gplay games events reset
+
+Reset the calling tester's progress for an event.
+
+```
+gplay games events reset --event-id <id>
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--event-id` | Event ID | `` |
+
+---
+
+## gplay games events reset-all
+
+Reset the calling tester's progress for all events.
+
+```
+gplay games events reset-all --confirm
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--confirm` | Confirm resetting all events for the calling tester | `false` |
+
+---
+
+## gplay games events reset-for-all-players
+
+Reset an event for all testers of the application.
+
+```
+gplay games events reset-for-all-players --event-id <id> --confirm
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--confirm` | Confirm resetting this event for ALL testers | `false` |
+| `--event-id` | Event ID | `` |
+
+---
+
+## gplay games players
+
+Hide, unhide, and list hidden players (testers).
+
+```
+gplay games players <subcommand> [flags]
+```
+
+---
+
+## gplay games players hide
+
+Hide a player's scores from an application's leaderboards.
+
+```
+gplay games players hide --application-id <id> --player-id <id>
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--application-id` | Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id) | `` |
+| `--player-id` | Player ID to hide from leaderboards | `` |
+
+---
+
+## gplay games players unhide
+
+Unhide a previously hidden player's scores.
+
+```
+gplay games players unhide --application-id <id> --player-id <id>
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--application-id` | Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id) | `` |
+| `--player-id` | Player ID to unhide | `` |
+
+---
+
+## gplay games players list-hidden
+
+List players hidden from an application's leaderboards.
+
+```
+gplay games players list-hidden --application-id <id> [flags]
+```
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--application-id` | Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id) | `` |
+| `--max-results` | Maximum hidden players per page (server default when 0) | `0` |
+| `--output` | Output format: json (default), table, markdown | `json` |
+| `--paginate` | Fetch all pages | `false` |
 | `--pretty` | Pretty-print JSON output | `false` |
 
 ---

--- a/internal/cli/games/achievements.go
+++ b/internal/cli/games/achievements.go
@@ -1,0 +1,355 @@
+package games
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	gamesconfiguration "google.golang.org/api/gamesconfiguration/v1configuration"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/gamesclient"
+)
+
+// AchievementsCommand groups achievement configuration and progress-reset commands.
+func AchievementsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games achievements", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "achievements",
+		ShortUsage: "gplay games achievements <subcommand> [flags]",
+		ShortHelp:  "Manage achievement definitions and reset achievement progress.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			achievementsListCommand(),
+			achievementsGetCommand(),
+			achievementsCreateCommand(),
+			achievementsUpdateCommand(),
+			achievementsDeleteCommand(),
+			achievementsResetCommand(),
+			achievementsResetAllCommand(),
+			achievementsResetForAllCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func achievementsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games achievements list", flag.ExitOnError)
+	appID := fs.String("application-id", "", "Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id)")
+	maxResults := fs.Int("max-results", 0, "Maximum achievements per page (server default when 0)")
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "gplay games achievements list --application-id <id> [flags]",
+		ShortHelp:  "List achievement configurations for an application.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			resolved, err := resolveApplicationID(*appID)
+			if err != nil {
+				return err
+			}
+			if resolved == "" {
+				return shared.UsageError(missingApplicationIDMsg)
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			call := service.Configuration.AchievementConfigurations.List(resolved).Context(ctx)
+			if *maxResults > 0 {
+				call = call.MaxResults(int64(*maxResults))
+			}
+			if !*paginate {
+				resp, err := call.Do()
+				if err != nil {
+					return shared.WrapGoogleAPIError("list achievement configurations", err)
+				}
+				return shared.PrintOutput(resp, *outputFlag, *pretty)
+			}
+			var all []*gamesconfiguration.AchievementConfiguration
+			err = call.Pages(ctx, func(resp *gamesconfiguration.AchievementConfigurationListResponse) error {
+				all = append(all, resp.Items...)
+				return nil
+			})
+			if err != nil {
+				return shared.WrapGoogleAPIError("list achievement configurations", err)
+			}
+			return shared.PrintOutput(all, *outputFlag, *pretty)
+		},
+	}
+}
+
+func achievementsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games achievements get", flag.ExitOnError)
+	id := fs.String("achievement-id", "", "Achievement ID")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "gplay games achievements get --achievement-id <id> [flags]",
+		ShortHelp:  "Get a single achievement configuration.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--achievement-id is required")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Configuration.AchievementConfigurations.Get(*id).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("get achievement configuration", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func achievementsCreateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games achievements create", flag.ExitOnError)
+	appID := fs.String("application-id", "", "Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id)")
+	data := fs.String("data", "", "Achievement configuration JSON (inline or @file)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "create",
+		ShortUsage: "gplay games achievements create --application-id <id> --data <json> [flags]",
+		ShortHelp:  "Create (insert) an achievement configuration.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			resolved, err := resolveApplicationID(*appID)
+			if err != nil {
+				return err
+			}
+			if resolved == "" {
+				return shared.UsageError(missingApplicationIDMsg)
+			}
+			if strings.TrimSpace(*data) == "" {
+				return shared.UsageError("--data is required (achievement configuration JSON, inline or @file)")
+			}
+			var body gamesconfiguration.AchievementConfiguration
+			if err := shared.LoadJSONArg(*data, &body); err != nil {
+				return shared.UsageErrorf("invalid --data JSON: %v", err)
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Configuration.AchievementConfigurations.Insert(resolved, &body).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("create achievement configuration", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func achievementsUpdateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games achievements update", flag.ExitOnError)
+	id := fs.String("achievement-id", "", "Achievement ID")
+	data := fs.String("data", "", "Achievement configuration JSON (inline or @file)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "update",
+		ShortUsage: "gplay games achievements update --achievement-id <id> --data <json> [flags]",
+		ShortHelp:  "Update an achievement configuration (full replace).",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--achievement-id is required")
+			}
+			if strings.TrimSpace(*data) == "" {
+				return shared.UsageError("--data is required (achievement configuration JSON, inline or @file)")
+			}
+			var body gamesconfiguration.AchievementConfiguration
+			if err := shared.LoadJSONArg(*data, &body); err != nil {
+				return shared.UsageErrorf("invalid --data JSON: %v", err)
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Configuration.AchievementConfigurations.Update(*id, &body).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("update achievement configuration", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func achievementsDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games achievements delete", flag.ExitOnError)
+	id := fs.String("achievement-id", "", "Achievement ID")
+	confirm := fs.Bool("confirm", false, "Confirm deletion")
+
+	return &ffcli.Command{
+		Name:       "delete",
+		ShortUsage: "gplay games achievements delete --achievement-id <id> --confirm",
+		ShortHelp:  "Delete an achievement configuration.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--achievement-id is required")
+			}
+			if !*confirm {
+				return shared.UsageError("refusing to delete without --confirm")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if err := service.Configuration.AchievementConfigurations.Delete(*id).Context(ctx).Do(); err != nil {
+				return shared.WrapGoogleAPIError("delete achievement configuration", err)
+			}
+			return shared.PrintOutput(map[string]string{"status": "deleted", "achievementId": *id}, "json", false)
+		},
+	}
+}
+
+func achievementsResetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games achievements reset", flag.ExitOnError)
+	id := fs.String("achievement-id", "", "Achievement ID")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "reset",
+		ShortUsage: "gplay games achievements reset --achievement-id <id> [flags]",
+		ShortHelp:  "Reset the calling tester's progress for an achievement.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--achievement-id is required")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Management.Achievements.Reset(*id).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("reset achievement progress", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func achievementsResetAllCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games achievements reset-all", flag.ExitOnError)
+	confirm := fs.Bool("confirm", false, "Confirm resetting all achievements for the calling tester")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "reset-all",
+		ShortUsage: "gplay games achievements reset-all --confirm [flags]",
+		ShortHelp:  "Reset the calling tester's progress for all achievements.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if !*confirm {
+				return shared.UsageError("refusing to reset all achievements without --confirm")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Management.Achievements.ResetAll().Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("reset all achievement progress", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func achievementsResetForAllCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games achievements reset-for-all-players", flag.ExitOnError)
+	id := fs.String("achievement-id", "", "Achievement ID")
+	confirm := fs.Bool("confirm", false, "Confirm resetting this achievement for ALL testers")
+
+	return &ffcli.Command{
+		Name:       "reset-for-all-players",
+		ShortUsage: "gplay games achievements reset-for-all-players --achievement-id <id> --confirm",
+		ShortHelp:  "Reset an achievement for all testers of the application.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--achievement-id is required")
+			}
+			if !*confirm {
+				return shared.UsageError("refusing to reset for all players without --confirm")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if err := service.Management.Achievements.ResetForAllPlayers(*id).Context(ctx).Do(); err != nil {
+				return shared.WrapGoogleAPIError("reset achievement for all players", err)
+			}
+			return shared.PrintOutput(map[string]string{"status": "reset", "achievementId": *id}, "json", false)
+		},
+	}
+}

--- a/internal/cli/games/events.go
+++ b/internal/cli/games/events.go
@@ -1,0 +1,123 @@
+package games
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/gamesclient"
+)
+
+// EventsCommand groups event-progress reset commands (gamesManagement API).
+func EventsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games events", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "events",
+		ShortUsage: "gplay games events <subcommand> [flags]",
+		ShortHelp:  "Reset event progress for testers.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			eventsResetCommand(),
+			eventsResetAllCommand(),
+			eventsResetForAllCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func eventsResetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games events reset", flag.ExitOnError)
+	id := fs.String("event-id", "", "Event ID")
+
+	return &ffcli.Command{
+		Name:       "reset",
+		ShortUsage: "gplay games events reset --event-id <id>",
+		ShortHelp:  "Reset the calling tester's progress for an event.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--event-id is required")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if err := service.Management.Events.Reset(*id).Context(ctx).Do(); err != nil {
+				return shared.WrapGoogleAPIError("reset event progress", err)
+			}
+			return shared.PrintOutput(map[string]string{"status": "reset", "eventId": *id}, "json", false)
+		},
+	}
+}
+
+func eventsResetAllCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games events reset-all", flag.ExitOnError)
+	confirm := fs.Bool("confirm", false, "Confirm resetting all events for the calling tester")
+
+	return &ffcli.Command{
+		Name:       "reset-all",
+		ShortUsage: "gplay games events reset-all --confirm",
+		ShortHelp:  "Reset the calling tester's progress for all events.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if !*confirm {
+				return shared.UsageError("refusing to reset all events without --confirm")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if err := service.Management.Events.ResetAll().Context(ctx).Do(); err != nil {
+				return shared.WrapGoogleAPIError("reset all event progress", err)
+			}
+			return shared.PrintOutput(map[string]string{"status": "reset-all"}, "json", false)
+		},
+	}
+}
+
+func eventsResetForAllCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games events reset-for-all-players", flag.ExitOnError)
+	id := fs.String("event-id", "", "Event ID")
+	confirm := fs.Bool("confirm", false, "Confirm resetting this event for ALL testers")
+
+	return &ffcli.Command{
+		Name:       "reset-for-all-players",
+		ShortUsage: "gplay games events reset-for-all-players --event-id <id> --confirm",
+		ShortHelp:  "Reset an event for all testers of the application.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--event-id is required")
+			}
+			if !*confirm {
+				return shared.UsageError("refusing to reset for all players without --confirm")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if err := service.Management.Events.ResetForAllPlayers(*id).Context(ctx).Do(); err != nil {
+				return shared.WrapGoogleAPIError("reset event for all players", err)
+			}
+			return shared.PrintOutput(map[string]string{"status": "reset", "eventId": *id}, "json", false)
+		},
+	}
+}

--- a/internal/cli/games/games.go
+++ b/internal/cli/games/games.go
@@ -1,0 +1,60 @@
+// Package games implements the `gplay games` command group for managing Play
+// Games Services content (achievements, leaderboards) and player/progress
+// operations via the Play Games Publishing and Management APIs.
+package games
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+)
+
+// GamesCommand returns the Play Games command group.
+func GamesCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "games",
+		ShortUsage: "gplay games <subcommand> [flags]",
+		ShortHelp:  "Manage Play Games Services achievements, leaderboards, and player progress.",
+		LongHelp: `Manage Play Games Services achievements, leaderboards, and player progress.
+
+Games commands use the https://www.googleapis.com/auth/androidpublisher OAuth
+scope (the same service account credentials as the rest of gplay) across two
+API surfaces:
+
+  - gamesConfiguration (https://gamesconfiguration.googleapis.com) manages the
+    achievement and leaderboard definitions shown in the Play Games section of
+    Play Console.
+  - gamesManagement (https://gamesmanagement.googleapis.com) resets player
+    progress and hides/unhides players. These operations target testers only.
+
+Identifiers differ from the rest of gplay: list/create operations take the
+numeric Play Games application ID (--application-id, or GPLAY_GAMES_APP_ID /
+games_application_id in config), NOT the Android package name. Individual
+resources are addressed by their string achievement/leaderboard/event IDs.
+
+The service account must be linked in the Play Games Services setup for the
+game; a normal Play Console grant is not sufficient.`,
+		FlagSet:   fs,
+		UsageFunc: shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			AchievementsCommand(),
+			LeaderboardsCommand(),
+			ScoresCommand(),
+			EventsCommand(),
+			PlayersCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			if len(args) == 0 {
+				return flag.ErrHelp
+			}
+			fmt.Fprintf(os.Stderr, "Unknown subcommand: %s\n", args[0])
+			return flag.ErrHelp
+		},
+	}
+}

--- a/internal/cli/games/helpers.go
+++ b/internal/cli/games/helpers.go
@@ -1,0 +1,24 @@
+package games
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/tamtom/play-console-cli/internal/config"
+	"github.com/tamtom/play-console-cli/internal/gamesclient"
+)
+
+// resolveApplicationID resolves the Play Games application ID from the flag,
+// GPLAY_GAMES_APP_ID, or config, loading config independently so validation can
+// run before the authenticated service is built.
+func resolveApplicationID(flagValue string) (string, error) {
+	cfg, err := config.Load()
+	if err != nil && !errors.Is(err, config.ErrNotFound) {
+		return "", fmt.Errorf("load config: %w", err)
+	}
+	return gamesclient.ResolveApplicationID(flagValue, cfg), nil
+}
+
+// missingApplicationIDError is the shared usage message for commands that
+// require an application ID.
+const missingApplicationIDMsg = "--application-id is required (or set GPLAY_GAMES_APP_ID/games_application_id)"

--- a/internal/cli/games/leaderboards.go
+++ b/internal/cli/games/leaderboards.go
@@ -1,0 +1,249 @@
+package games
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	gamesconfiguration "google.golang.org/api/gamesconfiguration/v1configuration"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/gamesclient"
+)
+
+// LeaderboardsCommand groups leaderboard configuration commands.
+func LeaderboardsCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games leaderboards", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "leaderboards",
+		ShortUsage: "gplay games leaderboards <subcommand> [flags]",
+		ShortHelp:  "Manage leaderboard definitions.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			leaderboardsListCommand(),
+			leaderboardsGetCommand(),
+			leaderboardsCreateCommand(),
+			leaderboardsUpdateCommand(),
+			leaderboardsDeleteCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func leaderboardsListCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games leaderboards list", flag.ExitOnError)
+	appID := fs.String("application-id", "", "Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id)")
+	maxResults := fs.Int("max-results", 0, "Maximum leaderboards per page (server default when 0)")
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list",
+		ShortUsage: "gplay games leaderboards list --application-id <id> [flags]",
+		ShortHelp:  "List leaderboard configurations for an application.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			resolved, err := resolveApplicationID(*appID)
+			if err != nil {
+				return err
+			}
+			if resolved == "" {
+				return shared.UsageError(missingApplicationIDMsg)
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			call := service.Configuration.LeaderboardConfigurations.List(resolved).Context(ctx)
+			if *maxResults > 0 {
+				call = call.MaxResults(int64(*maxResults))
+			}
+			if !*paginate {
+				resp, err := call.Do()
+				if err != nil {
+					return shared.WrapGoogleAPIError("list leaderboard configurations", err)
+				}
+				return shared.PrintOutput(resp, *outputFlag, *pretty)
+			}
+			var all []*gamesconfiguration.LeaderboardConfiguration
+			err = call.Pages(ctx, func(resp *gamesconfiguration.LeaderboardConfigurationListResponse) error {
+				all = append(all, resp.Items...)
+				return nil
+			})
+			if err != nil {
+				return shared.WrapGoogleAPIError("list leaderboard configurations", err)
+			}
+			return shared.PrintOutput(all, *outputFlag, *pretty)
+		},
+	}
+}
+
+func leaderboardsGetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games leaderboards get", flag.ExitOnError)
+	id := fs.String("leaderboard-id", "", "Leaderboard ID")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "get",
+		ShortUsage: "gplay games leaderboards get --leaderboard-id <id> [flags]",
+		ShortHelp:  "Get a single leaderboard configuration.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--leaderboard-id is required")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Configuration.LeaderboardConfigurations.Get(*id).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("get leaderboard configuration", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func leaderboardsCreateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games leaderboards create", flag.ExitOnError)
+	appID := fs.String("application-id", "", "Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id)")
+	data := fs.String("data", "", "Leaderboard configuration JSON (inline or @file)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "create",
+		ShortUsage: "gplay games leaderboards create --application-id <id> --data <json> [flags]",
+		ShortHelp:  "Create (insert) a leaderboard configuration.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			resolved, err := resolveApplicationID(*appID)
+			if err != nil {
+				return err
+			}
+			if resolved == "" {
+				return shared.UsageError(missingApplicationIDMsg)
+			}
+			if strings.TrimSpace(*data) == "" {
+				return shared.UsageError("--data is required (leaderboard configuration JSON, inline or @file)")
+			}
+			var body gamesconfiguration.LeaderboardConfiguration
+			if err := shared.LoadJSONArg(*data, &body); err != nil {
+				return shared.UsageErrorf("invalid --data JSON: %v", err)
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Configuration.LeaderboardConfigurations.Insert(resolved, &body).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("create leaderboard configuration", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func leaderboardsUpdateCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games leaderboards update", flag.ExitOnError)
+	id := fs.String("leaderboard-id", "", "Leaderboard ID")
+	data := fs.String("data", "", "Leaderboard configuration JSON (inline or @file)")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "update",
+		ShortUsage: "gplay games leaderboards update --leaderboard-id <id> --data <json> [flags]",
+		ShortHelp:  "Update a leaderboard configuration (full replace).",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--leaderboard-id is required")
+			}
+			if strings.TrimSpace(*data) == "" {
+				return shared.UsageError("--data is required (leaderboard configuration JSON, inline or @file)")
+			}
+			var body gamesconfiguration.LeaderboardConfiguration
+			if err := shared.LoadJSONArg(*data, &body); err != nil {
+				return shared.UsageErrorf("invalid --data JSON: %v", err)
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Configuration.LeaderboardConfigurations.Update(*id, &body).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("update leaderboard configuration", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func leaderboardsDeleteCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games leaderboards delete", flag.ExitOnError)
+	id := fs.String("leaderboard-id", "", "Leaderboard ID")
+	confirm := fs.Bool("confirm", false, "Confirm deletion")
+
+	return &ffcli.Command{
+		Name:       "delete",
+		ShortUsage: "gplay games leaderboards delete --leaderboard-id <id> --confirm",
+		ShortHelp:  "Delete a leaderboard configuration.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--leaderboard-id is required")
+			}
+			if !*confirm {
+				return shared.UsageError("refusing to delete without --confirm")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if err := service.Configuration.LeaderboardConfigurations.Delete(*id).Context(ctx).Do(); err != nil {
+				return shared.WrapGoogleAPIError("delete leaderboard configuration", err)
+			}
+			return shared.PrintOutput(map[string]string{"status": "deleted", "leaderboardId": *id}, "json", false)
+		},
+	}
+}

--- a/internal/cli/games/players.go
+++ b/internal/cli/games/players.go
@@ -1,0 +1,163 @@
+package games
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+	gamesmanagement "google.golang.org/api/gamesmanagement/v1management"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/gamesclient"
+)
+
+// PlayersCommand groups player hide/unhide/list commands (gamesManagement API).
+func PlayersCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games players", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "players",
+		ShortUsage: "gplay games players <subcommand> [flags]",
+		ShortHelp:  "Hide, unhide, and list hidden players (testers).",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			playersHideCommand(),
+			playersUnhideCommand(),
+			playersListHiddenCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func playersHideCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games players hide", flag.ExitOnError)
+	appID := fs.String("application-id", "", "Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id)")
+	playerID := fs.String("player-id", "", "Player ID to hide from leaderboards")
+
+	return &ffcli.Command{
+		Name:       "hide",
+		ShortUsage: "gplay games players hide --application-id <id> --player-id <id>",
+		ShortHelp:  "Hide a player's scores from an application's leaderboards.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			resolved, err := resolveApplicationID(*appID)
+			if err != nil {
+				return err
+			}
+			if resolved == "" {
+				return shared.UsageError(missingApplicationIDMsg)
+			}
+			if strings.TrimSpace(*playerID) == "" {
+				return shared.UsageError("--player-id is required")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if err := service.Management.Players.Hide(resolved, *playerID).Context(ctx).Do(); err != nil {
+				return shared.WrapGoogleAPIError("hide player", err)
+			}
+			return shared.PrintOutput(map[string]string{"status": "hidden", "applicationId": resolved, "playerId": *playerID}, "json", false)
+		},
+	}
+}
+
+func playersUnhideCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games players unhide", flag.ExitOnError)
+	appID := fs.String("application-id", "", "Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id)")
+	playerID := fs.String("player-id", "", "Player ID to unhide")
+
+	return &ffcli.Command{
+		Name:       "unhide",
+		ShortUsage: "gplay games players unhide --application-id <id> --player-id <id>",
+		ShortHelp:  "Unhide a previously hidden player's scores.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			resolved, err := resolveApplicationID(*appID)
+			if err != nil {
+				return err
+			}
+			if resolved == "" {
+				return shared.UsageError(missingApplicationIDMsg)
+			}
+			if strings.TrimSpace(*playerID) == "" {
+				return shared.UsageError("--player-id is required")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if err := service.Management.Players.Unhide(resolved, *playerID).Context(ctx).Do(); err != nil {
+				return shared.WrapGoogleAPIError("unhide player", err)
+			}
+			return shared.PrintOutput(map[string]string{"status": "unhidden", "applicationId": resolved, "playerId": *playerID}, "json", false)
+		},
+	}
+}
+
+func playersListHiddenCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games players list-hidden", flag.ExitOnError)
+	appID := fs.String("application-id", "", "Play Games application ID (overrides GPLAY_GAMES_APP_ID/games_application_id)")
+	maxResults := fs.Int("max-results", 0, "Maximum hidden players per page (server default when 0)")
+	paginate := fs.Bool("paginate", false, "Fetch all pages")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "list-hidden",
+		ShortUsage: "gplay games players list-hidden --application-id <id> [flags]",
+		ShortHelp:  "List players hidden from an application's leaderboards.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			resolved, err := resolveApplicationID(*appID)
+			if err != nil {
+				return err
+			}
+			if resolved == "" {
+				return shared.UsageError(missingApplicationIDMsg)
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			call := service.Management.Applications.ListHidden(resolved).Context(ctx)
+			if *maxResults > 0 {
+				call = call.MaxResults(int64(*maxResults))
+			}
+			if !*paginate {
+				resp, err := call.Do()
+				if err != nil {
+					return shared.WrapGoogleAPIError("list hidden players", err)
+				}
+				return shared.PrintOutput(resp, *outputFlag, *pretty)
+			}
+			var all []*gamesmanagement.HiddenPlayer
+			err = call.Pages(ctx, func(resp *gamesmanagement.HiddenPlayerList) error {
+				all = append(all, resp.Items...)
+				return nil
+			})
+			if err != nil {
+				return shared.WrapGoogleAPIError("list hidden players", err)
+			}
+			return shared.PrintOutput(all, *outputFlag, *pretty)
+		},
+	}
+}

--- a/internal/cli/games/scores.go
+++ b/internal/cli/games/scores.go
@@ -1,0 +1,135 @@
+package games
+
+import (
+	"context"
+	"flag"
+	"strings"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/shared"
+	"github.com/tamtom/play-console-cli/internal/gamesclient"
+)
+
+// ScoresCommand groups leaderboard-score reset commands (gamesManagement API).
+func ScoresCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games scores", flag.ExitOnError)
+	return &ffcli.Command{
+		Name:       "scores",
+		ShortUsage: "gplay games scores <subcommand> [flags]",
+		ShortHelp:  "Reset leaderboard scores for testers.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Subcommands: []*ffcli.Command{
+			scoresResetCommand(),
+			scoresResetAllCommand(),
+			scoresResetForAllCommand(),
+		},
+		Exec: func(ctx context.Context, args []string) error {
+			return flag.ErrHelp
+		},
+	}
+}
+
+func scoresResetCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games scores reset", flag.ExitOnError)
+	id := fs.String("leaderboard-id", "", "Leaderboard ID")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "reset",
+		ShortUsage: "gplay games scores reset --leaderboard-id <id> [flags]",
+		ShortHelp:  "Reset the calling tester's scores for a leaderboard.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--leaderboard-id is required")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Management.Scores.Reset(*id).Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("reset leaderboard scores", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func scoresResetAllCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games scores reset-all", flag.ExitOnError)
+	confirm := fs.Bool("confirm", false, "Confirm resetting all leaderboard scores for the calling tester")
+	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
+	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
+
+	return &ffcli.Command{
+		Name:       "reset-all",
+		ShortUsage: "gplay games scores reset-all --confirm [flags]",
+		ShortHelp:  "Reset the calling tester's scores for all leaderboards.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
+				return err
+			}
+			if !*confirm {
+				return shared.UsageError("refusing to reset all scores without --confirm")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			resp, err := service.Management.Scores.ResetAll().Context(ctx).Do()
+			if err != nil {
+				return shared.WrapGoogleAPIError("reset all leaderboard scores", err)
+			}
+			return shared.PrintOutput(resp, *outputFlag, *pretty)
+		},
+	}
+}
+
+func scoresResetForAllCommand() *ffcli.Command {
+	fs := flag.NewFlagSet("games scores reset-for-all-players", flag.ExitOnError)
+	id := fs.String("leaderboard-id", "", "Leaderboard ID")
+	confirm := fs.Bool("confirm", false, "Confirm resetting this leaderboard for ALL testers")
+
+	return &ffcli.Command{
+		Name:       "reset-for-all-players",
+		ShortUsage: "gplay games scores reset-for-all-players --leaderboard-id <id> --confirm",
+		ShortHelp:  "Reset a leaderboard's scores for all testers of the application.",
+		FlagSet:    fs,
+		UsageFunc:  shared.DefaultUsageFunc,
+		Exec: func(ctx context.Context, args []string) error {
+			if strings.TrimSpace(*id) == "" {
+				return shared.UsageError("--leaderboard-id is required")
+			}
+			if !*confirm {
+				return shared.UsageError("refusing to reset for all players without --confirm")
+			}
+			service, err := gamesclient.NewService(ctx)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
+			defer cancel()
+
+			if err := service.Management.Scores.ResetForAllPlayers(*id).Context(ctx).Do(); err != nil {
+				return shared.WrapGoogleAPIError("reset leaderboard scores for all players", err)
+			}
+			return shared.PrintOutput(map[string]string{"status": "reset", "leaderboardId": *id}, "json", false)
+		},
+	}
+}

--- a/internal/cli/registry/registry.go
+++ b/internal/cli/registry/registry.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tamtom/play-console-cli/internal/cli/edits"
 	"github.com/tamtom/play-console-cli/internal/cli/expansion"
 	"github.com/tamtom/play-console-cli/internal/cli/externaltx"
+	"github.com/tamtom/play-console-cli/internal/cli/games"
 	"github.com/tamtom/play-console-cli/internal/cli/generatedapks"
 	"github.com/tamtom/play-console-cli/internal/cli/grants"
 	"github.com/tamtom/play-console-cli/internal/cli/iap"
@@ -134,6 +135,7 @@ func SubcommandsWithRuntime(version string, rt *cliruntime.Runtime) []*ffcli.Com
 		orders.OrdersCommand(),
 		purchases.PurchasesCommand(),
 		externaltx.ExternalTxCommand(),
+		games.GamesCommand(),
 		generatedapks.GeneratedAPKsCommand(),
 		grants.GrantsCommand(),
 		internalsharing.InternalSharingCommand(),

--- a/internal/cmdtest/games_test.go
+++ b/internal/cmdtest/games_test.go
@@ -1,0 +1,116 @@
+package cmdtest_test
+
+import (
+	"errors"
+	"flag"
+	"strings"
+	"testing"
+)
+
+func TestGames_Help(t *testing.T) {
+	stdout, stderr, err := runCommand(t, "games")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected help error, got %v", err)
+	}
+	combined := stdout + stderr
+	for _, want := range []string{"games", "achievements", "leaderboards", "scores", "events", "players"} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("help should mention %q, got: %q", want, combined)
+		}
+	}
+}
+
+func TestGamesAchievements_Help(t *testing.T) {
+	stdout, stderr, err := runCommand(t, "games", "achievements")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected help error, got %v", err)
+	}
+	combined := stdout + stderr
+	for _, want := range []string{"list", "get", "create", "update", "delete", "reset", "reset-for-all-players"} {
+		if !strings.Contains(combined, want) {
+			t.Fatalf("achievements help should mention %q, got: %q", want, combined)
+		}
+	}
+}
+
+func TestGamesAchievementsList_MissingApplicationID(t *testing.T) {
+	t.Setenv("GPLAY_GAMES_APP_ID", "")
+	_, stderr, err := runCommand(t, "games", "achievements", "list")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--application-id is required") {
+		t.Fatalf("stderr should mention missing application id, got: %q", stderr)
+	}
+}
+
+func TestGamesAchievementsGet_MissingID(t *testing.T) {
+	_, stderr, err := runCommand(t, "games", "achievements", "get")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--achievement-id is required") {
+		t.Fatalf("stderr should mention missing achievement id, got: %q", stderr)
+	}
+}
+
+func TestGamesAchievementsCreate_MissingData(t *testing.T) {
+	_, stderr, err := runCommand(t, "games", "achievements", "create", "--application-id", "123")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--data is required") {
+		t.Fatalf("stderr should mention missing data, got: %q", stderr)
+	}
+}
+
+func TestGamesAchievementsDelete_RequiresConfirm(t *testing.T) {
+	_, stderr, err := runCommand(t, "games", "achievements", "delete", "--achievement-id", "abc")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--confirm") {
+		t.Fatalf("stderr should mention --confirm, got: %q", stderr)
+	}
+}
+
+func TestGamesLeaderboardsList_MissingApplicationID(t *testing.T) {
+	t.Setenv("GPLAY_GAMES_APP_ID", "")
+	_, stderr, err := runCommand(t, "games", "leaderboards", "list")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--application-id is required") {
+		t.Fatalf("stderr should mention missing application id, got: %q", stderr)
+	}
+}
+
+func TestGamesScoresReset_MissingLeaderboardID(t *testing.T) {
+	_, stderr, err := runCommand(t, "games", "scores", "reset")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--leaderboard-id is required") {
+		t.Fatalf("stderr should mention missing leaderboard id, got: %q", stderr)
+	}
+}
+
+func TestGamesEventsResetForAll_RequiresConfirm(t *testing.T) {
+	_, stderr, err := runCommand(t, "games", "events", "reset-for-all-players", "--event-id", "e1")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--confirm") {
+		t.Fatalf("stderr should mention --confirm, got: %q", stderr)
+	}
+}
+
+func TestGamesPlayersHide_MissingPlayerID(t *testing.T) {
+	_, stderr, err := runCommand(t, "games", "players", "hide", "--application-id", "123")
+	if !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+	if !strings.Contains(stderr, "--player-id is required") {
+		t.Fatalf("stderr should mention missing player id, got: %q", stderr)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -131,6 +131,7 @@ type Config struct {
 	RetryDelay           string        `json:"retry_delay,omitempty"`
 	Debug                string        `json:"debug"`
 	ChecksAccount        string        `json:"checks_account,omitempty"`
+	GamesApplicationID   string        `json:"games_application_id,omitempty"`
 }
 
 const maxConfigRetries = 30

--- a/internal/gamesclient/client.go
+++ b/internal/gamesclient/client.go
@@ -1,0 +1,90 @@
+// Package gamesclient provides authenticated access to the Play Game Services
+// Publishing API (gamesConfiguration) and the Play Games Services Management API
+// (gamesManagement). Both share the androidpublisher OAuth scope, so this client
+// reuses playclient's credential resolution instead of duplicating it.
+package gamesclient
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+
+	gamesconfiguration "google.golang.org/api/gamesconfiguration/v1configuration"
+	gamesmanagement "google.golang.org/api/gamesmanagement/v1management"
+	"google.golang.org/api/option"
+
+	"github.com/tamtom/play-console-cli/internal/config"
+	"github.com/tamtom/play-console-cli/internal/playclient"
+)
+
+// GamesApplicationIDEnvVar is the environment variable that supplies the numeric
+// Play Games application (project) ID when the --application-id flag is omitted.
+const GamesApplicationIDEnvVar = "GPLAY_GAMES_APP_ID"
+
+// OAuth scopes required by the Play Games APIs. gamesConfiguration (publishing)
+// uses the androidpublisher scope; gamesManagement (player progress/hide) uses
+// the games scope. A single token requesting both covers every service this
+// client builds.
+const (
+	scopeAndroidPublisher = "https://www.googleapis.com/auth/androidpublisher"
+	scopeGames            = "https://www.googleapis.com/auth/games"
+)
+
+// Service wraps the two Play Games API surfaces and the loaded config.
+type Service struct {
+	// Configuration manages achievement and leaderboard definitions
+	// (the "content" of the Play Games section in Play Console).
+	Configuration *gamesconfiguration.Service
+	// Management performs player/progress operations (hide players, reset
+	// achievement/score/event progress).
+	Management *gamesmanagement.Service
+	Cfg        *config.Config
+}
+
+// NewService creates an authenticated Play Games service using the same
+// credentials as the Android Publisher API.
+func NewService(ctx context.Context) (*Service, error) {
+	client, cfg, err := playclient.NewAuthenticatedClientWithScopes(ctx, scopeAndroidPublisher, scopeGames)
+	if err != nil {
+		return nil, err
+	}
+	return newServiceFromClient(ctx, client, cfg, "")
+}
+
+// NewServiceWithClient builds the service from a caller-provided HTTP client.
+// Tests use this to point the generated clients at a mock server.
+func NewServiceWithClient(ctx context.Context, client *http.Client, basePath string) (*Service, error) {
+	return newServiceFromClient(ctx, client, &config.Config{}, basePath)
+}
+
+func newServiceFromClient(ctx context.Context, client *http.Client, cfg *config.Config, basePath string) (*Service, error) {
+	confSvc, err := gamesconfiguration.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	mgmtSvc, err := gamesmanagement.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	if basePath != "" {
+		confSvc.BasePath = basePath
+		mgmtSvc.BasePath = basePath
+	}
+	return &Service{Configuration: confSvc, Management: mgmtSvc, Cfg: cfg}, nil
+}
+
+// ResolveApplicationID returns the Play Games application ID from the flag, the
+// GPLAY_GAMES_APP_ID environment variable, or config, in that order.
+func ResolveApplicationID(flagValue string, cfg *config.Config) string {
+	if v := strings.TrimSpace(flagValue); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(os.Getenv(GamesApplicationIDEnvVar)); v != "" {
+		return v
+	}
+	if cfg != nil && strings.TrimSpace(cfg.GamesApplicationID) != "" {
+		return strings.TrimSpace(cfg.GamesApplicationID)
+	}
+	return ""
+}

--- a/internal/gamesclient/client_test.go
+++ b/internal/gamesclient/client_test.go
@@ -1,0 +1,47 @@
+package gamesclient
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/config"
+)
+
+func TestResolveApplicationIDPrecedence(t *testing.T) {
+	t.Setenv(GamesApplicationIDEnvVar, "env-app")
+	cfg := &config.Config{GamesApplicationID: "config-app"}
+
+	if got := ResolveApplicationID("flag-app", cfg); got != "flag-app" {
+		t.Fatalf("ResolveApplicationID flag precedence = %q, want flag-app", got)
+	}
+	if got := ResolveApplicationID("", cfg); got != "env-app" {
+		t.Fatalf("ResolveApplicationID env precedence = %q, want env-app", got)
+	}
+	t.Setenv(GamesApplicationIDEnvVar, "")
+	if got := ResolveApplicationID("", cfg); got != "config-app" {
+		t.Fatalf("ResolveApplicationID config fallback = %q, want config-app", got)
+	}
+	if got := ResolveApplicationID("", &config.Config{}); got != "" {
+		t.Fatalf("ResolveApplicationID empty = %q, want empty", got)
+	}
+}
+
+func TestNewServiceWithClientBuildsBothSurfaces(t *testing.T) {
+	svc, err := NewServiceWithClient(context.Background(), http.DefaultClient, "http://example.invalid/")
+	if err != nil {
+		t.Fatalf("NewServiceWithClient error: %v", err)
+	}
+	if svc.Configuration == nil {
+		t.Fatal("expected gamesConfiguration service to be built")
+	}
+	if svc.Management == nil {
+		t.Fatal("expected gamesManagement service to be built")
+	}
+	if svc.Configuration.BasePath != "http://example.invalid/" {
+		t.Fatalf("configuration BasePath = %q, want override applied", svc.Configuration.BasePath)
+	}
+	if svc.Management.BasePath != "http://example.invalid/" {
+		t.Fatalf("management BasePath = %q, want override applied", svc.Management.BasePath)
+	}
+}

--- a/internal/playclient/auth_common.go
+++ b/internal/playclient/auth_common.go
@@ -34,11 +34,22 @@ type resolvedCredentials struct {
 	ProfileName string
 }
 
-func resolveCredentials(ctx context.Context, cfg *config.Config) (*resolvedCredentials, error) {
+// effectiveScopes returns the requested scopes, or the default androidpublisher
+// scope when none are supplied. Sibling APIs on the same credentials (e.g. Play
+// Games management, which additionally needs the games scope) pass an explicit
+// list.
+func effectiveScopes(scopeList []string) []string {
+	if len(scopeList) == 0 {
+		return scopes
+	}
+	return scopeList
+}
+
+func resolveCredentials(ctx context.Context, cfg *config.Config, scopeList ...string) (*resolvedCredentials, error) {
 	profileName := shared.ResolveProfileName(cfg)
 	if profileName != "" && cfg != nil {
 		if profile, ok := findProfile(cfg, profileName); ok {
-			creds, err := credentialsFromProfile(ctx, profile)
+			creds, err := credentialsFromProfile(ctx, profile, scopeList...)
 			if err != nil {
 				return nil, err
 			}
@@ -61,7 +72,7 @@ func resolveCredentials(ctx context.Context, cfg *config.Config) (*resolvedCrede
 	}
 
 	if envAuthPresent() {
-		creds, err := credentialsFromEnv(ctx)
+		creds, err := credentialsFromEnv(ctx, scopeList...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/playclient/auth_env.go
+++ b/internal/playclient/auth_env.go
@@ -10,9 +10,9 @@ import (
 	"github.com/tamtom/play-console-cli/internal/cli/shared"
 )
 
-func credentialsFromEnv(ctx context.Context) (*resolvedCredentials, error) {
+func credentialsFromEnv(ctx context.Context, scopeList ...string) (*resolvedCredentials, error) {
 	if keyPath := strings.TrimSpace(os.Getenv(serviceAccountEnvVar)); keyPath != "" {
-		tokenSource, err := credentialsFromServiceAccount(ctx, keyPath)
+		tokenSource, err := credentialsFromServiceAccount(ctx, keyPath, scopeList...)
 		if err != nil {
 			return nil, err
 		}
@@ -30,7 +30,7 @@ func credentialsFromEnv(ctx context.Context) (*resolvedCredentials, error) {
 				"Set both env vars or use `gplay auth login` to create a profile.",
 			)
 		}
-		tokenSource, err := credentialsFromOAuth(ctx, tokenPath, clientID, clientSecret, redirectURIFromEnv())
+		tokenSource, err := credentialsFromOAuth(ctx, tokenPath, clientID, clientSecret, redirectURIFromEnv(), scopeList...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/playclient/auth_oauth.go
+++ b/internal/playclient/auth_oauth.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tamtom/play-console-cli/internal/cli/shared"
 )
 
-func credentialsFromOAuth(ctx context.Context, tokenPath, clientID, clientSecret, redirectURI string) (oauth2.TokenSource, error) {
+func credentialsFromOAuth(ctx context.Context, tokenPath, clientID, clientSecret, redirectURI string, scopeList ...string) (oauth2.TokenSource, error) {
 	data, err := os.ReadFile(tokenPath)
 	if err != nil {
 		return nil, shared.NewAuthError(
@@ -33,7 +33,7 @@ func credentialsFromOAuth(ctx context.Context, tokenPath, clientID, clientSecret
 		ClientID:     clientID,
 		ClientSecret: clientSecret,
 		Endpoint:     google.Endpoint,
-		Scopes:       scopes,
+		Scopes:       effectiveScopes(scopeList),
 		RedirectURL:  redirectURI,
 	}
 	return cfg.TokenSource(ctx, &token), nil

--- a/internal/playclient/auth_profile.go
+++ b/internal/playclient/auth_profile.go
@@ -10,7 +10,7 @@ import (
 	"github.com/tamtom/play-console-cli/internal/config"
 )
 
-func credentialsFromProfile(ctx context.Context, profile config.Profile) (*resolvedCredentials, error) {
+func credentialsFromProfile(ctx context.Context, profile config.Profile, scopeList ...string) (*resolvedCredentials, error) {
 	switch strings.ToLower(strings.TrimSpace(profile.Type)) {
 	case "service_account", "service-account", "serviceaccount":
 		if strings.TrimSpace(profile.KeyPath) == "" {
@@ -20,7 +20,7 @@ func credentialsFromProfile(ctx context.Context, profile config.Profile) (*resol
 				"Set key_path in config.json or re-run `gplay auth login` with --service-account.",
 			)
 		}
-		creds, err := credentialsFromServiceAccount(ctx, profile.KeyPath)
+		creds, err := credentialsFromServiceAccount(ctx, profile.KeyPath, scopeList...)
 		if err != nil {
 			return nil, err
 		}
@@ -42,7 +42,7 @@ func credentialsFromProfile(ctx context.Context, profile config.Profile) (*resol
 				"Set client_id/client_secret in config.json or re-run `gplay auth login` with --client-id/--client-secret.",
 			)
 		}
-		creds, err := credentialsFromOAuth(ctx, profile.TokenPath, clientID, clientSecret, redirectURIFromEnv())
+		creds, err := credentialsFromOAuth(ctx, profile.TokenPath, clientID, clientSecret, redirectURIFromEnv(), scopeList...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/playclient/auth_service_account.go
+++ b/internal/playclient/auth_service_account.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tamtom/play-console-cli/internal/cli/shared"
 )
 
-func credentialsFromServiceAccount(ctx context.Context, keyPath string) (oauth2.TokenSource, error) {
+func credentialsFromServiceAccount(ctx context.Context, keyPath string, scopeList ...string) (oauth2.TokenSource, error) {
 	data, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, shared.NewAuthError(
@@ -20,7 +20,7 @@ func credentialsFromServiceAccount(ctx context.Context, keyPath string) (oauth2.
 			fmt.Sprintf("Check that %s exists and is readable (configured via profile key_path or %s).", keyPath, serviceAccountEnvVar),
 		)
 	}
-	creds, err := google.CredentialsFromJSON(ctx, data, scopes...) //nolint:staticcheck // no replacement available yet
+	creds, err := google.CredentialsFromJSON(ctx, data, effectiveScopes(scopeList)...) //nolint:staticcheck // no replacement available yet
 	if err != nil {
 		return nil, shared.NewAuthError(
 			"failed to parse service account JSON",

--- a/internal/playclient/service.go
+++ b/internal/playclient/service.go
@@ -24,17 +24,44 @@ type Service struct {
 
 // NewService creates an authenticated Android Publisher service.
 func NewService(ctx context.Context) (*Service, error) {
+	client, cfg, err := NewAuthenticatedClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	api, err := androidpublisher.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, err
+	}
+	return &Service{API: api, Cfg: cfg}, nil
+}
+
+// NewAuthenticatedClient returns an HTTP client authenticated with the
+// androidpublisher OAuth scope, together with the loaded config. Sibling
+// clients that share this scope (e.g. the Play Games publishing API) build
+// their generated services on top of this client instead of duplicating the
+// credential-resolution logic. The transport is wrapped for dry-run when
+// dry-run mode is active, mirroring NewService.
+func NewAuthenticatedClient(ctx context.Context) (*http.Client, *config.Config, error) {
+	return NewAuthenticatedClientWithScopes(ctx)
+}
+
+// NewAuthenticatedClientWithScopes is like NewAuthenticatedClient but requests
+// an explicit set of OAuth scopes. Pass no scopes to default to the
+// androidpublisher scope. Sibling APIs that need additional scopes (e.g. the
+// Play Games management API additionally requires the games scope) pass the
+// full list so a single token covers every service they build.
+func NewAuthenticatedClientWithScopes(ctx context.Context, scopeList ...string) (*http.Client, *config.Config, error) {
 	cfg, err := config.Load()
 	if err != nil && !errors.Is(err, config.ErrNotFound) {
-		return nil, shared.NewActionableError(
+		return nil, nil, shared.NewActionableError(
 			"failed to load config",
 			err,
 			"Check that your config file is valid JSON and readable. Use `gplay auth init` to recreate it.",
 		)
 	}
-	client, err := newHTTPClient(ctx, cfg)
+	client, err := newHTTPClient(ctx, cfg, scopeList...)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Wrap transport with DryRunTransport when dry-run is active.
@@ -44,12 +71,7 @@ func NewService(ctx context.Context) (*Service, error) {
 			Writer: os.Stderr,
 		}
 	}
-
-	api, err := androidpublisher.NewService(ctx, option.WithHTTPClient(client))
-	if err != nil {
-		return nil, err
-	}
-	return &Service{API: api, Cfg: cfg}, nil
+	return client, cfg, nil
 }
 
 // NewServiceWithClient creates an Android Publisher service using a provided
@@ -65,8 +87,8 @@ func NewServiceWithClient(ctx context.Context, client *http.Client, basePath str
 	return &Service{API: api, Cfg: &config.Config{}}, nil
 }
 
-func newHTTPClient(ctx context.Context, cfg *config.Config) (*http.Client, error) {
-	creds, err := resolveCredentials(ctx, cfg)
+func newHTTPClient(ctx context.Context, cfg *config.Config, scopeList ...string) (*http.Client, error) {
+	creds, err := resolveCredentials(ctx, cfg, scopeList...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #235.

Adds a `gplay games` command group for managing **Play Games Services** content and player progress — the section requested in #235 — using the existing service-account credentials.

## Commands

**Content — `gamesConfiguration` (androidpublisher scope):**
- `games achievements` — `list · get · create · update · delete`
- `games leaderboards` — `list · get · create · update · delete`

**Player/progress — `gamesManagement` (games scope):**
- `games achievements` — `reset · reset-all · reset-for-all-players`
- `games scores` — `reset · reset-all · reset-for-all-players`
- `games events` — `reset · reset-all · reset-for-all-players`
- `games players` — `hide · unhide · list-hidden`

## Design notes
- **Reuses existing auth.** `playclient` now threads an optional OAuth scope list through its credential builders (defaults to the androidpublisher scope, so the existing path is unchanged) and exposes `NewAuthenticatedClientWithScopes`. The new `gamesclient` requests `androidpublisher` + `games` so one token covers both API surfaces.
- **Identifiers differ from the rest of gplay:** list/create take the numeric Play Games **application ID** (`--application-id`, `GPLAY_GAMES_APP_ID`, or `games_application_id` in config), not the Android package name. Individual resources use their string achievement/leaderboard/event IDs.
- Follows the merged `checks` feature's structure: dedicated client package, `internal/cli/games/` command tree, registry registration, `UsageFunc: shared.DefaultUsageFunc`, `shared.ContextWithTimeout`, JSON-first output, `--confirm` on destructive ops.

## Caveats
- **`gamesManagement` SA-linkage:** the token now carries the `games` scope, but those endpoints also require the service account to be linked in the game's Play Games Services config; some setups will get 403. The commands are correct — authorization depends on Games linkage.
- Achievement/leaderboard **icon assets** are not settable via this API version (stay manual in Console); all other fields are supported.

## Testing
- `make test` (full suite) ✅, `go vet ./...` ✅, pre-commit (format + lint + docs gate) ✅
- New: 11 black-box CLI tests (help trees + required-flag/`--confirm` validation) and `gamesclient` unit tests (ID precedence, dual-surface construction)
- Ran the built binary end-to-end: `games --help` renders; validation errors fire as expected
- `GPLAY.md` regenerated (check-docs gate passes)

https://claude.ai/code/session_01B7CnjjL3QuBTQUdQC3v1oJ