### PR TITLE
Fix StrictMode crash when adding install dir to PATH on Windows

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -104,7 +104,7 @@ try {
     $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
     $onPath = $false
     if ($userPath) {
-        $onPath = ($userPath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') }).Count -gt 0
+        $onPath = @($userPath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') }).Count -gt 0
     }
     if (-not $onPath) {
         $newPath = if ($userPath) { "$userPath;$installDir" } else { $installDir }


### PR DESCRIPTION
## Summary

This is a Windows-only fix. `install.ps1` is the PowerShell installer, so the bug only affects users who install on Windows. The Unix `install.sh` path does not run this code and is unaffected.

`install.ps1` aborts with this error right after it copies the binary:

```
The property 'Count' cannot be found on this object. Verify that the property exists.
```

<img width="1105" height="209" alt="image" src="https://github.com/user-attachments/assets/d45e3050-73e3-4046-a41c-211822912602" />


The installer copies the binary into the install directory but never reaches the step that adds that directory to PATH, so `gplay` is missing from PATH after an install that otherwise looks successful.

## Cause

The script runs under `Set-StrictMode -Version Latest`. The PATH check is:

```powershell
$onPath = ($userPath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') }).Count -gt 0
```

`Where-Object` returns a real array only when two or more items match. With zero matches (a first install) or one match (the install dir is already on PATH once), it returns `$null` or a single object. Neither exposes `.Count` under strict mode, so the property access throws. The crash therefore hits a first install and a single-entry re-install alike. Only the two-or-more case ever worked.

## Fix

Wrap the pipeline in an array subexpression so the result is always an array and `.Count` is always defined:

```powershell
$onPath = @($userPath -split ';' | Where-Object { $_.TrimEnd('\') -ieq $installDir.TrimEnd('\') }).Count -gt 0
```

The comparison keeps the same case-insensitive, trailing-slash-normalized behavior as before.

## Testing

Ran the expression on Windows PowerShell 5.1 and PowerShell 7.6.4 across four PATH states:

| PATH state | Before | After |
| --- | --- | --- |
| Not on PATH (first install) | throws | False |
| On PATH once | throws | True |
| On PATH with trailing slash | throws | True |
| On PATH twice or more | True | True |

`Parser::ParseFile` reports no syntax errors on either engine.