### PR TITLE
fix(purchases): migrate subscriptions revoke to the v2 endpoint

### DIFF
--- a/GPLAY.md
+++ b/GPLAY.md
@@ -5553,16 +5553,20 @@ The new expiry time must be:
 
 ## gplay purchases subscriptions revoke
 
-Revoke a subscription immediately.
+Revoke a subscription immediately with a full refund.
 
 ```
-gplay purchases subscriptions revoke --package <name> --subscription-id <id> --token <token> --confirm
+gplay purchases subscriptions revoke --package <name> --token <token> --confirm
 ```
 
-Revoke a subscription immediately.
+Revoke a subscription immediately with a full refund.
 
 Unlike cancel, this immediately ends the subscription and
 the user loses access right away.
+
+This runs on the subscriptionsv2 endpoint, which is keyed by purchase token
+alone; --subscription-id is accepted for backwards compatibility but ignored.
+For control over the refund mode, use "gplay purchases subscriptionsv2 revoke".
 
 | Flag | Description | Default |
 |------|-------------|---------|
@@ -5570,7 +5574,7 @@ the user loses access right away.
 | `--output` | Output format: json (default), table, markdown | `json` |
 | `--package` | Package name (applicationId) | `` |
 | `--pretty` | Pretty-print JSON output | `false` |
-| `--subscription-id` | Subscription ID | `` |
+| `--subscription-id` | Subscription ID (deprecated: ignored, the v2 endpoint is keyed by token) | `` |
 | `--token` | Purchase token | `` |
 
 ---

--- a/internal/cli/purchases/purchases.go
+++ b/internal/cli/purchases/purchases.go
@@ -820,7 +820,7 @@ The new expiry time must be:
 func SubscriptionsRevokeCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("purchases subscriptions revoke", flag.ExitOnError)
 	packageName := fs.String("package", "", "Package name (applicationId)")
-	subscriptionID := fs.String("subscription-id", "", "Subscription ID")
+	subscriptionID := fs.String("subscription-id", "", "Subscription ID (deprecated: ignored, the v2 endpoint is keyed by token)")
 	token := fs.String("token", "", "Purchase token")
 	confirm := fs.Bool("confirm", false, "Confirm revocation")
 	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
@@ -828,20 +828,21 @@ func SubscriptionsRevokeCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:       "revoke",
-		ShortUsage: "gplay purchases subscriptions revoke --package <name> --subscription-id <id> --token <token> --confirm",
-		ShortHelp:  "Revoke a subscription immediately.",
-		LongHelp: `Revoke a subscription immediately.
+		ShortUsage: "gplay purchases subscriptions revoke --package <name> --token <token> --confirm",
+		ShortHelp:  "Revoke a subscription immediately with a full refund.",
+		LongHelp: `Revoke a subscription immediately with a full refund.
 
 Unlike cancel, this immediately ends the subscription and
-the user loses access right away.`,
+the user loses access right away.
+
+This runs on the subscriptionsv2 endpoint, which is keyed by purchase token
+alone; --subscription-id is accepted for backwards compatibility but ignored.
+For control over the refund mode, use "gplay purchases subscriptionsv2 revoke".`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
 				return err
