### PR TITLE
feat(winget): publish gplay to Windows Package Manager

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,11 +77,23 @@ jobs:
 
           echo "Built: $BINARY_NAME"
 
+      # Portable-friendly zip for winget: the archive contains gplay.exe so the
+      # winget PortableCommandAlias exposes the command as `gplay`.
+      - name: Package Windows portable zip
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          Copy-Item "gplay-windows-${{ matrix.arch }}.exe" gplay.exe
+          Compress-Archive -Path gplay.exe -DestinationPath "gplay-windows-${{ matrix.arch }}.zip" -Force
+          Write-Host "Packaged: gplay-windows-${{ matrix.arch }}.zip"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: gplay-${{ matrix.os }}-${{ matrix.arch }}
-          path: gplay-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }}
+          path: |
+            gplay-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.os == 'windows' && '.exe' || '' }}
+            ${{ matrix.os == 'windows' && format('gplay-windows-{0}.zip', matrix.arch) || '' }}
           retention-days: 1
 
   release:
@@ -148,3 +160,35 @@ jobs:
           repository: tamtom/homebrew-tap
           event-type: update-formula
           client-payload: '{"version": "${{ steps.version.outputs.version }}"}'
+
+  winget:
+    name: Publish to winget
+    needs: release
+    runs-on: windows-latest
+    if: ${{ !contains(github.ref, '-') }}  # Skip pre-releases
+    steps:
+      - name: Get version
+        id: version
+        shell: bash
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      # Submits a manifest-update PR to microsoft/winget-pkgs via wingetcreate.
+      # Requires the WINGET_TOKEN secret (classic PAT with a fork of
+      # microsoft/winget-pkgs). The package tamtom.gplay must already exist in
+      # winget-pkgs (initial manifest submitted once from winget/manifests/).
+      - name: Update winget manifest
+        shell: pwsh
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+        run: |
+          if (-not $env:WINGET_TOKEN) {
+            Write-Host "WINGET_TOKEN not set; skipping winget submission."
+            exit 0
+          }
+          $ver = "${{ steps.version.outputs.version }}"
+          $url = "https://github.com/tamtom/play-console-cli/releases/download/v$ver/gplay-windows-amd64.zip"
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update tamtom.gplay --version $ver --urls "$url" --submit --token $env:WINGET_TOKEN

--- a/winget/README.md
+++ b/winget/README.md
@@ -1,0 +1,41 @@
+# winget packaging
+
+Manifests for publishing `gplay` to the [Windows Package Manager](https://learn.microsoft.com/windows/package-manager/) community repository, so users can install with:
+
+```powershell
+winget install tamtom.gplay
+```
+
+## How it works
+
+`gplay` ships as a single portable binary. The manifest uses `InstallerType: zip`
+with a nested `portable` installer and `PortableCommandAlias: gplay`, so winget
+downloads `gplay-windows-amd64.zip` (which contains `gplay.exe`), extracts it, and
+exposes a `gplay` command on PATH.
+
+The release workflow (`.github/workflows/release.yml`) builds that zip for every
+tagged release and includes it in the GitHub release assets.
+
+## Initial submission (one-time)
+
+The package must exist in `microsoft/winget-pkgs` before automated updates can run.
+
+1. Fork <https://github.com/microsoft/winget-pkgs>.
+2. Copy `manifests/t/tamtom/gplay/0.6.0/` into the fork under the same path.
+3. Open a PR to `microsoft/winget-pkgs`. The validation bot verifies the installer
+   URL and SHA-256, then a moderator merges it (usually 1–2 days).
+
+Alternatively, from a Windows machine:
+
+```powershell
+winget install wingetcreate
+wingetcreate submit --token <PAT> winget/manifests/t/tamtom/gplay/0.6.0
+```
+
+## Automated updates (subsequent releases)
+
+The `winget` job in the release workflow runs `wingetcreate update` on each tagged
+release and submits a version-bump PR automatically. It requires a repository
+secret **`WINGET_TOKEN`** — a classic GitHub PAT (public_repo scope) on an account
+that has forked `microsoft/winget-pkgs`. Without the secret the job logs a skip and
+succeeds, so releases are never blocked.


### PR DESCRIPTION
## Summary

Enables the install method Windows users are actually asking for:

```powershell
winget install tamtom.gplay
```

Adds winget manifests + release automation, mirroring the existing Homebrew tap dispatch in `release.yml`.

## Why zip (not the bare .exe)

`gplay` is a single portable binary, but a bare-`.exe` winget `portable` installer names the command after the **asset file** → users would type `gplay-windows-amd64`. Per the [winget schema](https://github.com/microsoft/winget-pkgs/blob/master/doc/manifest/schema/1.6.0/installer.md), `PortableCommandAlias` (which yields a clean `gplay`) is only valid inside a **zip** via `NestedInstallerFiles`. So we ship a zip containing `gplay.exe`.

## Changes

- **`winget/manifests/t/tamtom/gplay/0.6.0/`** — version, installer, and en-US locale manifests. `InstallerType: zip` + `NestedInstallerType: portable` + `PortableCommandAlias: gplay`. Points at the v0.6.0 release zip (SHA-256 verified against the live asset).
- **`.github/workflows/release.yml`**
  - New step: package `gplay-windows-<arch>.zip` (containing `gplay.exe`) per tagged release and include it in the GitHub release assets.
  - New `winget` job: runs `wingetcreate update` to auto-submit a version-bump PR to `microsoft/winget-pkgs`. Gated on a `WINGET_TOKEN` secret — logs a skip and succeeds when the secret is absent, so releases are never blocked.
- **`winget/README.md`** — documents the one-time initial submission and the automated update flow.

I also uploaded the `gplay-windows-amd64.zip` asset to the existing **v0.6.0** release so the 0.6.0 manifest is immediately valid/submittable (additive; existing assets and `checksums.txt` untouched).

## Validation

- [x] All three manifests parse as valid YAML; PackageIdentifier/version consistent across files
- [x] Installer type `zip`/nested `portable`, alias `gplay`, SHA-256 is 64 hex chars
- [x] Release zip is live on v0.6.0 and its downloaded SHA-256 matches the manifest
- [x] `release.yml` parses; jobs: build, release, homebrew, winget
- [x] Pre-commit hook passed (format, lint 0 issues, docs gate)
- [ ] ⚠️ Manifests not run through `winget validate` (needs Windows); authored to the 1.6.0 schema

## Required to go live (external, can't be done headlessly)

1. **Initial submission** (one-time): fork `microsoft/winget-pkgs`, copy `winget/manifests/t/tamtom/gplay/0.6.0/` in, open a PR. Bot validates URL+SHA → moderator merges (~1–2 days).
2. **`WINGET_TOKEN` secret**: classic PAT (public_repo) on an account that forked `winget-pkgs`, so the `winget` release job can auto-submit future bumps. Until it's set, the job just skips.

Once the package is accepted, a follow-up will add the `winget install tamtom.gplay` line to the README install block.

## Follow-ups (not here)
- `windows/arm64` still isn't published; the zip step already handles arch, so adding it to the build matrix would give a native ARM64 winget install too.

https://claude.ai/code/session_01LAPLzpiBYGLwHSLVkr6cXb