-			}
-			if strings.TrimSpace(*subscriptionID) == "" {
-				return fmt.Errorf("--subscription-id is required")
 			}
 			if strings.TrimSpace(*token) == "" {
 				return fmt.Errorf("--token is required")
@@ -849,7 +850,7 @@ the user loses access right away.`,
 			if !*confirm {
 				return fmt.Errorf("--confirm is required")
 			}
-			service, err := playclient.NewService(ctx)
+			service, err := newPlayService(ctx)
 			if err != nil {
 				return err
 			}
@@ -861,8 +862,15 @@ the user loses access right away.`,
 			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
 			defer cancel()
 
-			err = service.API.Purchases.Subscriptions.Revoke(pkg, *subscriptionID, *token).Context(ctx).Do()
-			if err != nil {
+			// The v1 revoke endpoint was removed from androidpublisher/v3. Its
+			// implicit behavior was terminate + full refund, which v2 requires
+			// callers to state explicitly.
+			req := androidpublisher.RevokeSubscriptionPurchaseRequest{
+				RevocationContext: &androidpublisher.RevocationContext{
+					FullRefund: &androidpublisher.RevocationContextFullRefund{},
+				},
+			}
+			if _, err := service.API.Purchases.Subscriptionsv2.Revoke(pkg, *token, &req).Context(ctx).Do(); err != nil {
 				return err
 			}
 

--- a/internal/cli/purchases/purchases_test.go
+++ b/internal/cli/purchases/purchases_test.go
@@ -105,6 +105,91 @@ func TestSubscriptionsV2CancelCommand_CallsAPI(t *testing.T) {
 	}
 }
 
+func TestSubscriptionsRevokeCommand_CallsV2API(t *testing.T) {
+	var gotPath, gotBody string
+	installMockPlayService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		body, _ := io.ReadAll(r.Body)
+		gotBody = string(body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{}`)
+	})
+
+	cmd := SubscriptionsRevokeCommand()
+	_ = cmd.FlagSet.Parse([]string{
+		"--package", "com.example.app",
+		"--subscription-id", "premium",
+		"--token", "tok",
+		"--confirm",
+	})
+	stdout, err := capturePurchasesStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	// The v1 endpoint was removed from androidpublisher/v3; this command now
+	// rides on subscriptionsv2, which is keyed by token alone.
+	if gotPath != "/androidpublisher/v3/applications/com.example.app/purchases/subscriptionsv2/tokens/tok:revoke" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+	// v2 requires an explicit revocation context; a full refund preserves the
+	// behavior the v1 endpoint applied implicitly.
+	if !strings.Contains(gotBody, "fullRefund") {
+		t.Fatalf("expected fullRefund revocation context, got %s", gotBody)
+	}
+	if !strings.Contains(stdout, `"revoked":true`) {
+		t.Fatalf("expected revoked output, got %s", stdout)
+	}
+	if !strings.Contains(stdout, `"subscriptionId":"premium"`) {
+		t.Fatalf("expected subscriptionId echoed in output, got %s", stdout)
+	}
+}
+
+// --subscription-id is meaningless to the v2 endpoint, so it must not be
+// required any more — but passing it stays valid for existing scripts.
+func TestSubscriptionsRevokeCommand_SubscriptionIDOptional(t *testing.T) {
+	var gotPath string
+	installMockPlayService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{}`)
+	})
+
+	cmd := SubscriptionsRevokeCommand()
+	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--token", "tok", "--confirm"})
+	if _, err := capturePurchasesStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	}); err != nil {
+		t.Fatalf("expected no error without --subscription-id, got %v", err)
+	}
+	if gotPath != "/androidpublisher/v3/applications/com.example.app/purchases/subscriptionsv2/tokens/tok:revoke" {
+		t.Fatalf("unexpected path: %s", gotPath)
+	}
+}
+
+func TestSubscriptionsRevokeCommand_Validation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"missing token", []string{"--package", "com.example.app", "--confirm"}, "--token is required"},
+		{"missing confirm", []string{"--package", "com.example.app", "--token", "tok"}, "--confirm is required"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := SubscriptionsRevokeCommand()
+			_ = cmd.FlagSet.Parse(tt.args)
+			err := cmd.Exec(context.Background(), nil)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected error containing %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
 func installMockPlayService(t *testing.T, handler http.HandlerFunc) {
 	t.Helper()
 


### PR DESCRIPTION
Unblocks #249.

## Problem

`google.golang.org/api` **v0.290.0** removes `Get`, `Refund` and `Revoke` from `PurchasesSubscriptionsService` — Google dropped the deprecated v1 purchase endpoints from the generated `androidpublisher/v3` client. Verified across versions:

| Method on `PurchasesSubscriptionsService` | 0.287.0 | 0.289.0 | 0.290.0 |
|---|---|---|---|
| `Acknowledge` / `Cancel` / `Defer` | ✅ | ✅ | ✅ |
| `Get` / `Refund` / `Revoke` | ✅ | ✅ | ❌ removed |

#249 started life as `0.287.0 → 0.289.0` (green), but dependabot's rebase retargeted it to 0.290.0, which fails to compile:

```
internal/cli/purchases/purchases.go:864:46: service.API.Purchases.Subscriptions.Revoke undefined
```

`Revoke` is the only removed method this repo calls — `Acknowledge`/`Cancel`/`Defer` (purchases.go:379, 738, 811) all survive, and `Get`/`Refund` were never used. One call site.

## Change

Reimplements `gplay purchases subscriptions revoke` on `Purchases.Subscriptionsv2.Revoke`, which was already used by `purchases subscriptionsv2 revoke` (purchases.go:635).

The two APIs differ in shape, so this is not a pure rename:

- **v2 is keyed by purchase token alone.** `--subscription-id` is now accepted but ignored rather than required, so existing invocations keep working unchanged. It stays in the output payload.
- **v2 requires an explicit `RevocationContext`.** The command sends `fullRefund`, which is what v1 applied implicitly — preserving today's behavior. Callers wanting a different refund mode still have `purchases subscriptionsv2 revoke --json`.

Also switches the command from `playclient.NewService` to the `newPlayService` hook so the package's mock-server tests can reach it, matching the surrounding v2 commands.

## Validation

- [x] Three tests added first and confirmed failing for the right reasons (wrong endpoint / `--subscription-id is required`), then passing: v2 path + `fullRefund` body, `--subscription-id` optional, and flag validation.
- [x] `make dev` (format + lint + test + build) — 0 lint issues, full suite green.
- [x] Built and ran `gplay purchases subscriptions revoke --help` to confirm the rendered help.
- [x] **Compiles and tests green against `google.golang.org/api@v0.290.0`** — the actual unblock. `go.mod` is deliberately left at 0.287.0 here so #249 stays the sole owner of the bump and rebases cleanly onto this.
- [x] `GPLAY.md` regenerated via `make docs`; `make check-docs` gate passes.

## Note

This is a deliberate, if small, CLI surface change: `--subscription-id` no longer does anything on this command. The alternative was deleting the command outright and pointing users at the v2 one — happy to go that way instead if you'd prefer not to keep a vestigial flag.