### PR TITLE
feat(preflight): offline 9-scanner engine with real manifest decoding

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -185,6 +185,7 @@ Available skills:
 - `gplay-user-management` - Developer account user and grant management
 - `gplay-metadata-sync` - Metadata and localization sync (incl. Fastlane format)
 - `gplay-migrate-fastlane` - Fastlane metadata migration
+- `gplay-preflight` - Offline AAB/APK scanning: nine scanners, manifest decoding, CI gating
 - `gplay-submission-checks` - Pre-submission validation
 - `gplay-screenshot-automation` - Upload and validate Play Store screenshots
 - `gplay-testers-orchestration` - Closed-testing tracks and tester management

--- a/Agents.md
+++ b/Agents.md
@@ -41,6 +41,7 @@ gplay migrate fastlane          # Migrate from Fastlane metadata
 gplay reports financial         # Financial reports (list/download from GCS)
 gplay reports stats             # Statistics reports (list/download from GCS)
 gplay custom-apps create        # Publish private apps via Managed Google Play
+gplay preflight                 # Offline 9-scanner compliance scan of an AAB/APK
 gplay listings locales          # List available locales with validation
 gplay release-notes generate    # Generate release notes from git history
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> Release notes for **0.5.0 – 0.7.1** were auto-generated and live in
+> [GitHub Releases](https://github.com/tamtom/play-console-cli/releases).
+
+
+## [0.8.0] - 2026-07-26
+
+### Added
+
+#### Offline preflight engine — `gplay preflight`
+
+`preflight` now decodes `AndroidManifest.xml` for real instead of matching
+substrings, and runs nine independently selectable scanners with no API calls
+and no credentials.
+
+- **Manifest decoding** — binary AXML (`internal/preflight/axml.go`) for APKs and
+  aapt2 protobuf `XmlNode` (`internal/preflight/protoxml.go`) for App Bundles,
+  normalized into one typed model (`internal/preflight/manifest.go`). Optional
+  attributes are tri-state, so *absent*, *explicitly false*, and *not statically
+  determinable* stay distinguishable.
+- **`manifest`** — `debuggable`, `testOnly`, exported components missing
+  `android:exported` on `targetSdk` 31+, exported providers granting URI
+  permissions, foreground service types without their matching Android 14
+  permission, cleartext traffic, `allowBackup`, package/version sanity.
+- **`permissions`** — 23 restricted permissions requiring a Play declaration,
+  18 sensitive permissions requiring a Data safety disclosure, legacy storage
+  permissions on modern targets, duplicates, deprecated permissions. Findings
+  carry Play policy documentation links.
+- **`native_libs`** — missing `arm64-v8a`, **16 KB memory page alignment** read
+  from real ELF program headers via `debug/elf`, unstripped debug symbols,
+  `extractNativeLibs="true"`.
+- **`metadata`** — listing text limits plus **real screenshot pixel dimensions**,
+  aspect ratio, count, and icon/feature-graphic sizes. Enabled by
+  `--listings-dir`.
+- **`secrets`** — 14 credential patterns, shipped keystores and `.pem` files,
+  `.git`/`.env` leakage; also scans dex string data with bounded chunked reads.
+- **`billing`** — Play Billing vs. third-party payment processors,
+  `com.android.vending.BILLING` declared without an implementation.
+- **`privacy`** — 40+ analytics/attribution/ads SDK signatures and `AD_ID`
+  permission consistency against `targetSdk` 33+.
+- **`policy`** — target API level floor, restricted services (accessibility,
+  VPN, device admin, notification listener), APK-vs-AAB upload format.
+- **`size`** — download size budget, dex fragmentation, payload breakdown.
+
+#### New flags
+
+- `--listings-dir` — validate a Fastlane-style listings directory in the same pass
+- `--only` / `--skip` — comma-separated scanner selection
+- `--list-scanners` — print the available scanner IDs and exit
+- `--min-target-sdk` — override the target API level floor without a rebuild
+
+### Changed
+
+- `preflight` text output now groups findings per scanner, reporting `ok`,
+  `skipped (reason)`, or the finding count for every scanner that ran.
+- The `google_api_key` secret pattern is now a **warning** rather than an error.
+  Android apps legitimately embed Maps and Firebase `AIza…` keys; the defence is
+  key restriction, not absence. Hard credentials (private keys, service-account
+  JSON, `sk_live_`, GitHub/Slack tokens) remain errors.
 
 ## [0.4.5] - 2026-02-26
 

--- a/GPLAY.md
+++ b/GPLAY.md
@@ -693,30 +693,50 @@ gplay preflight --file <app.aab> [flags]
 
 Run offline checks against an AAB or APK without any API calls.
 
-Checks include: manifest presence, bundle size, native lib coverage,
-dex count/size, debuggable flag, testOnly flag, cleartext traffic,
-dangerous permissions, secret scan (API keys/private keys/etc.),
-and developer-environment artifacts.
+AndroidManifest.xml is fully decoded — binary AXML for APKs, aapt2 protobuf
+for App Bundles — so checks read real, typed attribute values rather than
+guessing from substrings.
+
+Scanners:
+  manifest     debuggable/testOnly flags, exported components, foreground
+               service types, package and version sanity
+  permissions  restricted permissions needing a Play declaration, sensitive
+               permissions needing a Data safety disclosure, legacy storage
+  native_libs  64-bit coverage, 16 KB page alignment, debug symbols
+  metadata     listing text limits and real screenshot dimensions
+               (requires --listings-dir)
+  secrets      API keys, private keys, keystores, developer artifacts
+  billing      Play Billing vs third-party payment processors
+  privacy      analytics/ads SDKs and advertising ID consistency
+  policy       target API level floor, restricted services, upload format
+  size         download size budget, dex count, payload breakdown
 
 Exit codes:
-  0   clean
+  0   no findings at or above --fail-on
   1   findings at or above --fail-on severity
 
-Example:
+Examples:
   gplay preflight --file app.aab
-  gplay preflight --file app.aab --max-size 100M --fail-on warning
-  gplay preflight --file app.aab --output json | jq .
+  gplay preflight --file app.aab --fail-on warning
+  gplay preflight --file app.aab --listings-dir ./metadata
+  gplay preflight --file app.aab --only manifest,permissions
+  gplay preflight --file app.aab --skip size --output json | jq .
 
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--fail-on` | Exit non-zero when findings reach this severity: info, warning, error | `error` |
 | `--file` | Path to .aab or .apk to scan (required) | `` |
+| `--list-scanners` | Print the available scanner IDs and exit | `false` |
+| `--listings-dir` | Listings directory to validate (enables the metadata scanner) | `` |
 | `--max-dex` | Max allowed size per dex file (e.g. 64M) | `` |
 | `--max-size` | Max allowed bundle size (e.g. 150M) | `` |
+| `--min-target-sdk` | Minimum accepted targetSdkVersion (default: the current Play requirement) | `0` |
+| `--only` | Comma-separated scanners to run (default: all) | `` |
 | `--output` | Output format: text (default), json, markdown | `text` |
 | `--pretty` | Pretty-print JSON output | `false` |
-| `--skip-secrets` | Skip secret-pattern scan (faster) | `false` |
+| `--skip` | Comma-separated scanners to exclude | `` |
+| `--skip-secrets` | Skip the secrets scanner (faster) | `false` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ gplay reviews list --package com.example.app | jq '.reviews[0]'
 - **Store listings, screenshots & localization** — manage listing text, images, and metadata across every locale; sync with a local directory or Fastlane.
 - **Full monetization stack** — subscriptions, base plans, promotional offers, in-app products, one-time purchases, regional price conversion. Pairs with [RevenueCat](docs/monetization.md#using-gplay-with-revenuecat): create products in Play with `gplay`, import them into RevenueCat.
 - **Purchase verification** — verify tokens, acknowledge purchases, refund orders, decode RTDN webhooks.
+- **Offline preflight** — `gplay preflight --file app.aab` fully decodes `AndroidManifest.xml` (binary AXML for APKs, aapt2 protobuf for App Bundles) and runs nine scanners with no API calls and no credentials: manifest flags, restricted permissions, 64-bit and **16 KB page alignment**, listing text and real screenshot dimensions, secrets, billing, privacy SDKs, target API floor, and size. Catches the rejections *before* you upload.
 - **App health** — crash clusters, ANRs, performance vitals, review replies, financial & statistics reports.
 - **AI-agent native** — minified JSON output, explicit flags, `--help` everywhere, `--dry-run` for every write, no interactive prompts, [Agent Skills](docs/ai-agents.md) included.
 - **Lightweight, zero runtime to install** — a single compiled Go binary with instant startup. No Node.js, no Python, no JVM, no Gradle project required.
@@ -155,6 +156,7 @@ Versus [Fastlane `supply`](https://docs.fastlane.tools/actions/supply/) and [gra
 | Reviews: read + reply | ✅ | ❌ | ❌ |
 | Financial & statistics reports | ✅ | ❌ | ❌ |
 | Users & permission grants | ✅ | ❌ | ❌ |
+| Offline preflight (manifest decode, 16 KB alignment, secrets) | ✅ 9 scanners | ❌ | ❌ |
 | Managed Google Play (private/custom apps) | ✅ | ❌ | ❌ |
 | Google Checks compliance gate | ✅ | ❌ | ❌ |
 | AI-agent-friendly output | ✅ JSON default | ❌ Human logs | ❌ Gradle logs |

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -46,6 +46,7 @@ npx skills add tamtom/gplay-cli-skills
 | `gplay-user-management` | Developer account user and permission grant management |
 | `gplay-migrate-fastlane` | Migration from Fastlane metadata to gplay format |
 | `gplay-reports-download` | Financial and statistics report listing/downloading from GCS |
+| `gplay-preflight` | Offline AAB/APK scanning: nine scanners, manifest decoding, CI gating |
 | `gplay-submission-checks` | Pre-submission validation |
 | `gplay-screenshot-automation` | Screenshot management workflows |
 | `gplay-subscription-localization` | Subscription and in-app product localization |

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -54,8 +54,14 @@ deploy:
 ## Useful CI gates
 
 ```bash
-# Fail the build on compliance issues before uploading (offline, no API calls)
+# Fail the build on compliance issues before uploading (offline, no credentials needed)
 gplay preflight --file app.aab --max-size 100M --fail-on warning
+
+# Block only on hard blockers, and check the store listing in the same pass
+gplay preflight --file app.aab --listings-dir ./fastlane/metadata/android --fail-on error
+
+# Narrow the gate to specific scanners (see `gplay preflight --list-scanners`)
+gplay preflight --file app.aab --only manifest,permissions,native_libs,secrets --fail-on warning
 
 # Fail on bundle size regression
 gplay bundles compare --base old.aab --candidate new.aab --threshold 2M

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -108,16 +108,44 @@ gplay internal-sharing upload-apk --package com.example.app --file app.apk
 ## Pre-submission checks
 
 ```bash
-# Offline compliance scan on an AAB or APK (no API calls)
-# Checks: manifest, bundle size, native ABIs, dex, debuggable, testOnly,
-# cleartext traffic, dangerous permissions, secret scan, misplaced files.
+# Offline compliance scan on an AAB or APK — no API calls, no credentials
 gplay preflight --file app.aab
 gplay preflight --file app.aab --max-size 100M --fail-on warning   # CI gate
+gplay preflight --file app.aab --listings-dir ./metadata           # also check the listing
+gplay preflight --file app.aab --output json --pretty | jq .
+gplay preflight --list-scanners
 
 # Bundle size analysis (offline)
 gplay bundles analyze --file app.aab --top-files 20
 gplay bundles compare --base old.aab --candidate new.aab --threshold 2M
 ```
+
+### What preflight scans
+
+`preflight` decodes `AndroidManifest.xml` for real — binary AXML for APKs, aapt2
+protobuf for App Bundles — so checks read typed attribute values instead of
+guessing from substrings. Nine scanners run by default; select them with
+`--only` or `--skip`.
+
+| Scanner | Catches |
+|---|---|
+| `manifest` | `debuggable`, `testOnly`, exported components missing `android:exported` (install failure on Android 12+), exported providers granting URI permissions, foreground service types without their matching permission (Android 14 `SecurityException`), cleartext traffic, `allowBackup`, package/version sanity |
+| `permissions` | Restricted permissions that need a Play declaration form, sensitive permissions that need a Data safety disclosure, legacy storage permissions on modern targets, duplicates, deprecated permissions |
+| `native_libs` | Missing `arm64-v8a`, **16 KB memory page alignment** (read from real ELF program headers — required by Play for `targetSdk` 35+), unstripped debug symbols, `extractNativeLibs="true"` |
+| `metadata` | Listing title/description/release-note lengths and **actual screenshot pixel dimensions**, aspect ratio, count, and icon/feature-graphic sizes. Requires `--listings-dir` |
+| `secrets` | Private keys, AWS/Stripe/GitHub/Slack/SendGrid/OpenAI/Anthropic tokens, service-account JSON, shipped keystores and `.pem` files, `.git`/`.env` leakage. Also scans dex string data |
+| `billing` | Third-party payment processors alongside (or instead of) Play Billing, `com.android.vending.BILLING` declared with no implementation |
+| `privacy` | 40+ analytics/attribution/ads SDKs, and `AD_ID` permission consistency against `targetSdk` 33+ |
+| `policy` | Target API level floor (override with `--min-target-sdk`), restricted services (accessibility, VPN, device admin, notification listener), APK-vs-AAB upload format |
+| `size` | Download size budget, dex fragmentation, payload breakdown by bucket |
+
+Severity is `error`, `warning`, or `info`; `--fail-on` picks the CI gate
+threshold. Findings are grouped per scanner in text output and carry Play policy
+documentation links where one applies.
+
+> **Note:** `policy` compares `targetSdkVersion` against a constant that Google
+> raises roughly every August. Pass `--min-target-sdk` to override it without
+> waiting for a new gplay release.
 
 ## Google Checks (privacy & compliance)
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/term v0.45.0
 	google.golang.org/api v0.290.0
+	google.golang.org/protobuf v1.36.11
 )
 
 require (
@@ -42,5 +43,4 @@ require (
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260706201446-f0a921348800 // indirect
 	google.golang.org/grpc v1.82.0 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/internal/cli/preflight/preflight.go
+++ b/internal/cli/preflight/preflight.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
+	"sort"
 	"strings"
 
 	"github.com/peterbourgon/ff/v3/ffcli"
@@ -18,9 +20,14 @@ import (
 func PreflightCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("preflight", flag.ExitOnError)
 	file := fs.String("file", "", "Path to .aab or .apk to scan (required)")
+	listingsDir := fs.String("listings-dir", "", "Listings directory to validate (enables the metadata scanner)")
+	only := fs.String("only", "", "Comma-separated scanners to run (default: all)")
+	skip := fs.String("skip", "", "Comma-separated scanners to exclude")
+	minTargetSDK := fs.Int("min-target-sdk", 0, "Minimum accepted targetSdkVersion (default: the current Play requirement)")
 	maxSize := fs.String("max-size", "", "Max allowed bundle size (e.g. 150M)")
 	maxDex := fs.String("max-dex", "", "Max allowed size per dex file (e.g. 64M)")
-	skipSecrets := fs.Bool("skip-secrets", false, "Skip secret-pattern scan (faster)")
+	skipSecrets := fs.Bool("skip-secrets", false, "Skip the secrets scanner (faster)")
+	listScanners := fs.Bool("list-scanners", false, "Print the available scanner IDs and exit")
 	severity := fs.String("fail-on", "error", "Exit non-zero when findings reach this severity: info, warning, error")
 	outputFlag := fs.String("output", "text", "Output format: text (default), json, markdown")
 	pretty := fs.Bool("pretty", false, "Pretty-print JSON output")
@@ -31,23 +38,44 @@ func PreflightCommand() *ffcli.Command {
 		ShortHelp:  "Run offline compliance and hygiene checks against an AAB/APK.",
 		LongHelp: `Run offline checks against an AAB or APK without any API calls.
 
-Checks include: manifest presence, bundle size, native lib coverage,
-dex count/size, debuggable flag, testOnly flag, cleartext traffic,
-dangerous permissions, secret scan (API keys/private keys/etc.),
-and developer-environment artifacts.
+AndroidManifest.xml is fully decoded — binary AXML for APKs, aapt2 protobuf
+for App Bundles — so checks read real, typed attribute values rather than
+guessing from substrings.
+
+Scanners:
+  manifest     debuggable/testOnly flags, exported components, foreground
+               service types, package and version sanity
+  permissions  restricted permissions needing a Play declaration, sensitive
+               permissions needing a Data safety disclosure, legacy storage
+  native_libs  64-bit coverage, 16 KB page alignment, debug symbols
+  metadata     listing text limits and real screenshot dimensions
+               (requires --listings-dir)
+  secrets      API keys, private keys, keystores, developer artifacts
+  billing      Play Billing vs third-party payment processors
+  privacy      analytics/ads SDKs and advertising ID consistency
+  policy       target API level floor, restricted services, upload format
+  size         download size budget, dex count, payload breakdown
 
 Exit codes:
-  0   clean
+  0   no findings at or above --fail-on
   1   findings at or above --fail-on severity
 
-Example:
+Examples:
   gplay preflight --file app.aab
-  gplay preflight --file app.aab --max-size 100M --fail-on warning
-  gplay preflight --file app.aab --output json | jq .
+  gplay preflight --file app.aab --fail-on warning
+  gplay preflight --file app.aab --listings-dir ./metadata
+  gplay preflight --file app.aab --only manifest,permissions
+  gplay preflight --file app.aab --skip size --output json | jq .
 `,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
+			if *listScanners {
+				for _, id := range preflightpkg.ScannerIDs() {
+					fmt.Println(id)
+				}
+				return nil
+			}
 			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
 				return err
 			}
@@ -58,7 +86,18 @@ Example:
 			if err != nil {
 				return err
 			}
-			opts := preflightpkg.Options{SkipSecretScan: *skipSecrets}
+
+			opts := preflightpkg.Options{
+				SkipSecretScan: *skipSecrets,
+				ListingsDir:    strings.TrimSpace(*listingsDir),
+				MinTargetSDK:   *minTargetSDK,
+			}
+			if s := strings.TrimSpace(*only); s != "" {
+				opts.Only = []string{s}
+			}
+			if s := strings.TrimSpace(*skip); s != "" {
+				opts.Skip = []string{s}
+			}
 			if strings.TrimSpace(*maxSize) != "" {
 				b, err := bundleanalysis.ParseSizeThreshold(*maxSize)
 				if err != nil {
@@ -85,7 +124,7 @@ Example:
 				return err
 			}
 
-			if shouldFail(report, failOn) {
+			if report.AtOrAbove(failOn) {
 				return shared.NewReportedError(fmt.Errorf(
 					"preflight: %d error(s), %d warning(s), %d info",
 					report.Errors, report.Warnings, report.Infos,
@@ -109,46 +148,79 @@ func parseSeverity(s string) (preflightpkg.Severity, error) {
 	}
 }
 
-func severityRank(s preflightpkg.Severity) int {
-	switch s {
-	case preflightpkg.SeverityError:
-		return 3
-	case preflightpkg.SeverityWarning:
-		return 2
-	case preflightpkg.SeverityInfo:
-		return 1
-	}
-	return 0
-}
-
-func shouldFail(r *preflightpkg.Report, min preflightpkg.Severity) bool {
-	minR := severityRank(min)
-	for _, f := range r.Findings {
-		if severityRank(f.Severity) >= minR {
-			return true
-		}
-	}
-	return false
-}
-
+// printTextReport renders a human-readable report grouped by scanner.
 func printTextReport(r *preflightpkg.Report) {
-	fmt.Println("gplay preflight")
-	fmt.Println("===============")
-	fmt.Printf("  File: %s\n", r.Path)
-	fmt.Printf("  Size: %d bytes\n\n", r.TotalSize)
+	out := os.Stdout
+
+	fmt.Fprintln(out, "gplay preflight")
+	fmt.Fprintln(out, "===============")
+	fmt.Fprintf(out, "  File:   %s\n", r.Path)
+	if r.Format != "" {
+		fmt.Fprintf(out, "  Format: %s\n", r.Format)
+	}
+	if r.Package != "" {
+		fmt.Fprintf(out, "  App:    %s", r.Package)
+		if r.VersionName != "" || r.VersionCode > 0 {
+			fmt.Fprintf(out, " (%s, versionCode %d)", r.VersionName, r.VersionCode)
+		}
+		fmt.Fprintln(out)
+	}
+	if r.MinSdk > 0 || r.TargetSdk > 0 {
+		fmt.Fprintf(out, "  SDK:    min %d, target %d\n", r.MinSdk, r.TargetSdk)
+	}
+	fmt.Fprintf(out, "  Size:   %d bytes\n", r.TotalSize)
+	fmt.Fprintln(out)
+
 	if len(r.Findings) == 0 {
-		fmt.Println("  No findings. Looks clean.")
-	} else {
-		for _, f := range r.Findings {
-			fmt.Printf("  [%s] %s: %s\n", strings.ToUpper(string(f.Severity)), f.Check, f.Message)
+		fmt.Fprintln(out, "  No findings. Looks clean.")
+	}
+
+	for _, run := range r.Scanners {
+		findings := r.FindingsFor(run.ID)
+		switch {
+		case run.Skipped:
+			fmt.Fprintf(out, "  %-12s skipped (%s)\n", run.ID, run.Reason)
+			continue
+		case len(findings) == 0:
+			fmt.Fprintf(out, "  %-12s ok\n", run.ID)
+			continue
+		}
+
+		fmt.Fprintf(out, "  %-12s %d finding(s)\n", run.ID, len(findings))
+		sortFindings(findings)
+		for _, f := range findings {
+			fmt.Fprintf(out, "    [%s] %s: %s\n", strings.ToUpper(string(f.Severity)), f.Check, f.Message)
 			if f.Entry != "" {
-				fmt.Printf("         entry: %s\n", f.Entry)
+				fmt.Fprintf(out, "           entry: %s\n", f.Entry)
 			}
 			if f.Hint != "" {
-				fmt.Printf("          hint: %s\n", f.Hint)
+				fmt.Fprintf(out, "            hint: %s\n", f.Hint)
+			}
+			if f.Ref != "" {
+				fmt.Fprintf(out, "             ref: %s\n", f.Ref)
 			}
 		}
 	}
-	fmt.Printf("\nSummary: %d error(s), %d warning(s), %d info\n",
+
+	fmt.Fprintf(out, "\nSummary: %d error(s), %d warning(s), %d info\n",
 		r.Errors, r.Warnings, r.Infos)
+}
+
+// sortFindings orders findings most severe first, then by check name so
+// output is stable across runs.
+func sortFindings(f []preflightpkg.Finding) {
+	rank := map[preflightpkg.Severity]int{
+		preflightpkg.SeverityError:   0,
+		preflightpkg.SeverityWarning: 1,
+		preflightpkg.SeverityInfo:    2,
+	}
+	sort.SliceStable(f, func(i, j int) bool {
+		if rank[f[i].Severity] != rank[f[j].Severity] {
+			return rank[f[i].Severity] < rank[f[j].Severity]
+		}
+		if f[i].Check != f[j].Check {
+			return f[i].Check < f[j].Check
+		}
+		return f[i].Entry < f[j].Entry
+	})
 }

--- a/internal/cli/preflight/preflight_test.go
+++ b/internal/cli/preflight/preflight_test.go
@@ -121,6 +121,79 @@ func TestParseSeverity(t *testing.T) {
 	}
 }
 
+func TestPreflightListScanners(t *testing.T) {
+	cmd := PreflightCommand()
+	_ = cmd.FlagSet.Parse([]string{"--list-scanners"})
+	// --file is not required when only listing scanners.
+	if err := cmd.Exec(context.Background(), nil); err != nil {
+		t.Fatalf("expected --list-scanners to succeed, got %v", err)
+	}
+}
+
+func TestPreflightRejectsUnknownScanner(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.aab")
+	writeAAB(t, path, minimalAAB())
+	cmd := PreflightCommand()
+	_ = cmd.FlagSet.Parse([]string{"--file", path, "--only", "not-a-scanner"})
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "unknown scanner") {
+		t.Fatalf("expected unknown scanner error, got %v", err)
+	}
+}
+
+func TestPreflightOnlyLimitsScanners(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.aab")
+	entries := minimalAAB()
+	entries["base/assets/.DS_Store"] = []byte{0} // a secrets-scanner warning
+	writeAAB(t, path, entries)
+
+	// Restricting to the size scanner must suppress the secrets finding, so
+	// --fail-on warning no longer trips.
+	cmd := PreflightCommand()
+	_ = cmd.FlagSet.Parse([]string{"--file", path, "--output", "json", "--fail-on", "warning", "--only", "size"})
+	if err := cmd.Exec(context.Background(), nil); err != nil {
+		t.Fatalf("--only size should not surface secrets findings, got %v", err)
+	}
+
+	// The fixture's placeholder manifest also trips the manifest and
+	// native_libs scanners, so exclude those too; this doubles as coverage of
+	// comma-separated parsing.
+	cmd = PreflightCommand()
+	_ = cmd.FlagSet.Parse([]string{
+		"--file", path, "--output", "json", "--fail-on", "warning",
+		"--skip", "secrets,manifest,native_libs",
+	})
+	if err := cmd.Exec(context.Background(), nil); err != nil {
+		t.Fatalf("--skip secrets should not surface secrets findings, got %v", err)
+	}
+
+	// Without the exclusion the same bundle must fail, proving the flag is
+	// what suppressed the finding.
+	cmd = PreflightCommand()
+	_ = cmd.FlagSet.Parse([]string{
+		"--file", path, "--output", "json", "--fail-on", "warning",
+		"--skip", "manifest,native_libs",
+	})
+	if err := cmd.Exec(context.Background(), nil); err == nil {
+		t.Fatal("expected the .DS_Store warning to fail when secrets is not skipped")
+	}
+}
+
+func TestPreflightListingsDirIsValidated(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.aab")
+	writeAAB(t, path, minimalAAB())
+	cmd := PreflightCommand()
+	_ = cmd.FlagSet.Parse([]string{
+		"--file", path,
+		"--output", "json",
+		"--listings-dir", filepath.Join(t.TempDir(), "does-not-exist"),
+	})
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected an unreadable listings directory to produce an error finding")
+	}
+}
+
 func TestPreflightInvalidMaxSize(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "app.aab")
 	writeAAB(t, path, minimalAAB())

--- a/internal/preflight/axml.go
+++ b/internal/preflight/axml.go
@@ -1,0 +1,309 @@
+package preflight
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strconv"
+	"unicode/utf16"
+)
+
+// Binary XML (AXML) decoder for APK manifests.
+//
+// APKs store AndroidManifest.xml in the platform's binary resource-chunk
+// format rather than as text. This decoder reads the string pool and the
+// element chunks so scanners can inspect real, typed attribute values.
+//
+// Reference: frameworks/base/libs/androidfw/include/androidfw/ResourceTypes.h
+
+const (
+	chunkNull            = 0x0000
+	chunkStringPool      = 0x0001
+	chunkXML             = 0x0003
+	chunkXMLStartNS      = 0x0100
+	chunkXMLEndNS        = 0x0101
+	chunkXMLStartElement = 0x0102
+	chunkXMLEndElement   = 0x0103
+	chunkXMLCData        = 0x0104
+	chunkXMLResourceMap  = 0x0180
+)
+
+// Res_value data types we care about.
+const (
+	typeNull       = 0x00
+	typeReference  = 0x01
+	typeAttribute  = 0x02
+	typeString     = 0x03
+	typeFloat      = 0x04
+	typeDimension  = 0x05
+	typeFraction   = 0x06
+	typeIntDec     = 0x10
+	typeIntHex     = 0x11
+	typeIntBoolean = 0x12
+)
+
+const stringPoolUTF8Flag = 1 << 8
+
+// noRef is the sentinel used for "no string" in AXML string references.
+const noRef = 0xFFFFFFFF
+
+// errNotAXML signals the payload is not binary XML, letting callers fall back
+// to another decoder.
+var errNotAXML = errors.New("not binary AXML")
+
+// isAXML reports whether data looks like a binary XML chunk.
+func isAXML(data []byte) bool {
+	if len(data) < 8 {
+		return false
+	}
+	return binary.LittleEndian.Uint16(data[0:2]) == chunkXML
+}
+
+// parseAXML decodes a binary AndroidManifest.xml into a Node tree.
+func parseAXML(data []byte) (*Node, error) {
+	if !isAXML(data) {
+		return nil, errNotAXML
+	}
+	headerSize := binary.LittleEndian.Uint16(data[2:4])
+	totalSize := binary.LittleEndian.Uint32(data[4:8])
+	if int(headerSize) < 8 || int(headerSize) > len(data) {
+		return nil, fmt.Errorf("axml: bad header size %d", headerSize)
+	}
+	// Trust the smaller of declared size and actual length; some tools pad.
+	end := len(data)
+	if int(totalSize) <= len(data) && totalSize > 0 {
+		end = int(totalSize)
+	}
+
+	var pool []string
+	var root *Node
+	stack := []*Node{}
+
+	off := int(headerSize)
+	for off+8 <= end {
+		cType := binary.LittleEndian.Uint16(data[off : off+2])
+		cHeader := binary.LittleEndian.Uint16(data[off+2 : off+4])
+		cSize := binary.LittleEndian.Uint32(data[off+4 : off+8])
+		if cSize < 8 || int(cSize) > end-off {
+			return nil, fmt.Errorf("axml: bad chunk size %d at offset %d", cSize, off)
+		}
+		chunk := data[off : off+int(cSize)]
+
+		switch cType {
+		case chunkStringPool:
+			p, err := parseStringPool(chunk)
+			if err != nil {
+				return nil, err
+			}
+			pool = p
+		case chunkXMLStartElement:
+			node, err := parseStartElement(chunk, int(cHeader), pool)
+			if err != nil {
+				return nil, err
+			}
+			if len(stack) == 0 {
+				if root == nil {
+					root = node
+				}
+			} else {
+				parent := stack[len(stack)-1]
+				parent.Children = append(parent.Children, node)
+			}
+			stack = append(stack, node)
+		case chunkXMLEndElement:
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		case chunkXMLStartNS, chunkXMLEndNS, chunkXMLCData, chunkXMLResourceMap, chunkNull:
+			// Not needed: attribute namespaces are stored as full URIs.
+		}
+		off += int(cSize)
+	}
+
+	if root == nil {
+		return nil, errors.New("axml: no root element")
+	}
+	return root, nil
+}
+
+// parseStringPool decodes a RES_STRING_POOL chunk into its string values.
+func parseStringPool(chunk []byte) ([]string, error) {
+	if len(chunk) < 28 {
+		return nil, errors.New("axml: string pool too small")
+	}
+	count := binary.LittleEndian.Uint32(chunk[8:12])
+	flags := binary.LittleEndian.Uint32(chunk[16:20])
+	stringsStart := binary.LittleEndian.Uint32(chunk[20:24])
+	utf8 := flags&stringPoolUTF8Flag != 0
+
+	// Guard against absurd counts from malformed input before allocating.
+	if int(count) > len(chunk)/4 {
+		return nil, fmt.Errorf("axml: string count %d exceeds chunk capacity", count)
+	}
+	offsetsAt := 28
+	if offsetsAt+int(count)*4 > len(chunk) {
+		return nil, errors.New("axml: truncated string offset table")
+	}
+
+	out := make([]string, count)
+	for i := 0; i < int(count); i++ {
+		rel := binary.LittleEndian.Uint32(chunk[offsetsAt+i*4 : offsetsAt+i*4+4])
+		at := int(stringsStart) + int(rel)
+		if at < 0 || at >= len(chunk) {
+			continue // tolerate individual bad offsets
+		}
+		if utf8 {
+			out[i] = decodeUTF8String(chunk, at)
+		} else {
+			out[i] = decodeUTF16String(chunk, at)
+		}
+	}
+	return out, nil
+}
+
+// decodeLen8 reads a UTF-8 pool length, which uses a high-bit continuation.
+func decodeLen8(b []byte, at int) (length, next int) {
+	if at >= len(b) {
+		return 0, at
+	}
+	v := int(b[at])
+	at++
+	if v&0x80 != 0 {
+		if at >= len(b) {
+			return 0, at
+		}
+		v = ((v & 0x7F) << 8) | int(b[at])
+		at++
+	}
+	return v, at
+}
+
+// decodeLen16 reads a UTF-16 pool length, which uses a high-bit continuation.
+func decodeLen16(b []byte, at int) (length, next int) {
+	if at+2 > len(b) {
+		return 0, at
+	}
+	v := int(binary.LittleEndian.Uint16(b[at : at+2]))
+	at += 2
+	if v&0x8000 != 0 {
+		if at+2 > len(b) {
+			return 0, at
+		}
+		v = ((v & 0x7FFF) << 16) | int(binary.LittleEndian.Uint16(b[at:at+2]))
+		at += 2
+	}
+	return v, at
+}
+
+func decodeUTF8String(b []byte, at int) string {
+	// UTF-8 entries carry the character count first, then the byte count.
+	_, at = decodeLen8(b, at)
+	byteLen, at := decodeLen8(b, at)
+	if at+byteLen > len(b) || byteLen < 0 {
+		return ""
+	}
+	return string(b[at : at+byteLen])
+}
+
+func decodeUTF16String(b []byte, at int) string {
+	unitLen, at := decodeLen16(b, at)
+	if unitLen < 0 || at+unitLen*2 > len(b) {
+		return ""
+	}
+	units := make([]uint16, unitLen)
+	for i := 0; i < unitLen; i++ {
+		units[i] = binary.LittleEndian.Uint16(b[at+i*2 : at+i*2+2])
+	}
+	return string(utf16.Decode(units))
+}
+
+func poolAt(pool []string, idx uint32) string {
+	if idx == noRef || int(idx) >= len(pool) {
+		return ""
+	}
+	return pool[idx]
+}
+
+// parseStartElement decodes a RES_XML_START_ELEMENT chunk and its attributes.
+func parseStartElement(chunk []byte, headerSize int, pool []string) (*Node, error) {
+	// Layout after the node header: ns, name, attrStart, attrSize, attrCount, ...
+	if headerSize+20 > len(chunk) {
+		return nil, errors.New("axml: truncated start element")
+	}
+	base := headerSize
+	nameIdx := binary.LittleEndian.Uint32(chunk[base+4 : base+8])
+	attrStart := binary.LittleEndian.Uint16(chunk[base+8 : base+10])
+	attrSize := binary.LittleEndian.Uint16(chunk[base+10 : base+12])
+	attrCount := binary.LittleEndian.Uint16(chunk[base+12 : base+14])
+
+	node := &Node{Name: poolAt(pool, nameIdx)}
+	if attrSize == 0 {
+		attrSize = 20
+	}
+
+	at := base + int(attrStart)
+	for i := 0; i < int(attrCount); i++ {
+		if at+int(attrSize) > len(chunk) {
+			break // tolerate truncation rather than failing the whole parse
+		}
+		rec := chunk[at : at+int(attrSize)]
+		nsIdx := binary.LittleEndian.Uint32(rec[0:4])
+		nIdx := binary.LittleEndian.Uint32(rec[4:8])
+		rawIdx := binary.LittleEndian.Uint32(rec[8:12])
+		dataType := rec[15]
+		data := binary.LittleEndian.Uint32(rec[16:20])
+
+		a := Attr{
+			Namespace: poolAt(pool, nsIdx),
+			Name:      poolAt(pool, nIdx),
+			Value:     poolAt(pool, rawIdx),
+		}
+		applyResValue(&a, dataType, data, pool)
+		node.Attrs = append(node.Attrs, a)
+		at += int(attrSize)
+	}
+	return node, nil
+}
+
+// applyResValue fills in the typed portion of an attribute from a Res_value.
+func applyResValue(a *Attr, dataType byte, data uint32, pool []string) {
+	switch dataType {
+	case typeIntBoolean:
+		a.Type = AttrBool
+		a.Bool = data != 0
+		a.Int = int64(int32(data)) // #nosec G115 -- intentional signed reinterpretation
+		if a.Value == "" {
+			a.Value = strconv.FormatBool(a.Bool)
+		}
+	case typeIntDec:
+		a.Type = AttrInt
+		a.Int = int64(int32(data)) // #nosec G115
+		if a.Value == "" {
+			a.Value = strconv.FormatInt(a.Int, 10)
+		}
+	case typeIntHex:
+		a.Type = AttrInt
+		a.Int = int64(int32(data)) // #nosec G115
+		if a.Value == "" {
+			a.Value = "0x" + strconv.FormatUint(uint64(data), 16)
+		}
+	case typeString:
+		a.Type = AttrString
+		if a.Value == "" {
+			a.Value = poolAt(pool, data)
+		}
+	case typeReference, typeAttribute:
+		a.Type = AttrReference
+		if a.Value == "" {
+			a.Value = fmt.Sprintf("@0x%08x", data)
+		}
+	case typeNull:
+		a.Type = AttrUnknown
+	case typeFloat, typeDimension, typeFraction:
+		a.Type = AttrUnknown
+	default:
+		if a.Type == AttrUnknown && a.Value != "" {
+			a.Type = AttrString
+		}
+	}
+}

--- a/internal/preflight/axml_test.go
+++ b/internal/preflight/axml_test.go
@@ -1,0 +1,302 @@
+package preflight
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+	"unicode/utf16"
+)
+
+// --- minimal AXML encoder used to build fixtures ---------------------------
+
+type testAttr struct {
+	ns       string // "" means no namespace
+	name     string
+	raw      string // raw string value; "" for none
+	dataType byte
+	data     uint32
+}
+
+type testElem struct {
+	name     string
+	attrs    []testAttr
+	children []testElem
+}
+
+type axmlEncoder struct {
+	strs []string
+	idx  map[string]uint32
+	utf8 bool
+}
+
+func newAXMLEncoder(utf8 bool) *axmlEncoder {
+	return &axmlEncoder{idx: map[string]uint32{}, utf8: utf8}
+}
+
+func (e *axmlEncoder) intern(s string) uint32 {
+	if i, ok := e.idx[s]; ok {
+		return i
+	}
+	i := uint32(len(e.strs))
+	e.strs = append(e.strs, s)
+	e.idx[s] = i
+	return i
+}
+
+func (e *axmlEncoder) ref(s string) uint32 {
+	if s == "" {
+		return noRef
+	}
+	return e.intern(s)
+}
+
+// collect interns every string the tree needs, before offsets are computed.
+func (e *axmlEncoder) collect(el testElem) {
+	e.intern(el.name)
+	for _, a := range el.attrs {
+		if a.ns != "" {
+			e.intern(a.ns)
+		}
+		e.intern(a.name)
+		if a.raw != "" {
+			e.intern(a.raw)
+		}
+	}
+	for _, c := range el.children {
+		e.collect(c)
+	}
+}
+
+func u16(b *bytes.Buffer, v uint16) { _ = binary.Write(b, binary.LittleEndian, v) }
+func u32(b *bytes.Buffer, v uint32) { _ = binary.Write(b, binary.LittleEndian, v) }
+
+func (e *axmlEncoder) stringPool() []byte {
+	data := &bytes.Buffer{}
+	offsets := make([]uint32, len(e.strs))
+	for i, s := range e.strs {
+		offsets[i] = uint32(data.Len())
+		if e.utf8 {
+			data.WriteByte(byte(len([]rune(s))))
+			data.WriteByte(byte(len(s)))
+			data.WriteString(s)
+			data.WriteByte(0)
+		} else {
+			units := utf16.Encode([]rune(s))
+			u16(data, uint16(len(units)))
+			for _, u := range units {
+				u16(data, u)
+			}
+			u16(data, 0)
+		}
+	}
+	for data.Len()%4 != 0 {
+		data.WriteByte(0)
+	}
+
+	headerSize := uint32(28)
+	stringsStart := headerSize + uint32(len(e.strs))*4
+	total := stringsStart + uint32(data.Len())
+
+	out := &bytes.Buffer{}
+	u16(out, chunkStringPool)
+	u16(out, uint16(headerSize))
+	u32(out, total)
+	u32(out, uint32(len(e.strs)))
+	u32(out, 0) // styleCount
+	var flags uint32
+	if e.utf8 {
+		flags = stringPoolUTF8Flag
+	}
+	u32(out, flags)
+	u32(out, stringsStart)
+	u32(out, 0) // stylesStart
+	for _, o := range offsets {
+		u32(out, o)
+	}
+	out.Write(data.Bytes())
+	return out.Bytes()
+}
+
+func (e *axmlEncoder) element(el testElem) []byte {
+	out := &bytes.Buffer{}
+	size := uint32(36 + 20*len(el.attrs))
+	u16(out, chunkXMLStartElement)
+	u16(out, 16)
+	u32(out, size)
+	u32(out, 1)     // line
+	u32(out, noRef) // comment
+	u32(out, noRef) // element namespace
+	u32(out, e.intern(el.name))
+	u16(out, 20) // attributeStart
+	u16(out, 20) // attributeSize
+	u16(out, uint16(len(el.attrs)))
+	u16(out, 0) // idIndex
+	u16(out, 0) // classIndex
+	u16(out, 0) // styleIndex
+	for _, a := range el.attrs {
+		u32(out, e.ref(a.ns))
+		u32(out, e.intern(a.name))
+		u32(out, e.ref(a.raw))
+		u16(out, 8) // Res_value size
+		out.WriteByte(0)
+		out.WriteByte(a.dataType)
+		u32(out, a.data)
+	}
+
+	for _, c := range el.children {
+		out.Write(e.element(c))
+	}
+
+	end := &bytes.Buffer{}
+	u16(end, chunkXMLEndElement)
+	u16(end, 16)
+	u32(end, 24)
+	u32(end, 1)
+	u32(end, noRef)
+	u32(end, noRef)
+	u32(end, e.intern(el.name))
+	out.Write(end.Bytes())
+	return out.Bytes()
+}
+
+// encodeAXML renders a tree as a binary XML document.
+func encodeAXML(t *testing.T, root testElem, utf8 bool) []byte {
+	t.Helper()
+	e := newAXMLEncoder(utf8)
+	e.collect(root)
+	body := e.element(root)
+	pool := e.stringPool()
+
+	out := &bytes.Buffer{}
+	u16(out, chunkXML)
+	u16(out, 8)
+	u32(out, uint32(8+len(pool)+len(body)))
+	out.Write(pool)
+	out.Write(body)
+	return out.Bytes()
+}
+
+// --- tests -----------------------------------------------------------------
+
+func TestParseAXMLRejectsNonAXML(t *testing.T) {
+	if _, err := parseAXML([]byte("not xml at all")); err == nil {
+		t.Fatal("expected error for non-AXML input")
+	}
+	if _, err := parseAXML(nil); err == nil {
+		t.Fatal("expected error for empty input")
+	}
+}
+
+func TestParseAXMLTypedValues(t *testing.T) {
+	root := testElem{
+		name: "manifest",
+		attrs: []testAttr{
+			{name: "package", raw: "com.example.app", dataType: typeString},
+			{ns: AndroidNS, name: "versionCode", dataType: typeIntDec, data: 42},
+			{ns: AndroidNS, name: "testOnly", dataType: typeIntBoolean, data: 1},
+		},
+		children: []testElem{
+			{name: "uses-sdk", attrs: []testAttr{
+				{ns: AndroidNS, name: "minSdkVersion", dataType: typeIntDec, data: 24},
+				{ns: AndroidNS, name: "targetSdkVersion", dataType: typeIntDec, data: 34},
+			}},
+			{name: "application", attrs: []testAttr{
+				{ns: AndroidNS, name: "debuggable", dataType: typeIntBoolean, data: 0},
+				{ns: AndroidNS, name: "label", dataType: typeReference, data: 0x7f100001},
+			}},
+		},
+	}
+
+	for _, utf8 := range []bool{true, false} {
+		node, err := parseAXML(encodeAXML(t, root, utf8))
+		if err != nil {
+			t.Fatalf("utf8=%v: %v", utf8, err)
+		}
+		if node.Name != "manifest" {
+			t.Fatalf("utf8=%v: root = %q, want manifest", utf8, node.Name)
+		}
+		if a, ok := node.Plain("package"); !ok || a.Value != "com.example.app" {
+			t.Errorf("utf8=%v: package = %q ok=%v", utf8, a.Value, ok)
+		}
+		if v, ok := androidInt(node, "versionCode"); !ok || v != 42 {
+			t.Errorf("utf8=%v: versionCode = %d ok=%v", utf8, v, ok)
+		}
+		if v, ok := androidBool(node, "testOnly"); !ok || !v {
+			t.Errorf("utf8=%v: testOnly = %v ok=%v", utf8, v, ok)
+		}
+
+		sdk := node.Child("uses-sdk")
+		if sdk == nil {
+			t.Fatalf("utf8=%v: uses-sdk missing", utf8)
+		}
+		if v, ok := androidInt(sdk, "targetSdkVersion"); !ok || v != 34 {
+			t.Errorf("utf8=%v: targetSdk = %d ok=%v", utf8, v, ok)
+		}
+
+		app := node.Child("application")
+		if app == nil {
+			t.Fatalf("utf8=%v: application missing", utf8)
+		}
+		if v, ok := androidBool(app, "debuggable"); !ok || v {
+			t.Errorf("utf8=%v: debuggable = %v ok=%v, want false/known", utf8, v, ok)
+		}
+		// A resource reference is not statically determinable.
+		ref, _ := app.Android("label")
+		if _, ok := ref.BoolValue(); ok {
+			t.Errorf("utf8=%v: reference should not resolve to a bool", utf8)
+		}
+		if ref.Type != AttrReference {
+			t.Errorf("utf8=%v: label type = %v, want AttrReference", utf8, ref.Type)
+		}
+	}
+}
+
+func TestParseAXMLNestedChildren(t *testing.T) {
+	root := testElem{
+		name: "manifest",
+		children: []testElem{
+			{name: "application", children: []testElem{
+				{name: "activity", attrs: []testAttr{
+					{ns: AndroidNS, name: "name", raw: ".MainActivity", dataType: typeString},
+				}},
+				{name: "service", attrs: []testAttr{
+					{ns: AndroidNS, name: "name", raw: ".SyncService", dataType: typeString},
+				}},
+			}},
+		},
+	}
+	node, err := parseAXML(encodeAXML(t, root, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	app := node.Child("application")
+	if app == nil || len(app.Children) != 2 {
+		t.Fatalf("expected 2 application children, got %+v", app)
+	}
+	if got := androidString(app.Children[0], "name"); got != ".MainActivity" {
+		t.Errorf("activity name = %q", got)
+	}
+	if got := androidString(app.Children[1], "name"); got != ".SyncService" {
+		t.Errorf("service name = %q", got)
+	}
+}
+
+func TestParseAXMLTruncatedChunkIsRejected(t *testing.T) {
+	data := encodeAXML(t, testElem{name: "manifest"}, true)
+	// Corrupt the outer chunk size so parsing must bail rather than panic.
+	binary.LittleEndian.PutUint32(data[4:8], 0xFFFFFF)
+	if _, err := parseAXML(data[:16]); err == nil {
+		t.Fatal("expected error on truncated input")
+	}
+}
+
+func TestParseStringPoolRejectsAbsurdCount(t *testing.T) {
+	chunk := make([]byte, 40)
+	binary.LittleEndian.PutUint16(chunk[0:2], chunkStringPool)
+	binary.LittleEndian.PutUint16(chunk[2:4], 28)
+	binary.LittleEndian.PutUint32(chunk[4:8], 40)
+	binary.LittleEndian.PutUint32(chunk[8:12], 1<<30) // bogus string count
+	if _, err := parseStringPool(chunk); err == nil {
+		t.Fatal("expected error for absurd string count")
+	}
+}

--- a/internal/preflight/manifest.go
+++ b/internal/preflight/manifest.go
@@ -1,0 +1,257 @@
+package preflight
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Manifest is the decoded, format-independent view of an AndroidManifest.xml.
+//
+// Optional booleans are pointers so scanners can tell "absent" and "not
+// statically determinable" apart from an explicit false. A nil pointer means
+// the attribute was missing or resolved to a resource reference.
+type Manifest struct {
+	Package     string               `json:"package,omitempty"`
+	VersionCode int64                `json:"version_code,omitempty"`
+	VersionName string               `json:"version_name,omitempty"`
+	MinSdk      int                  `json:"min_sdk,omitempty"`
+	TargetSdk   int                  `json:"target_sdk,omitempty"`
+	TestOnly    *bool                `json:"test_only,omitempty"`
+	Permissions []ManifestPermission `json:"permissions,omitempty"`
+	Features    []ManifestFeature    `json:"features,omitempty"`
+	Application Application          `json:"application"`
+
+	// Root is the raw decoded tree, kept for checks that need to look at
+	// elements the typed model does not model explicitly.
+	Root *Node `json:"-"`
+}
+
+// ManifestPermission is a <uses-permission> declaration.
+type ManifestPermission struct {
+	Name   string `json:"name"`
+	MaxSdk int    `json:"max_sdk,omitempty"`
+}
+
+// ManifestFeature is a <uses-feature> declaration.
+type ManifestFeature struct {
+	Name     string `json:"name"`
+	Required *bool  `json:"required,omitempty"`
+}
+
+// Application is the decoded <application> element.
+type Application struct {
+	Present                      bool            `json:"present"`
+	Name                         string          `json:"name,omitempty"`
+	Debuggable                   *bool           `json:"debuggable,omitempty"`
+	AllowBackup                  *bool           `json:"allow_backup,omitempty"`
+	UsesCleartextTraffic         *bool           `json:"uses_cleartext_traffic,omitempty"`
+	NetworkSecurityConfig        string          `json:"network_security_config,omitempty"`
+	RequestLegacyExternalStorage *bool           `json:"request_legacy_external_storage,omitempty"`
+	ExtractNativeLibs            *bool           `json:"extract_native_libs,omitempty"`
+	MetaData                     []MetaDataEntry `json:"meta_data,omitempty"`
+	Components                   []Component     `json:"components,omitempty"`
+}
+
+// MetaDataEntry is an <meta-data> child of <application>.
+type MetaDataEntry struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+}
+
+// Component is an activity, activity-alias, service, receiver, or provider.
+type Component struct {
+	Kind                   string   `json:"kind"`
+	Name                   string   `json:"name"`
+	Exported               *bool    `json:"exported,omitempty"`
+	Permission             string   `json:"permission,omitempty"`
+	HasIntentFilter        bool     `json:"has_intent_filter,omitempty"`
+	IsLauncher             bool     `json:"is_launcher,omitempty"`
+	ForegroundServiceTypes []string `json:"foreground_service_types,omitempty"`
+	GrantURIPermissions    *bool    `json:"grant_uri_permissions,omitempty"`
+}
+
+// componentKinds are the manifest elements treated as app components.
+var componentKinds = []string{"activity", "activity-alias", "service", "receiver", "provider"}
+
+// parseManifestBytes decodes either an APK binary manifest or an AAB protobuf
+// manifest into the typed model.
+func parseManifestBytes(data []byte) (*Manifest, error) {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("manifest: empty")
+	}
+	var (
+		root *Node
+		err  error
+	)
+	if isAXML(data) {
+		root, err = parseAXML(data)
+	} else {
+		root, err = parseProtoXML(data)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("manifest: %w", err)
+	}
+	if root.Name != "manifest" {
+		return nil, fmt.Errorf("manifest: root element is %q, want manifest", root.Name)
+	}
+	return manifestFromNode(root), nil
+}
+
+// manifestFromNode projects a decoded tree onto the typed model.
+func manifestFromNode(root *Node) *Manifest {
+	m := &Manifest{Root: root}
+
+	if a, ok := root.Plain("package"); ok {
+		m.Package = a.Value
+	}
+	if v, ok := androidInt(root, "versionCode"); ok {
+		m.VersionCode = v
+	}
+	m.VersionName = androidString(root, "versionName")
+	m.TestOnly = optAndroidBool(root, "testOnly")
+
+	if sdk := root.Child("uses-sdk"); sdk != nil {
+		if v, ok := androidInt(sdk, "minSdkVersion"); ok {
+			m.MinSdk = int(v)
+		}
+		if v, ok := androidInt(sdk, "targetSdkVersion"); ok {
+			m.TargetSdk = int(v)
+		}
+	}
+
+	for _, p := range root.ChildrenNamed("uses-permission") {
+		perm := ManifestPermission{Name: androidString(p, "name")}
+		if v, ok := androidInt(p, "maxSdkVersion"); ok {
+			perm.MaxSdk = int(v)
+		}
+		if perm.Name != "" {
+			m.Permissions = append(m.Permissions, perm)
+		}
+	}
+	// <uses-permission-sdk-23> grants the same capability on newer platforms.
+	for _, p := range root.ChildrenNamed("uses-permission-sdk-23") {
+		if name := androidString(p, "name"); name != "" {
+			m.Permissions = append(m.Permissions, ManifestPermission{Name: name})
+		}
+	}
+
+	for _, f := range root.ChildrenNamed("uses-feature") {
+		name := androidString(f, "name")
+		if name == "" {
+			continue
+		}
+		m.Features = append(m.Features, ManifestFeature{
+			Name:     name,
+			Required: optAndroidBool(f, "required"),
+		})
+	}
+
+	if app := root.Child("application"); app != nil {
+		m.Application = applicationFromNode(app)
+	}
+	return m
+}
+
+// applicationFromNode projects the <application> subtree onto the typed model.
+func applicationFromNode(app *Node) Application {
+	out := Application{
+		Present:                      true,
+		Name:                         androidString(app, "name"),
+		Debuggable:                   optAndroidBool(app, "debuggable"),
+		AllowBackup:                  optAndroidBool(app, "allowBackup"),
+		UsesCleartextTraffic:         optAndroidBool(app, "usesCleartextTraffic"),
+		NetworkSecurityConfig:        androidString(app, "networkSecurityConfig"),
+		RequestLegacyExternalStorage: optAndroidBool(app, "requestLegacyExternalStorage"),
+		ExtractNativeLibs:            optAndroidBool(app, "extractNativeLibs"),
+	}
+
+	for _, md := range app.ChildrenNamed("meta-data") {
+		name := androidString(md, "name")
+		if name == "" {
+			continue
+		}
+		out.MetaData = append(out.MetaData, MetaDataEntry{Name: name, Value: androidString(md, "value")})
+	}
+
+	for _, kind := range componentKinds {
+		for _, c := range app.ChildrenNamed(kind) {
+			out.Components = append(out.Components, componentFromNode(kind, c))
+		}
+	}
+	return out
+}
+
+// componentFromNode projects a single component element onto the typed model.
+func componentFromNode(kind string, c *Node) Component {
+	comp := Component{
+		Kind:                kind,
+		Name:                androidString(c, "name"),
+		Exported:            optAndroidBool(c, "exported"),
+		Permission:          androidString(c, "permission"),
+		GrantURIPermissions: optAndroidBool(c, "grantUriPermissions"),
+	}
+
+	filters := c.ChildrenNamed("intent-filter")
+	comp.HasIntentFilter = len(filters) > 0
+	for _, f := range filters {
+		hasMain, hasLauncher := false, false
+		for _, a := range f.ChildrenNamed("action") {
+			if androidString(a, "name") == "android.intent.action.MAIN" {
+				hasMain = true
+			}
+		}
+		for _, cat := range f.ChildrenNamed("category") {
+			if androidString(cat, "name") == "android.intent.category.LAUNCHER" {
+				hasLauncher = true
+			}
+		}
+		if hasMain && hasLauncher {
+			comp.IsLauncher = true
+		}
+	}
+
+	if raw := androidString(c, "foregroundServiceType"); raw != "" {
+		for _, t := range strings.Split(raw, "|") {
+			if t = strings.TrimSpace(t); t != "" {
+				comp.ForegroundServiceTypes = append(comp.ForegroundServiceTypes, t)
+			}
+		}
+	}
+	return comp
+}
+
+// optAndroidBool returns a pointer to the boolean value of an android:
+// attribute, or nil when absent or not statically determinable.
+func optAndroidBool(n *Node, name string) *bool {
+	v, ok := androidBool(n, name)
+	if !ok {
+		return nil
+	}
+	return &v
+}
+
+// isTrue reports whether an optional boolean is present and true.
+func isTrue(b *bool) bool { return b != nil && *b }
+
+// isFalse reports whether an optional boolean is present and false.
+func isFalse(b *bool) bool { return b != nil && !*b }
+
+// HasPermission reports whether the manifest declares the named permission.
+func (m *Manifest) HasPermission(name string) bool {
+	for _, p := range m.Permissions {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// MetaDataValue returns the value of an <application> meta-data entry.
+func (m *Manifest) MetaDataValue(name string) (string, bool) {
+	for _, md := range m.Application.MetaData {
+		if md.Name == name {
+			return md.Value, true
+		}
+	}
+	return "", false
+}

--- a/internal/preflight/manifest_test.go
+++ b/internal/preflight/manifest_test.go
@@ -1,0 +1,178 @@
+package preflight
+
+import "testing"
+
+// richManifestProto builds an AAB-style manifest exercising the whole model.
+func richManifestProto() []byte {
+	return pbNode(pbElem{
+		name: "manifest",
+		attrs: []pbAttr{
+			{name: "package", value: "com.example.app"},
+			{ns: AndroidNS, name: "versionCode", compiled: pbPrimInt(7)},
+			{ns: AndroidNS, name: "versionName", value: "2.0.0"},
+		},
+		children: []pbElem{
+			{name: "uses-sdk", attrs: []pbAttr{
+				{ns: AndroidNS, name: "minSdkVersion", compiled: pbPrimInt(23)},
+				{ns: AndroidNS, name: "targetSdkVersion", compiled: pbPrimInt(35)},
+			}},
+			{name: "uses-permission", attrs: []pbAttr{
+				{ns: AndroidNS, name: "name", value: "android.permission.INTERNET"},
+			}},
+			{name: "uses-permission", attrs: []pbAttr{
+				{ns: AndroidNS, name: "name", value: "android.permission.WRITE_EXTERNAL_STORAGE"},
+				{ns: AndroidNS, name: "maxSdkVersion", compiled: pbPrimInt(28)},
+			}},
+			{name: "uses-permission-sdk-23", attrs: []pbAttr{
+				{ns: AndroidNS, name: "name", value: "android.permission.CAMERA"},
+			}},
+			{name: "uses-feature", attrs: []pbAttr{
+				{ns: AndroidNS, name: "name", value: "android.hardware.camera"},
+				{ns: AndroidNS, name: "required", compiled: pbPrimBool(false)},
+			}},
+			{name: "application", attrs: []pbAttr{
+				{ns: AndroidNS, name: "name", value: ".App"},
+				{ns: AndroidNS, name: "allowBackup", compiled: pbPrimBool(true)},
+				{ns: AndroidNS, name: "networkSecurityConfig", value: "@xml/net_config"},
+			}, children: []pbElem{
+				{name: "meta-data", attrs: []pbAttr{
+					{ns: AndroidNS, name: "name", value: "com.google.android.gms.ads.APPLICATION_ID"},
+					{ns: AndroidNS, name: "value", value: "ca-app-pub-000~111"},
+				}},
+				{name: "activity", attrs: []pbAttr{
+					{ns: AndroidNS, name: "name", value: ".MainActivity"},
+					{ns: AndroidNS, name: "exported", compiled: pbPrimBool(true)},
+				}, children: []pbElem{
+					{name: "intent-filter", children: []pbElem{
+						{name: "action", attrs: []pbAttr{
+							{ns: AndroidNS, name: "name", value: "android.intent.action.MAIN"},
+						}},
+						{name: "category", attrs: []pbAttr{
+							{ns: AndroidNS, name: "name", value: "android.intent.category.LAUNCHER"},
+						}},
+					}},
+				}},
+				{name: "service", attrs: []pbAttr{
+					{ns: AndroidNS, name: "name", value: ".SyncService"},
+					{ns: AndroidNS, name: "foregroundServiceType", value: "dataSync|location"},
+				}},
+				{name: "provider", attrs: []pbAttr{
+					{ns: AndroidNS, name: "name", value: ".FileProvider"},
+					{ns: AndroidNS, name: "exported", compiled: pbPrimBool(false)},
+					{ns: AndroidNS, name: "grantUriPermissions", compiled: pbPrimBool(true)},
+				}},
+			}},
+		},
+	})
+}
+
+func TestParseManifestBytesProtobuf(t *testing.T) {
+	m, err := parseManifestBytes(richManifestProto())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Package != "com.example.app" {
+		t.Errorf("package = %q", m.Package)
+	}
+	if m.VersionCode != 7 || m.VersionName != "2.0.0" {
+		t.Errorf("version = %d/%q", m.VersionCode, m.VersionName)
+	}
+	if m.MinSdk != 23 || m.TargetSdk != 35 {
+		t.Errorf("sdk = %d/%d", m.MinSdk, m.TargetSdk)
+	}
+	if len(m.Permissions) != 3 {
+		t.Fatalf("permissions = %d, want 3: %+v", len(m.Permissions), m.Permissions)
+	}
+	if !m.HasPermission("android.permission.CAMERA") {
+		t.Error("uses-permission-sdk-23 should contribute a permission")
+	}
+	if m.Permissions[1].MaxSdk != 28 {
+		t.Errorf("maxSdkVersion = %d, want 28", m.Permissions[1].MaxSdk)
+	}
+	if len(m.Features) != 1 || !isFalse(m.Features[0].Required) {
+		t.Errorf("features = %+v", m.Features)
+	}
+	if !m.Application.Present || m.Application.Name != ".App" {
+		t.Errorf("application = %+v", m.Application)
+	}
+	if !isTrue(m.Application.AllowBackup) {
+		t.Error("allowBackup should be true")
+	}
+	if m.Application.Debuggable != nil {
+		t.Error("absent debuggable should stay nil")
+	}
+	if v, ok := m.MetaDataValue("com.google.android.gms.ads.APPLICATION_ID"); !ok || v != "ca-app-pub-000~111" {
+		t.Errorf("ads meta-data = %q ok=%v", v, ok)
+	}
+
+	if len(m.Application.Components) != 3 {
+		t.Fatalf("components = %d, want 3", len(m.Application.Components))
+	}
+	act := m.Application.Components[0]
+	if act.Kind != "activity" || !act.IsLauncher || !act.HasIntentFilter || !isTrue(act.Exported) {
+		t.Errorf("activity = %+v", act)
+	}
+	svc := m.Application.Components[1]
+	if len(svc.ForegroundServiceTypes) != 2 || svc.ForegroundServiceTypes[0] != "dataSync" {
+		t.Errorf("fgs types = %+v", svc.ForegroundServiceTypes)
+	}
+	prov := m.Application.Components[2]
+	if !isFalse(prov.Exported) || !isTrue(prov.GrantURIPermissions) {
+		t.Errorf("provider = %+v", prov)
+	}
+}
+
+func TestParseManifestBytesBinaryAXML(t *testing.T) {
+	data := encodeAXML(t, testElem{
+		name: "manifest",
+		attrs: []testAttr{
+			{name: "package", raw: "com.example.apk", dataType: typeString},
+		},
+		children: []testElem{
+			{name: "uses-sdk", attrs: []testAttr{
+				{ns: AndroidNS, name: "targetSdkVersion", dataType: typeIntDec, data: 33},
+			}},
+			{name: "application", attrs: []testAttr{
+				{ns: AndroidNS, name: "debuggable", dataType: typeIntBoolean, data: 1},
+			}},
+		},
+	}, true)
+
+	m, err := parseManifestBytes(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m.Package != "com.example.apk" {
+		t.Errorf("package = %q", m.Package)
+	}
+	if m.TargetSdk != 33 {
+		t.Errorf("targetSdk = %d", m.TargetSdk)
+	}
+	if !isTrue(m.Application.Debuggable) {
+		t.Error("debuggable should be true")
+	}
+}
+
+func TestParseManifestBytesErrors(t *testing.T) {
+	if _, err := parseManifestBytes(nil); err == nil {
+		t.Error("expected error for empty manifest")
+	}
+	if _, err := parseManifestBytes([]byte("plain text manifest")); err == nil {
+		t.Error("expected error for undecodable manifest")
+	}
+	// A well-formed tree whose root is not <manifest> must be rejected.
+	notManifest := pbNode(pbElem{name: "resources"})
+	if _, err := parseManifestBytes(notManifest); err == nil {
+		t.Error("expected error for non-manifest root")
+	}
+}
+
+func TestOptionalBoolHelpers(t *testing.T) {
+	tr, fa := true, false
+	if !isTrue(&tr) || isTrue(&fa) || isTrue(nil) {
+		t.Error("isTrue")
+	}
+	if !isFalse(&fa) || isFalse(&tr) || isFalse(nil) {
+		t.Error("isFalse")
+	}
+}

--- a/internal/preflight/protoxml.go
+++ b/internal/preflight/protoxml.go
@@ -1,0 +1,287 @@
+package preflight
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// aapt2 protobuf XML decoder for AAB manifests.
+//
+// Unlike APKs, an App Bundle stores base/manifest/AndroidManifest.xml as a
+// serialized aapt2 `XmlNode` protobuf. We decode the wire format directly
+// rather than generating Go types from Resources.proto, which keeps the
+// dependency surface to protowire and avoids vendoring the schema.
+//
+// Field numbers below come from
+// frameworks/base/tools/aapt2/Resources.proto.
+
+// Field numbers for XmlNode.
+const (
+	fieldXMLNodeElement = 1
+	fieldXMLNodeText    = 2
+)
+
+// Field numbers for XmlElement.
+const (
+	fieldXMLElementNamespaceURI = 2
+	fieldXMLElementName         = 3
+	fieldXMLElementAttribute    = 4
+	fieldXMLElementChild        = 5
+)
+
+// Field numbers for XmlAttribute.
+const (
+	fieldXMLAttrNamespaceURI = 1
+	fieldXMLAttrName         = 2
+	fieldXMLAttrValue        = 3
+	fieldXMLAttrCompiledItem = 6
+)
+
+// Field numbers for Item.
+const (
+	fieldItemRef       = 1
+	fieldItemStr       = 2
+	fieldItemRawStr    = 3
+	fieldItemStyledStr = 4
+	fieldItemPrim      = 7
+)
+
+// Field numbers for Primitive's oneof.
+const (
+	fieldPrimIntDecimal     = 6
+	fieldPrimIntHexadecimal = 7
+	fieldPrimBoolean        = 8
+)
+
+// fieldStringValue is the `value` field on String/RawString/StyledString.
+const fieldStringValue = 1
+
+// maxProtoDepth bounds recursion so a malformed or hostile bundle cannot
+// exhaust the stack.
+const maxProtoDepth = 100
+
+// errNotProtoXML signals the payload is not a decodable aapt2 XmlNode.
+var errNotProtoXML = errors.New("not aapt2 protobuf XML")
+
+// parseProtoXML decodes a serialized aapt2 XmlNode into a Node tree.
+func parseProtoXML(data []byte) (*Node, error) {
+	if len(data) == 0 {
+		return nil, errNotProtoXML
+	}
+	node, err := decodeXMLNode(data, 0)
+	if err != nil {
+		return nil, err
+	}
+	if node == nil {
+		return nil, errNotProtoXML
+	}
+	return node, nil
+}
+
+// decodeXMLNode decodes an XmlNode message, returning nil for text nodes.
+func decodeXMLNode(b []byte, depth int) (*Node, error) {
+	if depth > maxProtoDepth {
+		return nil, errors.New("protoxml: nesting too deep")
+	}
+	var out *Node
+	err := eachField(b, func(num protowire.Number, typ protowire.Type, bytesVal []byte, _ uint64) error {
+		if num == fieldXMLNodeElement && typ == protowire.BytesType {
+			el, err := decodeXMLElement(bytesVal, depth+1)
+			if err != nil {
+				return err
+			}
+			out = el
+		}
+		// fieldXMLNodeText is ignored: manifests carry no meaningful text nodes.
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// decodeXMLElement decodes an XmlElement message into a Node.
+func decodeXMLElement(b []byte, depth int) (*Node, error) {
+	if depth > maxProtoDepth {
+		return nil, errors.New("protoxml: nesting too deep")
+	}
+	node := &Node{}
+	err := eachField(b, func(num protowire.Number, typ protowire.Type, bytesVal []byte, _ uint64) error {
+		if typ != protowire.BytesType {
+			return nil
+		}
+		switch num {
+		case fieldXMLElementName:
+			node.Name = string(bytesVal)
+		case fieldXMLElementNamespaceURI:
+			// Element namespace is unused; attributes carry their own URI.
+		case fieldXMLElementAttribute:
+			a, err := decodeXMLAttribute(bytesVal, depth+1)
+			if err != nil {
+				return err
+			}
+			node.Attrs = append(node.Attrs, a)
+		case fieldXMLElementChild:
+			child, err := decodeXMLNode(bytesVal, depth+1)
+			if err != nil {
+				return err
+			}
+			if child != nil {
+				node.Children = append(node.Children, child)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
+// decodeXMLAttribute decodes an XmlAttribute, preferring the compiled (typed)
+// value over the raw string when both are present.
+func decodeXMLAttribute(b []byte, depth int) (Attr, error) {
+	var a Attr
+	err := eachField(b, func(num protowire.Number, typ protowire.Type, bytesVal []byte, _ uint64) error {
+		if typ != protowire.BytesType {
+			return nil
+		}
+		switch num {
+		case fieldXMLAttrNamespaceURI:
+			a.Namespace = string(bytesVal)
+		case fieldXMLAttrName:
+			a.Name = string(bytesVal)
+		case fieldXMLAttrValue:
+			a.Value = string(bytesVal)
+		case fieldXMLAttrCompiledItem:
+			if err := decodeItem(bytesVal, &a, depth+1); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return Attr{}, err
+	}
+	if a.Type == AttrUnknown && a.Value != "" {
+		a.Type = AttrString
+	}
+	return a, nil
+}
+
+// decodeItem fills the typed portion of an attribute from an Item message.
+func decodeItem(b []byte, a *Attr, depth int) error {
+	if depth > maxProtoDepth {
+		return errors.New("protoxml: nesting too deep")
+	}
+	return eachField(b, func(num protowire.Number, typ protowire.Type, bytesVal []byte, _ uint64) error {
+		if typ != protowire.BytesType {
+			return nil
+		}
+		switch num {
+		case fieldItemPrim:
+			return decodePrimitive(bytesVal, a)
+		case fieldItemStr, fieldItemRawStr, fieldItemStyledStr:
+			s, err := decodeStringWrapper(bytesVal)
+			if err != nil {
+				return err
+			}
+			a.Type = AttrString
+			if a.Value == "" {
+				a.Value = s
+			}
+		case fieldItemRef:
+			// A resource reference is resolved from the resource table at
+			// runtime, so its value is not statically determinable here.
+			a.Type = AttrReference
+		}
+		return nil
+	})
+}
+
+// decodePrimitive reads the Primitive oneof into the attribute.
+func decodePrimitive(b []byte, a *Attr) error {
+	return eachField(b, func(num protowire.Number, typ protowire.Type, _ []byte, v uint64) error {
+		if typ != protowire.VarintType {
+			return nil
+		}
+		switch num {
+		case fieldPrimBoolean:
+			a.Type = AttrBool
+			a.Bool = v != 0
+			a.Int = int64(v) // #nosec G115 -- bool encodes as 0 or 1
+			if a.Value == "" {
+				a.Value = strconv.FormatBool(a.Bool)
+			}
+		case fieldPrimIntDecimal:
+			a.Type = AttrInt
+			a.Int = int64(int32(v)) // #nosec G115 -- proto int32 field
+			if a.Value == "" {
+				a.Value = strconv.FormatInt(a.Int, 10)
+			}
+		case fieldPrimIntHexadecimal:
+			a.Type = AttrInt
+			a.Int = int64(uint32(v)) // #nosec G115 -- proto uint32 field
+			if a.Value == "" {
+				a.Value = fmt.Sprintf("0x%x", uint32(v)) // #nosec G115
+			}
+		}
+		return nil
+	})
+}
+
+// decodeStringWrapper reads the `value` field of String/RawString/StyledString.
+func decodeStringWrapper(b []byte) (string, error) {
+	var s string
+	err := eachField(b, func(num protowire.Number, typ protowire.Type, bytesVal []byte, _ uint64) error {
+		if num == fieldStringValue && typ == protowire.BytesType {
+			s = string(bytesVal)
+		}
+		return nil
+	})
+	return s, err
+}
+
+// eachField walks a protobuf message, invoking fn per field. Length-delimited
+// fields arrive in bytesVal; varints arrive in varintVal.
+func eachField(b []byte, fn func(num protowire.Number, typ protowire.Type, bytesVal []byte, varintVal uint64) error) error {
+	for len(b) > 0 {
+		num, typ, n := protowire.ConsumeTag(b)
+		if n < 0 {
+			return fmt.Errorf("protoxml: bad tag: %w", protowire.ParseError(n))
+		}
+		b = b[n:]
+
+		switch typ {
+		case protowire.BytesType:
+			v, n := protowire.ConsumeBytes(b)
+			if n < 0 {
+				return fmt.Errorf("protoxml: bad length-delimited field %d: %w", num, protowire.ParseError(n))
+			}
+			if err := fn(num, typ, v, 0); err != nil {
+				return err
+			}
+			b = b[n:]
+		case protowire.VarintType:
+			v, n := protowire.ConsumeVarint(b)
+			if n < 0 {
+				return fmt.Errorf("protoxml: bad varint field %d: %w", num, protowire.ParseError(n))
+			}
+			if err := fn(num, typ, nil, v); err != nil {
+				return err
+			}
+			b = b[n:]
+		default:
+			n := protowire.ConsumeFieldValue(num, typ, b)
+			if n < 0 {
+				return fmt.Errorf("protoxml: bad field %d: %w", num, protowire.ParseError(n))
+			}
+			b = b[n:]
+		}
+	}
+	return nil
+}

--- a/internal/preflight/protoxml_test.go
+++ b/internal/preflight/protoxml_test.go
@@ -1,0 +1,193 @@
+package preflight
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// --- minimal aapt2 XmlNode encoder used to build fixtures ------------------
+
+func pbBytes(num protowire.Number, v []byte) []byte {
+	b := protowire.AppendTag(nil, num, protowire.BytesType)
+	return protowire.AppendBytes(b, v)
+}
+
+func pbString(num protowire.Number, s string) []byte {
+	return pbBytes(num, []byte(s))
+}
+
+func pbVarint(num protowire.Number, v uint64) []byte {
+	b := protowire.AppendTag(nil, num, protowire.VarintType)
+	return protowire.AppendVarint(b, v)
+}
+
+// pbPrimBool builds Item{prim{boolean_value}}.
+func pbPrimBool(v bool) []byte {
+	var n uint64
+	if v {
+		n = 1
+	}
+	prim := pbVarint(fieldPrimBoolean, n)
+	return pbBytes(fieldItemPrim, prim)
+}
+
+// pbPrimInt builds Item{prim{int_decimal_value}}.
+func pbPrimInt(v int32) []byte {
+	prim := pbVarint(fieldPrimIntDecimal, uint64(uint32(v)))
+	return pbBytes(fieldItemPrim, prim)
+}
+
+// pbPrimRef builds Item{ref{}}, i.e. an unresolved resource reference.
+func pbPrimRef() []byte {
+	return pbBytes(fieldItemRef, pbVarint(2, 0x7f100001))
+}
+
+type pbAttr struct {
+	ns       string
+	name     string
+	value    string
+	compiled []byte // optional Item payload
+}
+
+func pbAttribute(a pbAttr) []byte {
+	var body []byte
+	if a.ns != "" {
+		body = append(body, pbString(fieldXMLAttrNamespaceURI, a.ns)...)
+	}
+	body = append(body, pbString(fieldXMLAttrName, a.name)...)
+	if a.value != "" {
+		body = append(body, pbString(fieldXMLAttrValue, a.value)...)
+	}
+	if a.compiled != nil {
+		body = append(body, pbBytes(fieldXMLAttrCompiledItem, a.compiled)...)
+	}
+	return body
+}
+
+type pbElem struct {
+	name     string
+	attrs    []pbAttr
+	children []pbElem
+}
+
+// pbNode renders a pbElem as a serialized XmlNode message.
+func pbNode(el pbElem) []byte {
+	var body []byte
+	body = append(body, pbString(fieldXMLElementName, el.name)...)
+	for _, a := range el.attrs {
+		body = append(body, pbBytes(fieldXMLElementAttribute, pbAttribute(a))...)
+	}
+	for _, c := range el.children {
+		body = append(body, pbBytes(fieldXMLElementChild, pbNode(c))...)
+	}
+	return pbBytes(fieldXMLNodeElement, body)
+}
+
+// --- tests -----------------------------------------------------------------
+
+func TestParseProtoXMLTypedValues(t *testing.T) {
+	root := pbElem{
+		name: "manifest",
+		attrs: []pbAttr{
+			{name: "package", value: "com.example.app"},
+			{ns: AndroidNS, name: "versionCode", value: "42", compiled: pbPrimInt(42)},
+			{ns: AndroidNS, name: "versionName", value: "1.2.3"},
+		},
+		children: []pbElem{
+			{name: "uses-sdk", attrs: []pbAttr{
+				{ns: AndroidNS, name: "minSdkVersion", compiled: pbPrimInt(24)},
+				{ns: AndroidNS, name: "targetSdkVersion", compiled: pbPrimInt(34)},
+			}},
+			{name: "uses-permission", attrs: []pbAttr{
+				{ns: AndroidNS, name: "name", value: "android.permission.INTERNET"},
+			}},
+			{name: "application", attrs: []pbAttr{
+				{ns: AndroidNS, name: "debuggable", compiled: pbPrimBool(true)},
+				{ns: AndroidNS, name: "label", compiled: pbPrimRef()},
+			}, children: []pbElem{
+				{name: "activity", attrs: []pbAttr{
+					{ns: AndroidNS, name: "name", value: ".MainActivity"},
+					{ns: AndroidNS, name: "exported", compiled: pbPrimBool(true)},
+				}},
+			}},
+		},
+	}
+
+	node, err := parseProtoXML(pbNode(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if node.Name != "manifest" {
+		t.Fatalf("root = %q, want manifest", node.Name)
+	}
+	if a, _ := node.Plain("package"); a.Value != "com.example.app" {
+		t.Errorf("package = %q", a.Value)
+	}
+	if v, ok := androidInt(node, "versionCode"); !ok || v != 42 {
+		t.Errorf("versionCode = %d ok=%v", v, ok)
+	}
+
+	sdk := node.Child("uses-sdk")
+	if v, ok := androidInt(sdk, "minSdkVersion"); !ok || v != 24 {
+		t.Errorf("minSdk = %d ok=%v", v, ok)
+	}
+	if v, ok := androidInt(sdk, "targetSdkVersion"); !ok || v != 34 {
+		t.Errorf("targetSdk = %d ok=%v", v, ok)
+	}
+
+	app := node.Child("application")
+	if v, ok := androidBool(app, "debuggable"); !ok || !v {
+		t.Errorf("debuggable = %v ok=%v, want true", v, ok)
+	}
+	label, _ := app.Android("label")
+	if label.Type != AttrReference {
+		t.Errorf("label type = %v, want AttrReference", label.Type)
+	}
+	if _, ok := label.BoolValue(); ok {
+		t.Error("resource reference should not resolve to a bool")
+	}
+
+	act := app.Child("activity")
+	if v, ok := androidBool(act, "exported"); !ok || !v {
+		t.Errorf("exported = %v ok=%v", v, ok)
+	}
+}
+
+func TestParseProtoXMLCompiledItemBeatsEmptyValue(t *testing.T) {
+	// aapt2 often omits the raw string and keeps only the compiled value.
+	root := pbElem{name: "manifest", children: []pbElem{
+		{name: "application", attrs: []pbAttr{
+			{ns: AndroidNS, name: "testOnly", compiled: pbPrimBool(true)},
+		}},
+	}}
+	node, err := parseProtoXML(pbNode(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	v, ok := androidBool(node.Child("application"), "testOnly")
+	if !ok || !v {
+		t.Fatalf("testOnly = %v ok=%v, want true", v, ok)
+	}
+}
+
+func TestParseProtoXMLEmptyInput(t *testing.T) {
+	if _, err := parseProtoXML(nil); err == nil {
+		t.Fatal("expected error for empty input")
+	}
+}
+
+func TestParseProtoXMLMalformedInput(t *testing.T) {
+	// A truncated length-delimited field must error, not panic.
+	bad := []byte{0x0a, 0x7f, 0x01}
+	if _, err := parseProtoXML(bad); err == nil {
+		t.Fatal("expected error for malformed protobuf")
+	}
+}
+
+func TestParseProtoXMLTextNodeIsSkipped(t *testing.T) {
+	// An XmlNode carrying only text yields no element.
+	if _, err := parseProtoXML(pbString(fieldXMLNodeText, "hello")); err == nil {
+		t.Fatal("expected error when no element is present")
+	}
+}

--- a/internal/preflight/scan_billing.go
+++ b/internal/preflight/scan_billing.go
@@ -1,0 +1,81 @@
+package preflight
+
+import (
+	"fmt"
+	"strings"
+)
+
+const refPaymentsPolicy = "https://support.google.com/googleplay/android-developer/answer/10281818"
+
+// billingPermission is the legacy in-app billing permission.
+const billingPermission = "com.android.vending.BILLING"
+
+// scanBilling reports how the build takes payment. Play's Payments policy
+// requires Play Billing for in-app digital goods; third-party processors are
+// allowed only for physical goods and a narrow set of exemptions, so their
+// presence is worth surfacing before review rather than after.
+func scanBilling(c *scanContext) []Finding {
+	var out []Finding
+
+	hasPlayBilling := c.hasSDK(sdkPlayBilling)
+	thirdParty := c.sdksInCategory(categoryPayment)
+	wrappers := c.sdksInCategory(categoryBilling)
+
+	if len(thirdParty) > 0 {
+		sev := SeverityWarning
+		hint := "Play requires Google Play Billing for in-app digital goods; third-party processors are permitted only for physical goods or an approved exemption"
+		if hasPlayBilling {
+			// Shipping both is normal for apps selling physical and digital
+			// goods side by side.
+			sev = SeverityInfo
+			hint = "both Play Billing and a third-party processor are present; ensure digital goods route through Play Billing"
+		}
+		out = append(out, Finding{
+			Check:    "third_party_payments",
+			Severity: sev,
+			Message:  fmt.Sprintf("third-party payment SDK detected: %s", strings.Join(thirdParty, ", ")),
+			Hint:     hint,
+			Ref:      refPaymentsPolicy,
+		})
+	}
+
+	if c.manifest != nil {
+		hasPermission := c.manifest.HasPermission(billingPermission)
+		switch {
+		case hasPermission && !hasPlayBilling && len(wrappers) == 0:
+			out = append(out, Finding{
+				Check:    "billing_permission",
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("%s is declared but no Play Billing implementation was detected", billingPermission),
+				Hint:     "remove the permission if the app no longer sells in-app products",
+				Ref:      refPaymentsPolicy,
+			})
+		case hasPlayBilling:
+			out = append(out, Finding{
+				Check:    "play_billing",
+				Severity: SeverityInfo,
+				Message:  "Google Play Billing Library detected",
+				Hint:     "Play enforces a minimum Billing Library version for new uploads; keep the dependency current",
+				Ref:      "https://developer.android.com/google/play/billing/deprecation-faq",
+			})
+		}
+	}
+
+	// Billing wrappers still use Play Billing underneath, but the underlying
+	// library must be present for purchases to work at all.
+	for _, w := range wrappers {
+		if w == sdkNameByID(sdkPlayBilling) {
+			continue
+		}
+		if hasPlayBilling {
+			continue
+		}
+		out = append(out, Finding{
+			Check:    "billing_wrapper",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("%s was detected without the Google Play Billing Library", w),
+			Hint:     "billing wrappers depend on Play Billing; confirm the dependency was not stripped",
+		})
+	}
+	return out
+}

--- a/internal/preflight/scan_manifest.go
+++ b/internal/preflight/scan_manifest.go
@@ -1,0 +1,373 @@
+package preflight
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+)
+
+// scanManifest checks the structural and security-relevant properties of
+// AndroidManifest.xml. When the manifest cannot be decoded it falls back to
+// substring heuristics so an unusual or obfuscated build still gets coverage.
+func scanManifest(c *scanContext) []Finding {
+	var out []Finding
+
+	if len(c.manifestRaw) == 0 {
+		return append(out, Finding{
+			Check:    "manifest",
+			Severity: SeverityError,
+			Message:  "AndroidManifest.xml not found",
+			Hint:     "the archive must contain base/manifest/AndroidManifest.xml (AAB) or AndroidManifest.xml (APK)",
+		})
+	}
+
+	out = append(out, checkResourceTable(c)...)
+
+	if c.manifest == nil {
+		out = append(out, Finding{
+			Check:    "manifest_undecodable",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("AndroidManifest.xml could not be decoded (%v); falling back to heuristic checks", c.manifestErr),
+			Hint:     "structured manifest checks are unavailable for this build",
+		})
+		return append(out, heuristicManifestChecks(c.manifestRaw)...)
+	}
+
+	m := c.manifest
+	out = append(out, checkManifestIdentity(m)...)
+	out = append(out, checkManifestSecurityFlags(m)...)
+	out = append(out, checkExportedComponents(m)...)
+	out = append(out, checkForegroundServiceTypes(m)...)
+	return out
+}
+
+// checkResourceTable verifies a compiled resource table is present.
+func checkResourceTable(c *scanContext) []Finding {
+	if c.hasEntry("base/resources.pb") || c.hasEntry("resources.arsc") {
+		return nil
+	}
+	// Feature-only modules legitimately ship without a base resource table.
+	if c.hasEntrySuffix("/resources.pb") {
+		return nil
+	}
+	return []Finding{{
+		Check:    "resources",
+		Severity: SeverityError,
+		Message:  "resource table not found (base/resources.pb or resources.arsc)",
+		Hint:     "the upload does not look like a complete app bundle or APK",
+	}}
+}
+
+// checkManifestIdentity validates package name and version metadata.
+func checkManifestIdentity(m *Manifest) []Finding {
+	var out []Finding
+
+	if m.Package == "" {
+		out = append(out, Finding{
+			Check:    "package_name",
+			Severity: SeverityError,
+			Message:  "manifest declares no package name",
+		})
+	} else if isPlaceholderPackage(m.Package) {
+		out = append(out, Finding{
+			Check:    "package_name",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("package name %q uses a reserved placeholder prefix", m.Package),
+			Hint:     "Play rejects applicationIds under com.example, com.android, or android",
+		})
+	}
+
+	if !m.Application.Present {
+		out = append(out, Finding{
+			Check:    "application",
+			Severity: SeverityError,
+			Message:  "manifest has no <application> element",
+		})
+	}
+
+	if m.VersionCode <= 0 {
+		out = append(out, Finding{
+			Check:    "version_code",
+			Severity: SeverityWarning,
+			Message:  "versionCode is missing or not a positive integer",
+			Hint:     "Play requires a versionCode strictly greater than any previously uploaded build",
+		})
+	}
+
+	if m.MinSdk > 0 && m.TargetSdk > 0 && m.MinSdk > m.TargetSdk {
+		out = append(out, Finding{
+			Check:    "sdk_range",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("minSdkVersion %d is greater than targetSdkVersion %d", m.MinSdk, m.TargetSdk),
+		})
+	}
+	return out
+}
+
+// isPlaceholderPackage reports whether a package name uses a prefix Play
+// refuses to publish.
+func isPlaceholderPackage(pkg string) bool {
+	for _, bad := range []string{"com.example.", "com.android.", "android."} {
+		if strings.HasPrefix(pkg, bad) {
+			return true
+		}
+	}
+	return pkg == "com.example" || pkg == "com.android"
+}
+
+// checkManifestSecurityFlags inspects the security-relevant application flags.
+func checkManifestSecurityFlags(m *Manifest) []Finding {
+	var out []Finding
+	app := m.Application
+
+	if isTrue(app.Debuggable) {
+		out = append(out, Finding{
+			Check:    "debuggable",
+			Severity: SeverityError,
+			Message:  "android:debuggable is true",
+			Hint:     "release builds must not be debuggable; Play rejects debuggable uploads",
+		})
+	}
+
+	if isTrue(m.TestOnly) {
+		out = append(out, Finding{
+			Check:    "test_only",
+			Severity: SeverityError,
+			Message:  "android:testOnly is true",
+			Hint:     "remove testOnly; it is set by `gradlew installDebug` style builds and blocks Play upload",
+		})
+	}
+
+	if isTrue(app.UsesCleartextTraffic) {
+		sev, hint := SeverityWarning, "prefer HTTPS everywhere; cleartext traffic weakens transport security"
+		if app.NetworkSecurityConfig != "" {
+			sev = SeverityInfo
+			hint = "a network security config is present, which may already restrict cleartext to specific domains"
+		}
+		out = append(out, Finding{
+			Check:    "cleartext_traffic",
+			Severity: sev,
+			Message:  "android:usesCleartextTraffic is true",
+			Hint:     hint,
+		})
+	}
+
+	if isTrue(app.AllowBackup) {
+		out = append(out, Finding{
+			Check:    "allow_backup",
+			Severity: SeverityWarning,
+			Message:  "android:allowBackup is true",
+			Hint:     "app data can be extracted via adb backup on some devices; set false or supply a backup rules file",
+		})
+	}
+
+	if isTrue(app.RequestLegacyExternalStorage) && m.TargetSdk >= 30 {
+		out = append(out, Finding{
+			Check:    "legacy_storage",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("requestLegacyExternalStorage is set but targetSdk %d ignores it", m.TargetSdk),
+			Hint:     "scoped storage is mandatory from Android 11; migrate off legacy external storage",
+		})
+	}
+	return out
+}
+
+// checkExportedComponents flags components reachable by other apps.
+func checkExportedComponents(m *Manifest) []Finding {
+	var out []Finding
+
+	for _, comp := range m.Application.Components {
+		name := comp.Name
+		if name == "" {
+			name = "(unnamed " + comp.Kind + ")"
+		}
+
+		// Android 12 requires an explicit android:exported on any component
+		// with an intent filter; the install fails outright without it.
+		if comp.HasIntentFilter && comp.Exported == nil && m.TargetSdk >= 31 {
+			out = append(out, Finding{
+				Check:    "exported_undeclared",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("%s %s has an intent filter but no android:exported", comp.Kind, name),
+				Entry:    name,
+				Hint:     "Android 12+ refuses to install apps whose filtered components omit android:exported",
+				Ref:      "https://developer.android.com/guide/topics/manifest/activity-element#exported",
+			})
+			continue
+		}
+
+		if !isTrue(comp.Exported) {
+			continue
+		}
+		// A launcher activity is exported by design.
+		if comp.IsLauncher {
+			continue
+		}
+		if comp.Permission != "" {
+			continue
+		}
+
+		sev := SeverityWarning
+		if comp.Kind == "activity" && comp.HasIntentFilter {
+			// Deep-link style activities are commonly exported on purpose.
+			sev = SeverityInfo
+		}
+		out = append(out, Finding{
+			Check:    "exported_component",
+			Severity: sev,
+			Message:  fmt.Sprintf("%s %s is exported without a permission guard", comp.Kind, name),
+			Entry:    name,
+			Hint:     "any installed app can reach this component; add android:permission or set exported=false",
+		})
+
+		if comp.Kind == "provider" && isTrue(comp.GrantURIPermissions) {
+			out = append(out, Finding{
+				Check:    "exported_provider",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("provider %s is exported and grants URI permissions", name),
+				Entry:    name,
+				Hint:     "an exported provider with grantUriPermissions can leak private files to any app",
+			})
+		}
+	}
+	return out
+}
+
+// foregroundServiceTypesNeedingNoPermission are the types Android does not
+// gate behind a dedicated FOREGROUND_SERVICE_* permission.
+var foregroundServiceTypesNeedingNoPermission = map[string]bool{
+	"shortService": true,
+}
+
+// checkForegroundServiceTypes verifies each declared foreground service type
+// has its matching runtime permission. Android 14 throws
+// SecurityException at startForeground() when the permission is absent.
+func checkForegroundServiceTypes(m *Manifest) []Finding {
+	var out []Finding
+	if m.TargetSdk > 0 && m.TargetSdk < 34 {
+		return nil
+	}
+
+	for _, comp := range m.Application.Components {
+		if comp.Kind != "service" {
+			continue
+		}
+		for _, t := range comp.ForegroundServiceTypes {
+			if foregroundServiceTypesNeedingNoPermission[t] {
+				continue
+			}
+			perm := "android.permission.FOREGROUND_SERVICE_" + camelToScreamingSnake(t)
+			if m.HasPermission(perm) {
+				continue
+			}
+			out = append(out, Finding{
+				Check:    "foreground_service_type",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("service %s declares foregroundServiceType %q without %s", comp.Name, t, perm),
+				Entry:    comp.Name,
+				Hint:     "Android 14 throws SecurityException at startForeground() when the type permission is missing",
+				Ref:      "https://developer.android.com/about/versions/14/changes/fgs-types-required",
+			})
+		}
+	}
+
+	// A declared FGS type permission with no service using it is dead weight
+	// and, more importantly, expands the Play declaration surface.
+	declared := map[string]bool{}
+	for _, comp := range m.Application.Components {
+		for _, t := range comp.ForegroundServiceTypes {
+			declared[strings.ToLower(t)] = true
+		}
+	}
+	for _, p := range m.Permissions {
+		const prefix = "android.permission.FOREGROUND_SERVICE_"
+		if !strings.HasPrefix(p.Name, prefix) {
+			continue
+		}
+		suffix := strings.TrimPrefix(p.Name, prefix)
+		if declared[strings.ToLower(strings.ReplaceAll(suffix, "_", ""))] {
+			continue
+		}
+		out = append(out, Finding{
+			Check:    "foreground_service_unused",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("%s is declared but no service uses that foregroundServiceType", p.Name),
+			Hint:     "remove the permission or add the matching android:foregroundServiceType",
+		})
+	}
+	return out
+}
+
+// camelToScreamingSnake converts "mediaPlayback" to "MEDIA_PLAYBACK".
+func camelToScreamingSnake(s string) string {
+	var b strings.Builder
+	for i, r := range s {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				b.WriteByte('_')
+			}
+			b.WriteRune(r)
+			continue
+		}
+		if r >= 'a' && r <= 'z' {
+			b.WriteRune(r - 32)
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// heuristicManifestChecks runs substring checks used only when the manifest
+// could not be decoded. Binary manifests store booleans as typed values, so a
+// literal `="true"` match means the payload is text or unusual — either way,
+// worth reporting.
+func heuristicManifestChecks(manifest []byte) []Finding {
+	var out []Finding
+
+	type probe struct {
+		attr     string
+		check    string
+		severity Severity
+		message  string
+		hint     string
+	}
+	probes := []probe{
+		{"debuggable", "debuggable", SeverityError, "android:debuggable appears to be true", "release builds must not be debuggable"},
+		{"testOnly", "test_only", SeverityError, "manifest appears to set android:testOnly=true", "remove testOnly before uploading"},
+		{"usesCleartextTraffic", "cleartext_traffic", SeverityWarning, "android:usesCleartextTraffic appears to be true", "prefer HTTPS"},
+	}
+
+	for _, p := range probes {
+		if !bytes.Contains(manifest, []byte(p.attr)) {
+			continue
+		}
+		literal := []byte(p.attr + "=\"true\"")
+		if bytes.Contains(manifest, literal) || containsNearby(manifest, []byte(p.attr), []byte{0x01}, 4) {
+			out = append(out, Finding{
+				Check:    p.check,
+				Severity: p.severity,
+				Message:  p.message,
+				Hint:     p.hint,
+			})
+		}
+	}
+	return out
+}
+
+// containsNearby reports whether needle appears within window bytes after a
+// matching context marker.
+func containsNearby(haystack, context, needle []byte, window int) bool {
+	if len(context) == 0 || len(needle) == 0 {
+		return false
+	}
+	idx := bytes.Index(haystack, context)
+	if idx < 0 {
+		return false
+	}
+	end := idx + len(context) + window + len(needle)
+	if end > len(haystack) {
+		end = len(haystack)
+	}
+	return bytes.Contains(haystack[idx:end], needle)
+}

--- a/internal/preflight/scan_metadata.go
+++ b/internal/preflight/scan_metadata.go
@@ -1,0 +1,356 @@
+package preflight
+
+import (
+	"fmt"
+	"image"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	// Registered for image.DecodeConfig so screenshot dimensions can be read
+	// without decoding whole images.
+	_ "image/jpeg"
+	_ "image/png"
+
+	"github.com/tamtom/play-console-cli/internal/validation"
+)
+
+// Play store listing asset rules.
+const (
+	minScreenshotSide  = 320
+	maxScreenshotSide  = 3840
+	maxScreenshotRatio = 2.0
+	minPhoneScreenshot = 2
+	maxScreenshotCount = 8
+	maxScreenshotBytes = 8 * 1024 * 1024
+	maxIconBytes       = 1024 * 1024
+	maxGraphicBytes    = 15 * 1024 * 1024
+)
+
+// fixedSizeImages maps a single-image filename to its required dimensions.
+var fixedSizeImages = map[string]struct {
+	W, H     int
+	MaxBytes int64
+}{
+	"icon.png":           {512, 512, maxIconBytes},
+	"featureGraphic.png": {1024, 500, maxGraphicBytes},
+	"promoGraphic.png":   {180, 120, maxGraphicBytes},
+	"tvBanner.png":       {1280, 720, maxGraphicBytes},
+}
+
+// screenshotDirs are the per-form-factor screenshot directories.
+var screenshotDirs = []string{
+	"phoneScreenshots",
+	"sevenInchScreenshots",
+	"tenInchScreenshots",
+	"tvScreenshots",
+	"wearScreenshots",
+}
+
+// scanMetadata validates a Fastlane-style listings directory offline: text
+// field lengths and, uniquely, real screenshot pixel dimensions.
+func scanMetadata(c *scanContext) []Finding {
+	dir := c.opts.ListingsDir
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return []Finding{{
+			Check:    "listings_dir",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("cannot read listings directory: %v", err),
+			Entry:    dir,
+		}}
+	}
+
+	var locales []string
+	for _, e := range entries {
+		if e.IsDir() {
+			locales = append(locales, e.Name())
+		}
+	}
+	sort.Strings(locales)
+
+	if len(locales) == 0 {
+		return []Finding{{
+			Check:    "listings_dir",
+			Severity: SeverityError,
+			Message:  "listings directory contains no locale subdirectories",
+			Entry:    dir,
+			Hint:     "expected a layout like <dir>/en-US/title.txt",
+		}}
+	}
+
+	var out []Finding
+	for _, locale := range locales {
+		localeDir := filepath.Join(dir, locale)
+		out = append(out, checkListingText(locale, localeDir)...)
+		out = append(out, checkListingImages(locale, filepath.Join(localeDir, "images"))...)
+	}
+	return out
+}
+
+// listingTextField describes one validated text file in a locale directory.
+type listingTextField struct {
+	file     string
+	label    string
+	max      int
+	required bool
+}
+
+// checkListingText validates the text assets for one locale.
+func checkListingText(locale, localeDir string) []Finding {
+	fields := []listingTextField{
+		{"title.txt", "title", validation.MaxTitleLength, true},
+		{"short_description.txt", "short description", validation.MaxShortDescriptionLength, true},
+		{"full_description.txt", "full description", validation.MaxFullDescriptionLength, true},
+	}
+
+	var out []Finding
+	for _, f := range fields {
+		path := filepath.Join(localeDir, f.file)
+		data, err := os.ReadFile(path) // #nosec G304 -- path derived from the user-supplied listings dir
+		if err != nil {
+			if os.IsNotExist(err) && f.required {
+				out = append(out, Finding{
+					Check:    "listing_text_missing",
+					Severity: SeverityError,
+					Message:  fmt.Sprintf("[%s] %s is missing", locale, f.file),
+					Entry:    path,
+				})
+			}
+			continue
+		}
+		text := strings.TrimSpace(string(data))
+		if text == "" {
+			out = append(out, Finding{
+				Check:    "listing_text_empty",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("[%s] %s is empty", locale, f.label),
+				Entry:    path,
+			})
+			continue
+		}
+		if n := utf8.RuneCountInString(text); n > f.max {
+			out = append(out, Finding{
+				Check:    "listing_text_length",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("[%s] %s is %d characters, over the %d limit", locale, f.label, n, f.max),
+				Entry:    path,
+				Hint:     fmt.Sprintf("trim to %d characters or fewer", f.max),
+			})
+		}
+	}
+
+	out = append(out, checkChangelogs(locale, filepath.Join(localeDir, "changelogs"))...)
+	return out
+}
+
+// checkChangelogs validates release-note files for one locale.
+func checkChangelogs(locale, dir string) []Finding {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil // changelogs are optional
+	}
+	var out []Finding
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".txt") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		data, err := os.ReadFile(path) // #nosec G304 -- path derived from the user-supplied listings dir
+		if err != nil {
+			continue
+		}
+		if n := utf8.RuneCountInString(strings.TrimSpace(string(data))); n > validation.MaxReleaseNotesLength {
+			out = append(out, Finding{
+				Check:    "listing_release_notes",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("[%s] release notes are %d characters, over the %d limit", locale, n, validation.MaxReleaseNotesLength),
+				Entry:    path,
+			})
+		}
+	}
+	return out
+}
+
+// checkListingImages validates icons, graphics, and screenshots for a locale.
+func checkListingImages(locale, imagesDir string) []Finding {
+	if _, err := os.Stat(imagesDir); err != nil {
+		return nil // a locale may legitimately ship text only
+	}
+
+	var out []Finding
+	for name, spec := range fixedSizeImages {
+		path := filepath.Join(imagesDir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		cfg, format, err := decodeImageConfig(path)
+		if err != nil {
+			out = append(out, Finding{
+				Check:    "image_unreadable",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("[%s] %s could not be decoded: %v", locale, name, err),
+				Entry:    path,
+				Hint:     "Play accepts 24-bit PNG or JPEG assets",
+			})
+			continue
+		}
+		if cfg.Width != spec.W || cfg.Height != spec.H {
+			out = append(out, Finding{
+				Check:    "image_dimensions",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("[%s] %s is %dx%d, must be %dx%d", locale, name, cfg.Width, cfg.Height, spec.W, spec.H),
+				Entry:    path,
+			})
+		}
+		if info.Size() > spec.MaxBytes {
+			out = append(out, Finding{
+				Check:    "image_size",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("[%s] %s is %d bytes, over the %d limit", locale, name, info.Size(), spec.MaxBytes),
+				Entry:    path,
+			})
+		}
+		if name == "icon.png" && format != "png" {
+			out = append(out, Finding{
+				Check:    "image_format",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("[%s] icon must be a PNG, found %s", locale, format),
+				Entry:    path,
+			})
+		}
+	}
+
+	for _, sd := range screenshotDirs {
+		out = append(out, checkScreenshotDir(locale, sd, filepath.Join(imagesDir, sd))...)
+	}
+	return out
+}
+
+// checkScreenshotDir validates one screenshot form factor.
+func checkScreenshotDir(locale, kind, dir string) []Finding {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if kind == "phoneScreenshots" {
+			return []Finding{{
+				Check:    "screenshot_count",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("[%s] no phone screenshots found", locale),
+				Entry:    dir,
+				Hint:     fmt.Sprintf("Play requires at least %d phone screenshots", minPhoneScreenshot),
+			}}
+		}
+		return nil
+	}
+
+	var out []Finding
+	var images []string
+	for _, e := range entries {
+		if e.IsDir() || !isImageFile(e.Name()) {
+			continue
+		}
+		images = append(images, filepath.Join(dir, e.Name()))
+	}
+	sort.Strings(images)
+
+	if kind == "phoneScreenshots" && len(images) < minPhoneScreenshot {
+		out = append(out, Finding{
+			Check:    "screenshot_count",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("[%s] %d phone screenshot(s); Play requires at least %d", locale, len(images), minPhoneScreenshot),
+			Entry:    dir,
+		})
+	}
+	if len(images) > maxScreenshotCount {
+		out = append(out, Finding{
+			Check:    "screenshot_count",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("[%s] %d %s exceed the %d Play accepts; extras are ignored", locale, len(images), kind, maxScreenshotCount),
+			Entry:    dir,
+		})
+	}
+
+	for _, path := range images {
+		out = append(out, checkScreenshotFile(locale, path)...)
+	}
+	return out
+}
+
+// checkScreenshotFile validates one screenshot's dimensions and size.
+func checkScreenshotFile(locale, path string) []Finding {
+	var out []Finding
+
+	info, err := os.Stat(path)
+	if err == nil && info.Size() > maxScreenshotBytes {
+		out = append(out, Finding{
+			Check:    "image_size",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("[%s] %s is %d bytes, over the %d limit", locale, filepath.Base(path), info.Size(), maxScreenshotBytes),
+			Entry:    path,
+		})
+	}
+
+	cfg, _, err := decodeImageConfig(path)
+	if err != nil {
+		return append(out, Finding{
+			Check:    "image_unreadable",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("[%s] %s could not be decoded: %v", locale, filepath.Base(path), err),
+			Entry:    path,
+			Hint:     "Play accepts PNG and JPEG screenshots",
+		})
+	}
+
+	short, long := cfg.Width, cfg.Height
+	if short > long {
+		short, long = long, short
+	}
+	if short < minScreenshotSide {
+		out = append(out, Finding{
+			Check:    "image_dimensions",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("[%s] %s is %dx%d; each side must be at least %dpx", locale, filepath.Base(path), cfg.Width, cfg.Height, minScreenshotSide),
+			Entry:    path,
+		})
+	}
+	if long > maxScreenshotSide {
+		out = append(out, Finding{
+			Check:    "image_dimensions",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("[%s] %s is %dx%d; no side may exceed %dpx", locale, filepath.Base(path), cfg.Width, cfg.Height, maxScreenshotSide),
+			Entry:    path,
+		})
+	}
+	if short > 0 && float64(long)/float64(short) > maxScreenshotRatio {
+		out = append(out, Finding{
+			Check:    "image_ratio",
+			Severity: SeverityError,
+			Message: fmt.Sprintf("[%s] %s has a %.2f:1 aspect ratio; Play allows at most %.0f:1",
+				locale, filepath.Base(path), float64(long)/float64(short), maxScreenshotRatio),
+			Entry: path,
+		})
+	}
+	return out
+}
+
+// decodeImageConfig reads image dimensions without decoding pixel data.
+func decodeImageConfig(path string) (image.Config, string, error) {
+	f, err := os.Open(path) // #nosec G304 -- path derived from the user-supplied listings dir
+	if err != nil {
+		return image.Config{}, "", err
+	}
+	defer func() { _ = f.Close() }()
+	return image.DecodeConfig(f)
+}
+
+// isImageFile reports whether a filename has a Play-supported image extension.
+func isImageFile(name string) bool {
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".png", ".jpg", ".jpeg":
+		return true
+	}
+	return false
+}

--- a/internal/preflight/scan_nativelibs.go
+++ b/internal/preflight/scan_nativelibs.go
@@ -1,0 +1,239 @@
+package preflight
+
+import (
+	"archive/zip"
+	"bytes"
+	"debug/elf"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// requiredPageSize is the memory page size Android 15+ devices may use.
+// Shared libraries must be built with segments aligned to at least this
+// boundary or they cannot be loaded on 16 KB page-size devices.
+const requiredPageSize = 16384
+
+// maxELFBytes caps how large a shared library may be before it is skipped for
+// ELF inspection, keeping memory use bounded.
+const maxELFBytes = 64 * 1024 * 1024
+
+// sixteenKBTargetSDK is the target SDK from which Play requires 16 KB page
+// size support for apps shipping native code.
+const sixteenKBTargetSDK = 35
+
+// abi64Bit lists the 64-bit ABIs Play cares about for page-size compliance.
+var abi64Bit = map[string]bool{
+	"arm64-v8a": true,
+	"x86_64":    true,
+	"riscv64":   true,
+}
+
+// scanNativeLibs checks 64-bit coverage, ABI hygiene, page-size alignment,
+// and debug-symbol bloat in shipped shared libraries.
+func scanNativeLibs(c *scanContext) []Finding {
+	libs := c.nativeLibs()
+	if len(libs) == 0 {
+		return nil
+	}
+
+	var out []Finding
+	out = append(out, checkABICoverage(libs)...)
+	out = append(out, checkPageAlignment(c, libs)...)
+	out = append(out, checkStrippedSymbols(c, libs)...)
+	out = append(out, checkExtractNativeLibs(c)...)
+	return out
+}
+
+// checkABICoverage verifies the shipped ABI set meets Play requirements.
+func checkABICoverage(libs map[string][]*zip.File) []Finding {
+	var out []Finding
+
+	abis := make([]string, 0, len(libs))
+	for abi := range libs {
+		abis = append(abis, abi)
+	}
+	sort.Strings(abis)
+
+	if libs["arm64-v8a"] == nil {
+		out = append(out, Finding{
+			Check:    "native_libs",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("native libraries present (%s) but arm64-v8a is missing", strings.Join(abis, ", ")),
+			Hint:     "Play requires 64-bit support; add arm64-v8a to your ABI splits",
+			Ref:      "https://developer.android.com/google/play/requirements/64-bit",
+		})
+	}
+	if libs["x86"] != nil && libs["x86_64"] == nil {
+		out = append(out, Finding{
+			Check:    "native_abi",
+			Severity: SeverityInfo,
+			Message:  "x86 is shipped without x86_64",
+			Hint:     "64-bit x86 emulators and Chromebooks cannot use the 32-bit variant",
+		})
+	}
+	if libs["armeabi"] != nil {
+		out = append(out, Finding{
+			Check:    "native_abi",
+			Severity: SeverityWarning,
+			Message:  "armeabi (ARMv5) libraries are shipped",
+			Hint:     "the ABI has been unsupported since NDK r17; drop it to save download size",
+		})
+	}
+	return out
+}
+
+// checkPageAlignment verifies 64-bit shared libraries are built for 16 KB
+// memory pages, which Android 15 devices may use.
+func checkPageAlignment(c *scanContext, libs map[string][]*zip.File) []Finding {
+	var misaligned []string
+	var skipped int
+
+	for abi, files := range libs {
+		if !abi64Bit[abi] {
+			continue
+		}
+		for _, f := range files {
+			if !strings.HasSuffix(f.Name, ".so") {
+				continue
+			}
+			if int64(f.UncompressedSize64) > maxELFBytes { // #nosec G115
+				skipped++
+				continue
+			}
+			data := c.read(f, maxELFBytes)
+			ok, err := isPageAligned(data, requiredPageSize)
+			if err != nil {
+				skipped++
+				continue
+			}
+			if !ok {
+				misaligned = append(misaligned, f.Name)
+			}
+		}
+	}
+
+	var out []Finding
+	if len(misaligned) > 0 {
+		sort.Strings(misaligned)
+		sev := SeverityWarning
+		hint := "rebuild with NDK r28+, or pass -Wl,-z,max-page-size=16384 to the linker"
+		if c.manifest != nil && c.manifest.TargetSdk >= sixteenKBTargetSDK {
+			sev = SeverityError
+			hint = "required for apps targeting Android 15+; rebuild with NDK r28+ or -Wl,-z,max-page-size=16384"
+		}
+		for _, name := range misaligned {
+			out = append(out, Finding{
+				Check:    "page_alignment",
+				Severity: sev,
+				Message:  "shared library is not aligned for 16 KB memory pages",
+				Entry:    name,
+				Hint:     hint,
+				Ref:      "https://developer.android.com/guide/practices/page-sizes",
+			})
+		}
+	}
+	if skipped > 0 {
+		out = append(out, Finding{
+			Check:    "page_alignment",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("%d shared librar(y/ies) could not be inspected for page alignment", skipped),
+			Hint:     "the file was too large to read or is not a valid ELF object",
+		})
+	}
+	return out
+}
+
+// isPageAligned reports whether every loadable ELF segment is aligned to at
+// least pageSize.
+func isPageAligned(data []byte, pageSize uint64) (bool, error) {
+	if len(data) == 0 {
+		return false, fmt.Errorf("empty file")
+	}
+	f, err := elf.NewFile(bytes.NewReader(data))
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = f.Close() }()
+
+	// 32-bit objects never run on 16 KB page devices, so the rule is moot.
+	if f.Class == elf.ELFCLASS32 {
+		return true, nil
+	}
+
+	sawLoad := false
+	for _, p := range f.Progs {
+		if p.Type != elf.PT_LOAD {
+			continue
+		}
+		sawLoad = true
+		if p.Align < pageSize {
+			return false, nil
+		}
+	}
+	if !sawLoad {
+		return false, fmt.Errorf("no PT_LOAD segments")
+	}
+	return true, nil
+}
+
+// checkStrippedSymbols flags libraries still carrying debug information.
+func checkStrippedSymbols(c *scanContext, libs map[string][]*zip.File) []Finding {
+	var out []Finding
+	for _, files := range libs {
+		for _, f := range files {
+			if !strings.HasSuffix(f.Name, ".so") {
+				continue
+			}
+			if int64(f.UncompressedSize64) > maxELFBytes { // #nosec G115
+				continue
+			}
+			data := c.read(f, maxELFBytes)
+			if !hasDebugSections(data) {
+				continue
+			}
+			out = append(out, Finding{
+				Check:    "unstripped_library",
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("shared library ships debug symbols (%d bytes uncompressed)", f.UncompressedSize64),
+				Entry:    f.Name,
+				Hint:     "run the NDK strip tool, or upload a native debug symbols file separately instead",
+			})
+		}
+	}
+	return out
+}
+
+// hasDebugSections reports whether an ELF object retains debug sections.
+func hasDebugSections(data []byte) bool {
+	if len(data) == 0 {
+		return false
+	}
+	f, err := elf.NewFile(bytes.NewReader(data))
+	if err != nil {
+		return false
+	}
+	defer func() { _ = f.Close() }()
+
+	for _, s := range f.Sections {
+		if strings.HasPrefix(s.Name, ".debug_") || s.Name == ".symtab" {
+			return true
+		}
+	}
+	return false
+}
+
+// checkExtractNativeLibs flags the legacy extraction mode, which doubles the
+// on-device footprint of native code.
+func checkExtractNativeLibs(c *scanContext) []Finding {
+	if c.manifest == nil || !isTrue(c.manifest.Application.ExtractNativeLibs) {
+		return nil
+	}
+	return []Finding{{
+		Check:    "extract_native_libs",
+		Severity: SeverityWarning,
+		Message:  "android:extractNativeLibs is true",
+		Hint:     "set it false so libraries are loaded from the APK; this cuts install size and speeds updates",
+		Ref:      "https://developer.android.com/topic/performance/reduce-apk-size",
+	}}
+}

--- a/internal/preflight/scan_permissions.go
+++ b/internal/preflight/scan_permissions.go
@@ -1,0 +1,224 @@
+package preflight
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// permissionRule describes how a permission should be reported.
+type permissionRule struct {
+	Severity Severity
+	Reason   string
+	Hint     string
+	Ref      string
+}
+
+const (
+	refPermissionDeclaration = "https://support.google.com/googleplay/android-developer/answer/9214102"
+	refAllFilesAccess        = "https://support.google.com/googleplay/android-developer/answer/10467955"
+	refBackgroundLocation    = "https://support.google.com/googleplay/android-developer/answer/9799150"
+	refPackageVisibility     = "https://support.google.com/googleplay/android-developer/answer/10158779"
+	refDataSafety            = "https://support.google.com/googleplay/android-developer/answer/10787469"
+)
+
+// restrictedPermissions require an approved Play declaration. Shipping them
+// without one is the single most common cause of a policy rejection.
+var restrictedPermissions = map[string]permissionRule{
+	"android.permission.READ_SMS":                           {SeverityWarning, "SMS permission group", "requires an approved Permissions Declaration; only default SMS handlers qualify", refPermissionDeclaration},
+	"android.permission.SEND_SMS":                           {SeverityWarning, "SMS permission group", "requires an approved Permissions Declaration; only default SMS handlers qualify", refPermissionDeclaration},
+	"android.permission.RECEIVE_SMS":                        {SeverityWarning, "SMS permission group", "requires an approved Permissions Declaration; only default SMS handlers qualify", refPermissionDeclaration},
+	"android.permission.RECEIVE_MMS":                        {SeverityWarning, "SMS permission group", "requires an approved Permissions Declaration", refPermissionDeclaration},
+	"android.permission.RECEIVE_WAP_PUSH":                   {SeverityWarning, "SMS permission group", "requires an approved Permissions Declaration", refPermissionDeclaration},
+	"android.permission.WRITE_SMS":                          {SeverityWarning, "SMS permission group", "requires an approved Permissions Declaration", refPermissionDeclaration},
+	"android.permission.READ_CALL_LOG":                      {SeverityWarning, "Call Log permission group", "requires an approved Permissions Declaration; only default phone/assistant handlers qualify", refPermissionDeclaration},
+	"android.permission.WRITE_CALL_LOG":                     {SeverityWarning, "Call Log permission group", "requires an approved Permissions Declaration", refPermissionDeclaration},
+	"android.permission.PROCESS_OUTGOING_CALLS":             {SeverityWarning, "Call Log permission group", "deprecated and restricted; migrate to CallRedirectionService", refPermissionDeclaration},
+	"android.permission.MANAGE_EXTERNAL_STORAGE":            {SeverityWarning, "All files access", "requires an approved All Files Access declaration; most apps should use scoped storage or the photo picker", refAllFilesAccess},
+	"android.permission.ACCESS_BACKGROUND_LOCATION":         {SeverityWarning, "Background location", "requires an approved Location Permissions declaration and a demo video", refBackgroundLocation},
+	"android.permission.QUERY_ALL_PACKAGES":                 {SeverityWarning, "Broad package visibility", "requires justification; prefer a <queries> element listing the packages you need", refPackageVisibility},
+	"android.permission.REQUEST_INSTALL_PACKAGES":           {SeverityWarning, "Unknown app install", "restricted to apps whose core purpose is installing other apps", refPermissionDeclaration},
+	"android.permission.SYSTEM_ALERT_WINDOW":                {SeverityWarning, "Display over other apps", "overlays are heavily restricted and a common rejection reason", refPermissionDeclaration},
+	"android.permission.PACKAGE_USAGE_STATS":                {SeverityWarning, "Usage access", "requires justification; usage data is treated as sensitive", refPermissionDeclaration},
+	"android.permission.BIND_ACCESSIBILITY_SERVICE":         {SeverityWarning, "Accessibility service", "AccessibilityService may only be used for accessibility; other uses are rejected", refPermissionDeclaration},
+	"android.permission.BIND_DEVICE_ADMIN":                  {SeverityWarning, "Device admin", "device admin APIs are restricted to enterprise management use cases", refPermissionDeclaration},
+	"android.permission.USE_FULL_SCREEN_INTENT":             {SeverityWarning, "Full-screen intent", "from Android 14 this is granted only to calling and alarm apps", refPermissionDeclaration},
+	"android.permission.SCHEDULE_EXACT_ALARM":               {SeverityWarning, "Exact alarms", "requires justification; prefer setAndAllowWhileIdle or WorkManager", refPermissionDeclaration},
+	"android.permission.USE_EXACT_ALARM":                    {SeverityWarning, "Exact alarms", "restricted to alarm clock and calendar apps", refPermissionDeclaration},
+	"android.permission.MANAGE_MEDIA":                       {SeverityWarning, "Manage media", "requires justification for bulk media modification", refPermissionDeclaration},
+	"android.permission.BIND_NOTIFICATION_LISTENER_SERVICE": {SeverityWarning, "Notification access", "reading all notifications requires justification and is treated as sensitive data", refPermissionDeclaration},
+	"android.permission.BIND_VPN_SERVICE":                   {SeverityWarning, "VPN service", "VpnService use is restricted and requires a specific policy declaration", refPermissionDeclaration},
+}
+
+// sensitivePermissions are legitimate but must be disclosed in Data safety.
+var sensitivePermissions = map[string]permissionRule{
+	"android.permission.CAMERA":                               {SeverityInfo, "Camera access", "disclose photo/video collection in the Data safety form", refDataSafety},
+	"android.permission.RECORD_AUDIO":                         {SeverityInfo, "Microphone access", "disclose audio collection in the Data safety form", refDataSafety},
+	"android.permission.ACCESS_FINE_LOCATION":                 {SeverityInfo, "Precise location", "disclose location collection in the Data safety form", refDataSafety},
+	"android.permission.ACCESS_COARSE_LOCATION":               {SeverityInfo, "Approximate location", "disclose location collection in the Data safety form", refDataSafety},
+	"android.permission.READ_CONTACTS":                        {SeverityInfo, "Contacts access", "disclose contact collection in the Data safety form", refDataSafety},
+	"android.permission.WRITE_CONTACTS":                       {SeverityInfo, "Contacts modification", "disclose contact access in the Data safety form", refDataSafety},
+	"android.permission.GET_ACCOUNTS":                         {SeverityInfo, "Account list access", "disclose account access in the Data safety form", refDataSafety},
+	"android.permission.BODY_SENSORS":                         {SeverityInfo, "Body sensors", "health data must be disclosed and may need extra policy review", refDataSafety},
+	"android.permission.ACTIVITY_RECOGNITION":                 {SeverityInfo, "Physical activity", "disclose fitness data collection in the Data safety form", refDataSafety},
+	"android.permission.READ_PHONE_STATE":                     {SeverityInfo, "Phone state", "device identifiers are sensitive; avoid using them for tracking", refDataSafety},
+	"android.permission.READ_PHONE_NUMBERS":                   {SeverityInfo, "Phone number", "disclose phone number collection in the Data safety form", refDataSafety},
+	"android.permission.READ_MEDIA_IMAGES":                    {SeverityInfo, "Photo access", "consider the Android photo picker, which needs no permission", refDataSafety},
+	"android.permission.READ_MEDIA_VIDEO":                     {SeverityInfo, "Video access", "consider the Android photo picker, which needs no permission", refDataSafety},
+	"android.permission.READ_MEDIA_AUDIO":                     {SeverityInfo, "Audio file access", "disclose audio file access in the Data safety form", refDataSafety},
+	"android.permission.POST_NOTIFICATIONS":                   {SeverityInfo, "Notifications", "must be requested at runtime from Android 13", ""},
+	"com.google.android.gms.permission.AD_ID":                 {SeverityInfo, "Advertising ID", "declare advertising ID use in the Data safety form", refDataSafety},
+	"android.permission.RECEIVE_BOOT_COMPLETED":               {SeverityInfo, "Start at boot", "background startup is scrutinized for battery impact", ""},
+	"android.permission.FOREGROUND_SERVICE":                   {SeverityInfo, "Foreground service", "from Android 14 each service also needs a typed FOREGROUND_SERVICE_* permission", ""},
+	"android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS": {SeverityWarning, "Battery optimisation exemption", "allowed only for a narrow set of app categories", refPermissionDeclaration},
+}
+
+// deprecatedPermissions no longer do anything on modern Android.
+var deprecatedPermissions = map[string]string{
+	"android.permission.GET_TASKS":                  "removed in API 21; use ActivityManager.getAppTasks",
+	"android.permission.PERSISTENT_ACTIVITY":        "removed in API 15",
+	"android.permission.RESTART_PACKAGES":           "no-op since API 15",
+	"android.permission.SET_PREFERRED_APPLICATIONS": "no-op since API 15",
+	"android.permission.SMS_FINANCIAL_TRANSACTIONS": "removed in API 31",
+}
+
+// scanPermissions audits declared permissions against Play policy.
+func scanPermissions(c *scanContext) []Finding {
+	if c.manifest == nil {
+		return heuristicPermissionChecks(c.manifestRaw)
+	}
+	m := c.manifest
+
+	var out []Finding
+	seen := map[string]int{}
+
+	for _, p := range m.Permissions {
+		seen[p.Name]++
+
+		if rule, ok := restrictedPermissions[p.Name]; ok {
+			out = append(out, Finding{
+				Check:    "dangerous_permissions",
+				Severity: rule.Severity,
+				Message:  fmt.Sprintf("%s (%s)", p.Name, rule.Reason),
+				Entry:    p.Name,
+				Hint:     rule.Hint,
+				Ref:      rule.Ref,
+			})
+			continue
+		}
+		if rule, ok := sensitivePermissions[p.Name]; ok {
+			out = append(out, Finding{
+				Check:    "dangerous_permissions",
+				Severity: rule.Severity,
+				Message:  fmt.Sprintf("%s (%s)", p.Name, rule.Reason),
+				Entry:    p.Name,
+				Hint:     rule.Hint,
+				Ref:      rule.Ref,
+			})
+			continue
+		}
+		if why, ok := deprecatedPermissions[p.Name]; ok {
+			out = append(out, Finding{
+				Check:    "deprecated_permission",
+				Severity: SeverityInfo,
+				Message:  fmt.Sprintf("%s is deprecated: %s", p.Name, why),
+				Entry:    p.Name,
+				Hint:     "remove it; it grants nothing on supported Android versions",
+			})
+		}
+	}
+
+	out = append(out, checkStoragePermissions(m)...)
+	out = append(out, checkDuplicatePermissions(seen)...)
+	return out
+}
+
+// checkStoragePermissions flags legacy storage permissions that no longer
+// apply on modern target SDKs.
+func checkStoragePermissions(m *Manifest) []Finding {
+	var out []Finding
+	for _, p := range m.Permissions {
+		switch p.Name {
+		case "android.permission.WRITE_EXTERNAL_STORAGE":
+			if m.TargetSdk >= 30 && p.MaxSdk == 0 {
+				out = append(out, Finding{
+					Check:    "legacy_storage_permission",
+					Severity: SeverityWarning,
+					Message:  fmt.Sprintf("WRITE_EXTERNAL_STORAGE is declared without android:maxSdkVersion on targetSdk %d", m.TargetSdk),
+					Entry:    p.Name,
+					Hint:     `the permission does nothing from Android 11; add android:maxSdkVersion="28" or remove it`,
+				})
+			}
+		case "android.permission.READ_EXTERNAL_STORAGE":
+			if m.TargetSdk >= 33 && p.MaxSdk == 0 {
+				out = append(out, Finding{
+					Check:    "legacy_storage_permission",
+					Severity: SeverityWarning,
+					Message:  fmt.Sprintf("READ_EXTERNAL_STORAGE is declared without android:maxSdkVersion on targetSdk %d", m.TargetSdk),
+					Entry:    p.Name,
+					Hint:     `superseded by READ_MEDIA_* from Android 13; add android:maxSdkVersion="32"`,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// checkDuplicatePermissions reports permissions declared more than once.
+func checkDuplicatePermissions(seen map[string]int) []Finding {
+	var dupes []string
+	for name, n := range seen {
+		if n > 1 {
+			dupes = append(dupes, name)
+		}
+	}
+	if len(dupes) == 0 {
+		return nil
+	}
+	sort.Strings(dupes)
+	return []Finding{{
+		Check:    "duplicate_permission",
+		Severity: SeverityInfo,
+		Message:  fmt.Sprintf("declared more than once: %s", strings.Join(dupes, ", ")),
+		Hint:     "usually a merged-manifest artifact from a library; harmless but worth tidying",
+	}}
+}
+
+// heuristicPermissionChecks scans raw manifest bytes when decoding failed.
+// Permission names are stored as plain UTF-8 strings in both manifest
+// encodings, so substring matching stays reliable here.
+func heuristicPermissionChecks(raw []byte) []Finding {
+	if len(raw) == 0 {
+		return nil
+	}
+	var out []Finding
+
+	names := make([]string, 0, len(restrictedPermissions)+len(sensitivePermissions))
+	for name := range restrictedPermissions {
+		names = append(names, name)
+	}
+	for name := range sensitivePermissions {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if !bytes.Contains(raw, []byte(name)) {
+			continue
+		}
+		rule, ok := restrictedPermissions[name]
+		if !ok {
+			rule = sensitivePermissions[name]
+		}
+		out = append(out, Finding{
+			Check:    "dangerous_permissions",
+			Severity: rule.Severity,
+			Message:  fmt.Sprintf("%s (%s)", name, rule.Reason),
+			Entry:    name,
+			Hint:     rule.Hint,
+			Ref:      rule.Ref,
+		})
+	}
+	return out
+}

--- a/internal/preflight/scan_policy.go
+++ b/internal/preflight/scan_policy.go
@@ -1,0 +1,155 @@
+package preflight
+
+import "fmt"
+
+// currentMinTargetSDK is the minimum target API level Play accepts for new
+// apps and updates.
+//
+// Google raises this every year, roughly each August, to "latest release
+// minus one". Review this constant annually; `--min-target-sdk` overrides it
+// without a rebuild.
+const currentMinTargetSDK = 35
+
+// lowMinSDK is the API level below which device coverage no longer justifies
+// the compatibility cost.
+const lowMinSDK = 21
+
+const (
+	refTargetSDK      = "https://developer.android.com/google/play/requirements/target-sdk"
+	refFamiliesPolicy = "https://support.google.com/googleplay/android-developer/answer/9893335"
+	refAccessibility  = "https://support.google.com/googleplay/android-developer/answer/10964491"
+)
+
+// restrictedServicePermissions map a component's bind permission to the
+// policy that governs it.
+var restrictedServicePermissions = map[string]struct {
+	Label string
+	Hint  string
+	Ref   string
+}{
+	"android.permission.BIND_ACCESSIBILITY_SERVICE": {
+		"accessibility service",
+		"AccessibilityService may only be used to help users with disabilities; any other use is rejected and can suspend the account",
+		refAccessibility,
+	},
+	"android.permission.BIND_VPN_SERVICE": {
+		"VPN service",
+		"VpnService requires a dedicated policy declaration explaining how traffic is handled",
+		refPermissionDeclaration,
+	},
+	"android.permission.BIND_DEVICE_ADMIN": {
+		"device admin receiver",
+		"device administration APIs are restricted to enterprise management apps",
+		refPermissionDeclaration,
+	},
+	"android.permission.BIND_NOTIFICATION_LISTENER_SERVICE": {
+		"notification listener",
+		"reading all notifications is sensitive data access and needs justification",
+		refPermissionDeclaration,
+	},
+}
+
+// scanPolicy checks Play policy deadlines and restricted app behaviors.
+func scanPolicy(c *scanContext) []Finding {
+	var out []Finding
+	out = append(out, checkTargetSDKFloor(c)...)
+	out = append(out, checkUploadFormat(c)...)
+	out = append(out, checkRestrictedServices(c)...)
+	out = append(out, checkFamiliesExposure(c)...)
+	return out
+}
+
+// checkTargetSDKFloor enforces the Play target API level requirement.
+func checkTargetSDKFloor(c *scanContext) []Finding {
+	if c.manifest == nil {
+		return nil
+	}
+	m := c.manifest
+
+	floor := c.opts.MinTargetSDK
+	if floor <= 0 {
+		floor = currentMinTargetSDK
+	}
+
+	var out []Finding
+	switch {
+	case m.TargetSdk == 0:
+		out = append(out, Finding{
+			Check:    "target_sdk",
+			Severity: SeverityWarning,
+			Message:  "targetSdkVersion could not be determined from the manifest",
+			Hint:     "Play requires an explicit target API level; check your <uses-sdk> or Gradle configuration",
+			Ref:      refTargetSDK,
+		})
+	case m.TargetSdk < floor:
+		out = append(out, Finding{
+			Check:    "target_sdk",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("targetSdkVersion %d is below the Play minimum of %d", m.TargetSdk, floor),
+			Hint:     "Play blocks uploads below the current target API requirement; raise targetSdk and retest",
+			Ref:      refTargetSDK,
+		})
+	}
+
+	if m.MinSdk > 0 && m.MinSdk < lowMinSDK {
+		out = append(out, Finding{
+			Check:    "min_sdk",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("minSdkVersion %d supports devices below Android 5.0", m.MinSdk),
+			Hint:     "these versions have negligible share and no security updates; raising minSdk cuts build and test cost",
+		})
+	}
+	return out
+}
+
+// checkUploadFormat notes when an APK is scanned rather than an App Bundle.
+func checkUploadFormat(c *scanContext) []Finding {
+	if c.format != formatAPK {
+		return nil
+	}
+	return []Finding{{
+		Check:    "upload_format",
+		Severity: SeverityInfo,
+		Message:  "scanned artifact is an APK",
+		Hint:     "new apps on Play must be published as Android App Bundles; APKs are accepted only for existing apps and internal sharing",
+		Ref:      "https://developer.android.com/guide/app-bundle",
+	}}
+}
+
+// checkRestrictedServices flags components bound by a restricted permission.
+func checkRestrictedServices(c *scanContext) []Finding {
+	if c.manifest == nil {
+		return nil
+	}
+	var out []Finding
+	for _, comp := range c.manifest.Application.Components {
+		rule, ok := restrictedServicePermissions[comp.Permission]
+		if !ok {
+			continue
+		}
+		out = append(out, Finding{
+			Check:    "restricted_service",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("%s declares a %s", comp.Name, rule.Label),
+			Entry:    comp.Name,
+			Hint:     rule.Hint,
+			Ref:      rule.Ref,
+		})
+	}
+	return out
+}
+
+// checkFamiliesExposure notes the extra obligations that ads create for apps
+// that may be targeted at children.
+func checkFamiliesExposure(c *scanContext) []Finding {
+	if len(c.sdksInCategory(categoryAds)) == 0 {
+		return nil
+	}
+	return []Finding{{
+		Check:    "families_policy",
+		Severity: SeverityInfo,
+		Message:  "app serves ads",
+		Hint:     "if the app targets children, ads must come from a Google-certified ad SDK and no personalised ads or AD_ID may be used",
+		Ref:      refFamiliesPolicy,
+	}}
+}

--- a/internal/preflight/scan_privacy.go
+++ b/internal/preflight/scan_privacy.go
@@ -1,0 +1,102 @@
+package preflight
+
+import (
+	"fmt"
+	"strings"
+)
+
+// adIDPermission is required to read the advertising ID from Android 13.
+const adIDPermission = "com.google.android.gms.permission.AD_ID"
+
+// adIDTargetSDK is the target SDK from which AD_ID must be declared.
+const adIDTargetSDK = 33
+
+// scanPrivacy surfaces the tracking and advertising SDKs in the build and the
+// Data safety obligations they create.
+func scanPrivacy(c *scanContext) []Finding {
+	tracking := c.sdksInCategory(categoryTracking)
+	ads := c.sdksInCategory(categoryAds)
+
+	var out []Finding
+
+	if len(tracking) > 0 {
+		out = append(out, Finding{
+			Check:    "tracking_sdk",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("analytics/attribution SDK detected: %s", strings.Join(tracking, ", ")),
+			Hint:     "every data type these SDKs collect must be disclosed in the Data safety form, including data collected by the SDK itself",
+			Ref:      refDataSafety,
+		})
+	}
+	if len(ads) > 0 {
+		out = append(out, Finding{
+			Check:    "ads_sdk",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("advertising SDK detected: %s", strings.Join(ads, ", ")),
+			Hint:     "declare the app as containing ads in the Play Console and disclose ad-related data collection",
+			Ref:      refDataSafety,
+		})
+	}
+
+	out = append(out, checkAdvertisingID(c, len(ads) > 0, len(tracking) > 0)...)
+	out = append(out, checkNetworkPrivacy(c, len(tracking)+len(ads) > 0)...)
+	return out
+}
+
+// checkAdvertisingID reconciles the AD_ID permission with the SDKs present.
+func checkAdvertisingID(c *scanContext, hasAds, hasTracking bool) []Finding {
+	if c.manifest == nil {
+		return nil
+	}
+	m := c.manifest
+	declared := m.HasPermission(adIDPermission)
+
+	switch {
+	case !declared && (hasAds || hasTracking) && m.TargetSdk >= adIDTargetSDK:
+		return []Finding{{
+			Check:    "advertising_id",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("an ads/attribution SDK is present but %s is not declared (targetSdk %d)", adIDPermission, m.TargetSdk),
+			Hint:     "apps targeting Android 13+ must declare this permission to receive the advertising ID; without it the SDK reads zeros",
+			Ref:      "https://support.google.com/googleplay/android-developer/answer/6048248",
+		}}
+	case declared && !hasAds && !hasTracking:
+		return []Finding{{
+			Check:    "advertising_id",
+			Severity: SeverityInfo,
+			Message:  fmt.Sprintf("%s is declared but no ads or attribution SDK was detected", adIDPermission),
+			Hint:     "remove the permission if the advertising ID is unused; declaring it commits you to a Data safety disclosure",
+			Ref:      refDataSafety,
+		}}
+	}
+	return nil
+}
+
+// checkNetworkPrivacy flags transport-level exposure that affects the data
+// safety story.
+func checkNetworkPrivacy(c *scanContext, hasDataSDK bool) []Finding {
+	if c.manifest == nil {
+		return nil
+	}
+	m := c.manifest
+
+	var out []Finding
+	if hasDataSDK && isTrue(m.Application.UsesCleartextTraffic) {
+		out = append(out, Finding{
+			Check:    "insecure_transit",
+			Severity: SeverityWarning,
+			Message:  "cleartext traffic is enabled while data-collecting SDKs are present",
+			Hint:     "the Data safety form asks whether data is encrypted in transit; cleartext contradicts that claim",
+			Ref:      refDataSafety,
+		})
+	}
+	if hasDataSDK && isTrue(m.Application.AllowBackup) {
+		out = append(out, Finding{
+			Check:    "backup_exposure",
+			Severity: SeverityInfo,
+			Message:  "allowBackup is enabled while data-collecting SDKs are present",
+			Hint:     "exclude analytics identifiers and tokens from backups via android:dataExtractionRules",
+		})
+	}
+	return out
+}

--- a/internal/preflight/scan_secrets.go
+++ b/internal/preflight/scan_secrets.go
@@ -1,0 +1,282 @@
+package preflight
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// secretPattern is one credential-shaped signature.
+type secretPattern struct {
+	ID       string
+	Severity Severity
+	Hint     string
+	Re       *regexp.Regexp
+}
+
+// secretPatterns are deliberately conservative: each anchors on a vendor
+// prefix rather than on entropy, so false positives stay rare.
+//
+// Severity reflects blast radius. A private key or live server-side token is
+// an error. A Google API key is a warning: Android apps legitimately embed
+// Maps and Firebase keys, and the real defense is key restriction, not
+// absence.
+var secretPatterns = []secretPattern{
+	{
+		"private_key_block", SeverityError, "remove the key from the build; never ship private keys to clients",
+		regexp.MustCompile(`-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----`),
+	},
+	{
+		"aws_access_key", SeverityError, "rotate the key and move AWS access behind your backend",
+		regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+	},
+	{
+		"stripe_secret_key", SeverityError, "rotate immediately; secret keys must never leave your server",
+		regexp.MustCompile(`sk_live_[0-9A-Za-z]{24,}`),
+	},
+	{
+		"github_token", SeverityError, "revoke the token; it grants repository access",
+		regexp.MustCompile(`gh[pousr]_[A-Za-z0-9]{36}`),
+	},
+	{
+		"slack_token", SeverityError, "revoke the token in Slack admin",
+		regexp.MustCompile(`xox[baprs]-[0-9A-Za-z\-]{10,}`),
+	},
+	{
+		"slack_webhook", SeverityError, "revoke the webhook; anyone can post to the channel with it",
+		regexp.MustCompile(`https://hooks\.slack\.com/services/[A-Za-z0-9/+_-]{20,}`),
+	},
+	{
+		"sendgrid_key", SeverityError, "revoke the key in SendGrid",
+		regexp.MustCompile(`SG\.[A-Za-z0-9_\-]{20,}\.[A-Za-z0-9_\-]{40,}`),
+	},
+	{
+		"google_oauth_client_secret", SeverityError, "rotate the client secret in Google Cloud Console",
+		regexp.MustCompile(`GOCSPX-[A-Za-z0-9_\-]{20,}`),
+	},
+	{
+		"anthropic_api_key", SeverityError, "revoke the key; model API keys must stay server-side",
+		regexp.MustCompile(`sk-ant-[A-Za-z0-9_\-]{20,}`),
+	},
+	{
+		"openai_api_key", SeverityError, "revoke the key; model API keys must stay server-side",
+		regexp.MustCompile(`sk-proj-[A-Za-z0-9_\-]{20,}`),
+	},
+	{
+		"gcp_service_account", SeverityError, "a service account key grants server-side access; remove it from the build",
+		regexp.MustCompile(`"type"\s*:\s*"service_account"`),
+	},
+	{
+		"google_api_key", SeverityWarning, "restrict the key to your package name and signing certificate in Cloud Console",
+		regexp.MustCompile(`AIza[0-9A-Za-z_\-]{35}`),
+	},
+	{
+		"jwt_token", SeverityWarning, "confirm this is not a long-lived credential baked into the build",
+		regexp.MustCompile(`eyJ[A-Za-z0-9_=\-]{10,}\.[A-Za-z0-9_=\-]{10,}\.[A-Za-z0-9_.=\-]{10,}`),
+	},
+	{
+		"firebase_url", SeverityInfo, "confirm your Realtime Database security rules are not left open",
+		regexp.MustCompile(`https://[a-z0-9\-]+\.firebaseio\.com`),
+	},
+}
+
+// credentialFileSuffixes are file types that should never ship in a build.
+var credentialFileSuffixes = map[string]string{
+	".jks":      "Java keystore",
+	".keystore": "keystore",
+	".p12":      "PKCS#12 keystore",
+	".pfx":      "PKCS#12 keystore",
+	".pem":      "PEM key or certificate",
+	".ppk":      "PuTTY private key",
+}
+
+// developerArtifacts are paths that indicate an unclean build input.
+var developerArtifacts = []string{
+	".DS_Store", "__MACOSX/", ".git/", ".gitignore", "Thumbs.db",
+	".env", ".idea/", ".gradle/", "local.properties",
+}
+
+// binaryEntrySuffixes are skipped by the regex scan; they are large and
+// compressed, so pattern matching is expensive and unreliable there.
+var binaryEntrySuffixes = []string{
+	".png", ".jpg", ".jpeg", ".webp", ".gif", ".mp3", ".mp4", ".ogg",
+	".wav", ".otf", ".ttf", ".zip", ".so", ".kotlin_module", ".version",
+}
+
+// secretScanOverlap is the number of bytes carried across chunk boundaries so
+// a credential split across a boundary is still matched.
+const secretScanOverlap = 512
+
+// scanSecrets looks for credentials and developer artifacts in the build.
+func scanSecrets(c *scanContext) []Finding {
+	var out []Finding
+	out = append(out, scanEntriesForSecrets(c)...)
+	out = append(out, checkCredentialFiles(c)...)
+	out = append(out, checkDeveloperArtifacts(c)...)
+	return out
+}
+
+// scanEntriesForSecrets applies the pattern set to resource entries and to
+// dex bytecode, where hardcoded string literals also live.
+func scanEntriesForSecrets(c *scanContext) []Finding {
+	var out []Finding
+
+	for _, f := range c.files {
+		if f.UncompressedSize64 == 0 {
+			continue
+		}
+		isDex := strings.HasSuffix(f.Name, ".dex")
+		if !isDex && skipForSecretScan(f.Name) {
+			continue
+		}
+
+		limit := c.maxEntryBytes()
+		if isDex {
+			limit = c.maxDexScanBytes()
+		} else if int64(f.UncompressedSize64) > limit { // #nosec G115
+			continue
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			continue
+		}
+		hits := scanReaderForSecrets(rc, limit)
+		_ = rc.Close()
+
+		ids := make([]string, 0, len(hits))
+		for id := range hits {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+
+		for _, id := range ids {
+			p := secretPatternByID(id)
+			out = append(out, Finding{
+				Check:    "secrets",
+				Severity: p.Severity,
+				Message:  fmt.Sprintf("%s pattern matched", id),
+				Entry:    f.Name,
+				Hint:     p.Hint,
+			})
+		}
+	}
+	return out
+}
+
+// scanReaderForSecrets streams a reader in bounded chunks, returning the set
+// of matched pattern IDs.
+func scanReaderForSecrets(r io.Reader, limit int64) map[string]bool {
+	found := map[string]bool{}
+
+	const chunkSize = 1 << 20
+	buf := make([]byte, 0, chunkSize+secretScanOverlap)
+	tmp := make([]byte, chunkSize)
+
+	var read int64
+	for read < limit {
+		toRead := int64(chunkSize)
+		if remaining := limit - read; remaining < toRead {
+			toRead = remaining
+		}
+		n, err := r.Read(tmp[:toRead])
+		if n > 0 {
+			read += int64(n)
+			buf = append(buf, tmp[:n]...)
+			for _, p := range secretPatterns {
+				if found[p.ID] {
+					continue
+				}
+				if p.Re.Match(buf) {
+					found[p.ID] = true
+				}
+			}
+			if len(buf) > secretScanOverlap {
+				keep := buf[len(buf)-secretScanOverlap:]
+				buf = append(buf[:0], keep...)
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	return found
+}
+
+// secretPatternByID resolves a pattern ID back to its definition.
+func secretPatternByID(id string) secretPattern {
+	for _, p := range secretPatterns {
+		if p.ID == id {
+			return p
+		}
+	}
+	return secretPattern{ID: id, Severity: SeverityWarning}
+}
+
+// skipForSecretScan reports whether an entry is a binary type worth skipping.
+func skipForSecretScan(name string) bool {
+	lower := strings.ToLower(name)
+	for _, suffix := range binaryEntrySuffixes {
+		if strings.HasSuffix(lower, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkCredentialFiles flags keystores and key material shipped in the build.
+func checkCredentialFiles(c *scanContext) []Finding {
+	var out []Finding
+	for _, f := range c.files {
+		lower := strings.ToLower(f.Name)
+		for suffix, label := range credentialFileSuffixes {
+			if !strings.HasSuffix(lower, suffix) {
+				continue
+			}
+			// Play signing metadata legitimately lives under META-INF.
+			if strings.HasPrefix(f.Name, "META-INF/") {
+				continue
+			}
+			out = append(out, Finding{
+				Check:    "credential_file",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("build ships a %s", label),
+				Entry:    f.Name,
+				Hint:     "remove it from the packaged assets and rotate the key if it was ever released",
+			})
+			break
+		}
+	}
+	return out
+}
+
+// checkDeveloperArtifacts flags files that leaked in from the dev environment.
+func checkDeveloperArtifacts(c *scanContext) []Finding {
+	var out []Finding
+	seen := map[string]bool{}
+
+	for _, f := range c.files {
+		for _, artifact := range developerArtifacts {
+			if !strings.Contains(f.Name, artifact) || seen[f.Name] {
+				continue
+			}
+			seen[f.Name] = true
+			sev := SeverityWarning
+			if strings.Contains(f.Name, ".git/") || strings.Contains(f.Name, ".env") {
+				// Repository metadata and dotenv files routinely carry secrets.
+				sev = SeverityError
+			}
+			out = append(out, Finding{
+				Check:    "misplaced_files",
+				Severity: sev,
+				Message:  "build contains a developer-environment artifact",
+				Entry:    f.Name,
+				Hint:     "exclude it from your assets/resources source sets",
+			})
+			break
+		}
+	}
+	return out
+}

--- a/internal/preflight/scan_secrets.go
+++ b/internal/preflight/scan_secrets.go
@@ -23,6 +23,12 @@ type secretPattern struct {
 // an error. A Google API key is a warning: Android apps legitimately embed
 // Maps and Firebase keys, and the real defense is key restriction, not
 // absence.
+//
+// These patterns are intentionally unanchored: they search for a credential
+// anywhere inside an arbitrary blob, rather than validating that a whole
+// string is a trusted URL. The URL-shaped ones therefore match on host and
+// path only, without a scheme — a token is just as leaked when the scheme is
+// absent or the URL was assembled by string concatenation.
 var secretPatterns = []secretPattern{
 	{
 		"private_key_block", SeverityError, "remove the key from the build; never ship private keys to clients",
@@ -46,7 +52,7 @@ var secretPatterns = []secretPattern{
 	},
 	{
 		"slack_webhook", SeverityError, "revoke the webhook; anyone can post to the channel with it",
-		regexp.MustCompile(`https://hooks\.slack\.com/services/[A-Za-z0-9/+_-]{20,}`),
+		regexp.MustCompile(`hooks\.slack\.com/services/[A-Za-z0-9/+_-]{20,}`),
 	},
 	{
 		"sendgrid_key", SeverityError, "revoke the key in SendGrid",
@@ -78,7 +84,7 @@ var secretPatterns = []secretPattern{
 	},
 	{
 		"firebase_url", SeverityInfo, "confirm your Realtime Database security rules are not left open",
-		regexp.MustCompile(`https://[a-z0-9\-]+\.firebaseio\.com`),
+		regexp.MustCompile(`[a-z0-9\-]+\.firebaseio\.com`),
 	},
 }
 

--- a/internal/preflight/scan_secrets.go
+++ b/internal/preflight/scan_secrets.go
@@ -26,9 +26,9 @@ type secretPattern struct {
 //
 // These patterns are intentionally unanchored: they search for a credential
 // anywhere inside an arbitrary blob, rather than validating that a whole
-// string is a trusted URL. The URL-shaped ones therefore match on host and
-// path only, without a scheme — a token is just as leaked when the scheme is
-// absent or the URL was assembled by string concatenation.
+// string is a trusted URL. Where a credential is carried in a URL, the pattern
+// keys on the secret-bearing path rather than on the hostname, so the token is
+// still found when the URL is assembled at runtime.
 var secretPatterns = []secretPattern{
 	{
 		"private_key_block", SeverityError, "remove the key from the build; never ship private keys to clients",
@@ -52,7 +52,10 @@ var secretPatterns = []secretPattern{
 	},
 	{
 		"slack_webhook", SeverityError, "revoke the webhook; anyone can post to the channel with it",
-		regexp.MustCompile(`hooks\.slack\.com/services/[A-Za-z0-9/+_-]{20,}`),
+		// Matches the credential path itself rather than the hooks.slack.com
+		// host, so the token is still found when the URL is assembled at
+		// runtime or the host is held in a separate constant.
+		regexp.MustCompile(`/services/T[A-Za-z0-9]{6,}/B[A-Za-z0-9]{6,}/[A-Za-z0-9]{20,}`),
 	},
 	{
 		"sendgrid_key", SeverityError, "revoke the key in SendGrid",

--- a/internal/preflight/scan_size.go
+++ b/internal/preflight/scan_size.go
@@ -1,0 +1,189 @@
+package preflight
+
+import (
+	"archive/zip"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Play download-size budget. The hard limit applies to the generated APK set
+// a device downloads; the soft limit is where it is worth intervening.
+const (
+	defaultMaxBundleBytes  = 200 * 1024 * 1024
+	softBundleWarningBytes = 150 * 1024 * 1024
+	defaultMaxDexBytes     = 64 * 1024 * 1024
+	maxDexFiles            = 20
+	topEntriesReported     = 5
+)
+
+// scanSize reports download-size pressure and payload bloat.
+func scanSize(c *scanContext) []Finding {
+	limit := c.opts.MaxBundleBytes
+	if limit <= 0 {
+		limit = defaultMaxBundleBytes
+	}
+	maxDex := c.opts.MaxDexBytes
+	if maxDex <= 0 {
+		maxDex = defaultMaxDexBytes
+	}
+
+	var out []Finding
+	out = append(out, checkBundleSize(c, limit)...)
+	out = append(out, checkDexBudget(c, maxDex)...)
+	out = append(out, checkPayloadBreakdown(c, limit)...)
+	return out
+}
+
+// checkBundleSize compares the archive against the Play download budget.
+func checkBundleSize(c *scanContext, limit int64) []Finding {
+	total := c.totalCompressed
+
+	// The number Play enforces is the size of the split APKs it generates, so
+	// treat the archive size as an approximation and say so.
+	approx := "this is the archive's compressed size, an approximation of the generated download"
+
+	switch {
+	case total > limit:
+		return []Finding{{
+			Check:    "bundle_size",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("compressed size %s exceeds the %s limit", humanBytes(total), humanBytes(limit)),
+			Hint:     "move large assets to Play Asset Delivery or split them into dynamic feature modules; " + approx,
+			Ref:      "https://developer.android.com/guide/playcore/asset-delivery",
+		}}
+	case total > softBundleWarningBytes && limit > softBundleWarningBytes:
+		return []Finding{{
+			Check:    "bundle_size",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("compressed size %s is approaching the %s limit", humanBytes(total), humanBytes(limit)),
+			Hint:     "install rates fall as download size grows; " + approx,
+		}}
+	}
+	return nil
+}
+
+// checkDexBudget reports dex fragmentation and oversized dex files.
+func checkDexBudget(c *scanContext, maxDex int64) []Finding {
+	dexes := c.dexFiles()
+	if len(dexes) == 0 {
+		return nil
+	}
+
+	var out []Finding
+	for _, f := range dexes {
+		if int64(f.UncompressedSize64) > maxDex { // #nosec G115
+			out = append(out, Finding{
+				Check:    "dex",
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("%s is %s uncompressed, over the %s budget", f.Name, humanBytes(int64(f.UncompressedSize64)), humanBytes(maxDex)), // #nosec G115
+				Entry:    f.Name,
+			})
+		}
+	}
+	if len(dexes) > maxDexFiles {
+		out = append(out, Finding{
+			Check:    "dex",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("%d dex files in the build", len(dexes)),
+			Hint:     "enable R8 full mode and check for unused dependencies; heavy multidex slows cold start on older devices",
+		})
+	}
+	return out
+}
+
+// checkPayloadBreakdown summarizes where the bytes are when the build is
+// large enough for it to matter.
+func checkPayloadBreakdown(c *scanContext, limit int64) []Finding {
+	if c.totalCompressed <= softBundleWarningBytes && c.totalCompressed <= limit/2 {
+		return nil
+	}
+
+	buckets := map[string]int64{}
+	for _, f := range c.files {
+		buckets[sizeBucket(f.Name)] += int64(f.CompressedSize64) // #nosec G115
+	}
+
+	type kv struct {
+		name string
+		size int64
+	}
+	var ordered []kv
+	for name, size := range buckets {
+		ordered = append(ordered, kv{name, size})
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].size > ordered[j].size })
+
+	var parts []string
+	for _, b := range ordered {
+		parts = append(parts, fmt.Sprintf("%s %s", b.name, humanBytes(b.size)))
+	}
+
+	out := []Finding{{
+		Check:    "size_breakdown",
+		Severity: SeverityInfo,
+		Message:  fmt.Sprintf("compressed size by category: %s", strings.Join(parts, ", ")),
+	}}
+
+	if largest := largestEntries(c.files, topEntriesReported); len(largest) > 0 {
+		var names []string
+		for _, f := range largest {
+			names = append(names, fmt.Sprintf("%s (%s)", f.Name, humanBytes(int64(f.CompressedSize64)))) // #nosec G115
+		}
+		out = append(out, Finding{
+			Check:    "largest_entries",
+			Severity: SeverityInfo,
+			Message:  "largest entries: " + strings.Join(names, ", "),
+			Hint:     "compress or lazily download these assets to cut install size",
+		})
+	}
+	return out
+}
+
+// largestEntries returns the n biggest entries by compressed size.
+func largestEntries(files []*zip.File, n int) []*zip.File {
+	sorted := make([]*zip.File, len(files))
+	copy(sorted, files)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].CompressedSize64 > sorted[j].CompressedSize64
+	})
+	if len(sorted) > n {
+		sorted = sorted[:n]
+	}
+	return sorted
+}
+
+// sizeBucket classifies an entry into a reporting category.
+func sizeBucket(name string) string {
+	lower := strings.ToLower(name)
+	switch {
+	case strings.HasSuffix(lower, ".dex"):
+		return "dex"
+	case strings.HasSuffix(lower, ".so"):
+		return "native"
+	case strings.Contains(lower, "/res/") || strings.HasPrefix(lower, "res/"):
+		return "resources"
+	case strings.Contains(lower, "/assets/") || strings.HasPrefix(lower, "assets/"):
+		return "assets"
+	case strings.HasSuffix(lower, "resources.arsc") || strings.HasSuffix(lower, "resources.pb"):
+		return "resource-table"
+	case strings.HasPrefix(lower, "meta-inf/"):
+		return "meta-inf"
+	default:
+		return "other"
+	}
+}
+
+// humanBytes renders a byte count using binary units.
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit && exp < 3; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGT"[exp])
+}

--- a/internal/preflight/scanctx.go
+++ b/internal/preflight/scanctx.go
@@ -1,0 +1,316 @@
+package preflight
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"strings"
+	"sync"
+)
+
+// Bundle format identifiers.
+const (
+	formatAAB     = "aab"
+	formatAPK     = "apk"
+	formatUnknown = "unknown"
+)
+
+// scanContext carries everything the scanners need for one bundle. It is
+// built once and shared, so expensive work (dex scanning in particular)
+// happens at most once per run.
+type scanContext struct {
+	path   string
+	format string
+	opts   Options
+
+	files   []*zip.File
+	entries map[string]*zip.File
+
+	totalCompressed   int64
+	totalUncompressed int64
+
+	// manifestRaw is the undecoded AndroidManifest.xml payload.
+	manifestRaw []byte
+	// manifest is nil when the payload could not be decoded.
+	manifest *Manifest
+	// manifestErr records why decoding failed.
+	manifestErr error
+
+	sdkOnce sync.Once
+	sdkHits map[string]bool
+}
+
+// newScanContext indexes the archive and decodes the manifest.
+func newScanContext(path string, r *zip.ReadCloser, opts Options) *scanContext {
+	ctx := &scanContext{
+		path:    path,
+		opts:    opts,
+		files:   r.File,
+		entries: make(map[string]*zip.File, len(r.File)),
+	}
+	for _, f := range r.File {
+		ctx.entries[f.Name] = f
+		ctx.totalCompressed += int64(f.CompressedSize64)     // #nosec G115
+		ctx.totalUncompressed += int64(f.UncompressedSize64) // #nosec G115
+	}
+
+	ctx.format = detectFormat(ctx.entries)
+	ctx.manifestRaw = ctx.manifestBytes()
+	if len(ctx.manifestRaw) > 0 {
+		m, err := parseManifestBytes(ctx.manifestRaw)
+		if err != nil {
+			ctx.manifestErr = err
+		} else {
+			ctx.manifest = m
+		}
+	}
+	return ctx
+}
+
+// detectFormat classifies the archive as an App Bundle or an APK.
+func detectFormat(entries map[string]*zip.File) string {
+	if _, ok := entries["BundleConfig.pb"]; ok {
+		return formatAAB
+	}
+	if _, ok := entries["base/manifest/AndroidManifest.xml"]; ok {
+		return formatAAB
+	}
+	if _, ok := entries["AndroidManifest.xml"]; ok {
+		return formatAPK
+	}
+	return formatUnknown
+}
+
+// manifestBytes returns the raw manifest payload for either format.
+func (c *scanContext) manifestBytes() []byte {
+	if b := c.read(c.entries["base/manifest/AndroidManifest.xml"], c.maxEntryBytes()); len(b) > 0 {
+		return b
+	}
+	return c.read(c.entries["AndroidManifest.xml"], c.maxEntryBytes())
+}
+
+func (c *scanContext) maxEntryBytes() int64 {
+	if c.opts.MaxScanBytesPerEntry > 0 {
+		return c.opts.MaxScanBytesPerEntry
+	}
+	return 5 * 1024 * 1024
+}
+
+func (c *scanContext) maxDexScanBytes() int64 {
+	if c.opts.MaxDexScanBytes > 0 {
+		return c.opts.MaxDexScanBytes
+	}
+	return 96 * 1024 * 1024
+}
+
+// read returns up to maxBytes of an entry's contents, or nil.
+func (c *scanContext) read(f *zip.File, maxBytes int64) []byte {
+	if f == nil {
+		return nil
+	}
+	rc, err := f.Open()
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rc.Close() }()
+	data, err := io.ReadAll(io.LimitReader(rc, maxBytes))
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+// hasEntry reports whether an exact entry name exists.
+func (c *scanContext) hasEntry(name string) bool {
+	_, ok := c.entries[name]
+	return ok
+}
+
+// hasEntrySuffix reports whether any entry name ends with suffix.
+func (c *scanContext) hasEntrySuffix(suffix string) bool {
+	for name := range c.entries {
+		if strings.HasSuffix(name, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+// dexFiles returns every .dex entry in the archive.
+func (c *scanContext) dexFiles() []*zip.File {
+	var out []*zip.File
+	for _, f := range c.files {
+		if strings.HasSuffix(f.Name, ".dex") {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// nativeLibs returns entries under lib/<abi>/ or base/lib/<abi>/ keyed by ABI.
+func (c *scanContext) nativeLibs() map[string][]*zip.File {
+	out := map[string][]*zip.File{}
+	for _, f := range c.files {
+		abi, ok := nativeLibABI(f.Name)
+		if !ok {
+			continue
+		}
+		out[abi] = append(out[abi], f)
+	}
+	return out
+}
+
+// nativeLibABI extracts the ABI directory from a native library entry name.
+func nativeLibABI(name string) (string, bool) {
+	var prefix string
+	switch {
+	case strings.HasPrefix(name, "lib/"):
+		prefix = "lib/"
+	case strings.HasPrefix(name, "base/lib/"):
+		prefix = "base/lib/"
+	default:
+		// Dynamic feature modules use <module>/lib/<abi>/.
+		idx := strings.Index(name, "/lib/")
+		if idx < 0 {
+			return "", false
+		}
+		prefix = name[:idx+len("/lib/")]
+	}
+	rest := name[len(prefix):]
+	slash := strings.Index(rest, "/")
+	if slash <= 0 {
+		return "", false
+	}
+	return rest[:slash], true
+}
+
+// sdkIndex scans dex bytecode and entry paths once for every known SDK
+// signature, returning the set of matched signature IDs.
+func (c *scanContext) sdkIndex() map[string]bool {
+	c.sdkOnce.Do(func() {
+		c.sdkHits = map[string]bool{}
+
+		// Path-based signals are cheap; check them first.
+		for _, sig := range sdkSignatures {
+			for _, frag := range sig.Paths {
+				if c.anyEntryContains(frag) {
+					c.sdkHits[sig.ID] = true
+					break
+				}
+			}
+		}
+
+		// Collect the dex markers still worth searching for.
+		var needles [][]byte
+		var owners []string
+		for _, sig := range sdkSignatures {
+			if c.sdkHits[sig.ID] {
+				continue
+			}
+			for _, m := range sig.Markers {
+				needles = append(needles, []byte(m))
+				owners = append(owners, sig.ID)
+			}
+		}
+		if len(needles) == 0 {
+			return
+		}
+
+		for _, f := range c.dexFiles() {
+			rc, err := f.Open()
+			if err != nil {
+				continue
+			}
+			hits := searchStream(rc, needles, c.maxDexScanBytes())
+			_ = rc.Close()
+			for i := range hits {
+				c.sdkHits[owners[i]] = true
+			}
+		}
+	})
+	return c.sdkHits
+}
+
+// anyEntryContains reports whether any entry name contains the fragment.
+func (c *scanContext) anyEntryContains(frag string) bool {
+	for name := range c.entries {
+		if strings.Contains(name, frag) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasSDK reports whether a signature ID matched.
+func (c *scanContext) hasSDK(id string) bool { return c.sdkIndex()[id] }
+
+// sdksInCategory returns the display names of every matched SDK in a category.
+func (c *scanContext) sdksInCategory(category string) []string {
+	idx := c.sdkIndex()
+	var out []string
+	for _, sig := range sdkSignatures {
+		if sig.Category == category && idx[sig.ID] {
+			out = append(out, sig.Name)
+		}
+	}
+	return out
+}
+
+// searchStream scans a reader for any of the needles, returning the set of
+// matched needle indices. It reads in bounded chunks with an overlap so
+// matches spanning a chunk boundary are still found, keeping memory flat
+// regardless of how large the entry is.
+func searchStream(r io.Reader, needles [][]byte, limit int64) map[int]bool {
+	found := map[int]bool{}
+	if len(needles) == 0 {
+		return found
+	}
+
+	maxNeedle := 0
+	for _, n := range needles {
+		if len(n) > maxNeedle {
+			maxNeedle = len(n)
+		}
+	}
+	if maxNeedle == 0 {
+		return found
+	}
+
+	const chunkSize = 1 << 20
+	overlap := maxNeedle - 1
+	buf := make([]byte, 0, chunkSize+overlap)
+	tmp := make([]byte, chunkSize)
+
+	var read int64
+	for read < limit {
+		toRead := int64(chunkSize)
+		if remaining := limit - read; remaining < toRead {
+			toRead = remaining
+		}
+		n, err := r.Read(tmp[:toRead])
+		if n > 0 {
+			read += int64(n)
+			buf = append(buf, tmp[:n]...)
+			for i, needle := range needles {
+				if found[i] {
+					continue
+				}
+				if bytes.Contains(buf, needle) {
+					found[i] = true
+				}
+			}
+			if len(found) == len(needles) {
+				return found
+			}
+			// Keep only the tail so a match can span the next boundary.
+			if len(buf) > overlap {
+				keep := buf[len(buf)-overlap:]
+				buf = append(buf[:0], keep...)
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+	return found
+}

--- a/internal/preflight/scanner.go
+++ b/internal/preflight/scanner.go
@@ -1,115 +1,130 @@
 // Package preflight runs offline compliance and hygiene checks against an
 // AAB/APK before upload. It does NOT call the Play API.
 //
-// Checks are intentionally pragmatic: they operate on ZIP entries and raw
-// bytes without decoding the protobuf manifest, so they run in CI on any
-// machine. Checks can produce Info, Warning, or Error findings; Errors cause
-// a non-zero exit in the CLI.
+// The engine decodes AndroidManifest.xml for real — binary AXML for APKs and
+// the aapt2 protobuf encoding for App Bundles — then runs nine independent
+// scanners over the decoded manifest and the archive contents:
+//
+//	manifest     structural and security attributes of the manifest
+//	permissions  restricted and sensitive permission audit
+//	native_libs  64-bit coverage, ABI hygiene, 16 KB page alignment
+//	metadata     store listing text and screenshot validation
+//	secrets      credentials and developer artifacts shipped in the build
+//	billing      Play Billing vs third-party payment SDKs
+//	privacy      tracking/analytics SDKs and Data safety implications
+//	policy       Play policy deadlines and restricted behaviors
+//	size         download size, dex budget, and payload bloat
+//
+// Findings carry Info, Warning, or Error severity; the CLI decides which
+// level fails the build.
 package preflight
 
 import (
 	"archive/zip"
-	"bytes"
 	"errors"
 	"fmt"
-	"io"
-	"regexp"
-	"strings"
 )
 
-// Severity of a preflight finding.
-type Severity string
-
-const (
-	SeverityInfo    Severity = "info"
-	SeverityWarning Severity = "warning"
-	SeverityError   Severity = "error"
-)
-
-// Finding is a single preflight check result.
-type Finding struct {
-	Check    string   `json:"check"`
-	Severity Severity `json:"severity"`
-	Message  string   `json:"message"`
-	Entry    string   `json:"entry,omitempty"`
-	Hint     string   `json:"hint,omitempty"`
+// registeredScanner binds a scanner ID to its implementation.
+type registeredScanner struct {
+	ID  string
+	Run func(*scanContext) []Finding
 }
 
-// Report aggregates all findings.
-type Report struct {
-	Path      string    `json:"path"`
-	Findings  []Finding `json:"findings"`
-	Infos     int       `json:"infos"`
-	Warnings  int       `json:"warnings"`
-	Errors    int       `json:"errors"`
-	Checks    []string  `json:"checks_run"`
-	TotalSize int64     `json:"total_size_bytes"`
+// scanners is the ordered registry. Order determines report ordering.
+var scanners = []registeredScanner{
+	{ID: "manifest", Run: scanManifest},
+	{ID: "permissions", Run: scanPermissions},
+	{ID: "native_libs", Run: scanNativeLibs},
+	{ID: "metadata", Run: scanMetadata},
+	{ID: "secrets", Run: scanSecrets},
+	{ID: "billing", Run: scanBilling},
+	{ID: "privacy", Run: scanPrivacy},
+	{ID: "policy", Run: scanPolicy},
+	{ID: "size", Run: scanSize},
 }
 
-// Options tunes the scanner.
-type Options struct {
-	// MaxBundleBytes is the maximum allowed total compressed size (0 = default 150MB).
-	MaxBundleBytes int64
-	// MaxDexBytes is per-dex warning threshold (0 = default 64MB).
-	MaxDexBytes int64
-	// SkipSecretScan disables secret-pattern matching.
-	SkipSecretScan bool
-	// MaxScanBytesPerEntry caps how many bytes we scan per entry (0 = default 5MB).
-	MaxScanBytesPerEntry int64
+// ScannerIDs returns the IDs of every registered scanner, in run order.
+func ScannerIDs() []string {
+	out := make([]string, 0, len(scanners))
+	for _, s := range scanners {
+		out = append(out, s.ID)
+	}
+	return out
 }
 
-// Scan runs all checks and returns a Report.
+// ValidateScannerIDs returns an error naming the first unknown ID.
+func ValidateScannerIDs(ids []string) error {
+	known := ScannerIDs()
+	for _, id := range normalizeIDs(ids) {
+		if !containsID(known, id) {
+			return fmt.Errorf("unknown scanner %q (known: %v)", id, known)
+		}
+	}
+	return nil
+}
+
+// Scan runs the selected scanners against an AAB or APK and returns a Report.
 func Scan(path string, opts Options) (*Report, error) {
-	if opts.MaxBundleBytes == 0 {
-		opts.MaxBundleBytes = 150 * 1024 * 1024
+	if err := ValidateScannerIDs(opts.Only); err != nil {
+		return nil, err
 	}
-	if opts.MaxDexBytes == 0 {
-		opts.MaxDexBytes = 64 * 1024 * 1024
-	}
-	if opts.MaxScanBytesPerEntry == 0 {
-		opts.MaxScanBytesPerEntry = 5 * 1024 * 1024
+	if err := ValidateScannerIDs(opts.Skip); err != nil {
+		return nil, err
 	}
 
 	r, err := zip.OpenReader(path) // #nosec G304 -- user-supplied bundle
 	if err != nil {
-		return nil, fmt.Errorf("open zip: %w", err)
+		return nil, fmt.Errorf("open bundle: %w", err)
 	}
 	defer func() { _ = r.Close() }()
 
-	report := &Report{Path: path, Checks: allCheckNames()}
+	ctx := newScanContext(path, r, opts)
 
-	// Index entries for cross-checks.
-	entryNames := make(map[string]*zip.File, len(r.File))
-	var total int64
-	for _, f := range r.File {
-		entryNames[f.Name] = f
-		total += int64(f.CompressedSize64) // #nosec G115
+	report := &Report{
+		Path:      path,
+		Format:    ctx.format,
+		TotalSize: ctx.totalCompressed,
 	}
-	report.TotalSize = total
-
-	// Aggregate manifest bytes (useful for string-based checks).
-	manifestBytes := readEntry(entryNames["base/manifest/AndroidManifest.xml"], opts.MaxScanBytesPerEntry)
-	if len(manifestBytes) == 0 {
-		manifestBytes = readEntry(entryNames["AndroidManifest.xml"], opts.MaxScanBytesPerEntry)
+	if m := ctx.manifest; m != nil {
+		report.Package = m.Package
+		report.VersionCode = m.VersionCode
+		report.VersionName = m.VersionName
+		report.MinSdk = m.MinSdk
+		report.TargetSdk = m.TargetSdk
 	}
 
-	addAll := func(findings ...Finding) {
-		report.Findings = append(report.Findings, findings...)
-	}
+	only := normalizeIDs(opts.Only)
+	skip := normalizeIDs(opts.Skip)
 
-	addAll(checkManifestPresent(entryNames)...)
-	addAll(checkBundleSize(total, opts.MaxBundleBytes)...)
-	addAll(checkResourcesPresent(entryNames)...)
-	addAll(checkNativeLibArchitectures(entryNames)...)
-	addAll(checkDexCount(entryNames, opts.MaxDexBytes)...)
-	addAll(checkDebuggableFlag(manifestBytes)...)
-	addAll(checkTestOnly(manifestBytes)...)
-	addAll(checkCleartextTraffic(manifestBytes)...)
-	addAll(checkDangerousPermissions(manifestBytes)...)
-	if !opts.SkipSecretScan {
-		addAll(scanForSecrets(r.File, opts.MaxScanBytesPerEntry)...)
+	for _, s := range scanners {
+		run := ScannerRun{ID: s.ID}
+
+		switch {
+		case len(only) > 0 && !containsID(only, s.ID):
+			run.Skipped, run.Reason = true, "not selected by --only"
+		case containsID(skip, s.ID):
+			run.Skipped, run.Reason = true, "excluded by --skip"
+		case s.ID == "secrets" && opts.SkipSecretScan:
+			run.Skipped, run.Reason = true, "--skip-secrets"
+		case s.ID == "metadata" && opts.ListingsDir == "":
+			run.Skipped, run.Reason = true, "no --listings-dir provided"
+		}
+
+		if !run.Skipped {
+			findings := s.Run(ctx)
+			for i := range findings {
+				findings[i].Scanner = s.ID
+			}
+			report.Findings = append(report.Findings, findings...)
+			run.Findings = len(findings)
+		}
+
+		report.Scanners = append(report.Scanners, run)
+		if !run.Skipped {
+			report.Checks = append(report.Checks, s.ID)
+		}
 	}
-	addAll(checkMisplacedFiles(entryNames)...)
 
 	for _, f := range report.Findings {
 		switch f.Severity {
@@ -121,313 +136,8 @@ func Scan(path string, opts Options) (*Report, error) {
 			report.Errors++
 		}
 	}
-
 	return report, nil
 }
 
-func allCheckNames() []string {
-	return []string{
-		"manifest", "bundle_size", "resources", "native_libs",
-		"dex", "debuggable", "test_only", "cleartext_traffic",
-		"dangerous_permissions", "secrets", "misplaced_files",
-	}
-}
-
-func readEntry(f *zip.File, maxBytes int64) []byte {
-	if f == nil {
-		return nil
-	}
-	rc, err := f.Open()
-	if err != nil {
-		return nil
-	}
-	defer rc.Close()
-	lim := io.LimitReader(rc, maxBytes)
-	data, err := io.ReadAll(lim)
-	if err != nil {
-		return nil
-	}
-	return data
-}
-
-// --- individual checks ---
-
-func checkManifestPresent(entries map[string]*zip.File) []Finding {
-	_, aabOK := entries["base/manifest/AndroidManifest.xml"]
-	_, apkOK := entries["AndroidManifest.xml"]
-	if !aabOK && !apkOK {
-		return []Finding{{
-			Check:    "manifest",
-			Severity: SeverityError,
-			Message:  "AndroidManifest.xml not found",
-			Hint:     "the bundle must contain base/manifest/AndroidManifest.xml (AAB) or AndroidManifest.xml (APK)",
-		}}
-	}
-	return nil
-}
-
-func checkBundleSize(total, limit int64) []Finding {
-	if total > limit {
-		return []Finding{{
-			Check:    "bundle_size",
-			Severity: SeverityWarning,
-			Message:  fmt.Sprintf("bundle compressed size %d bytes exceeds limit %d", total, limit),
-			Hint:     "consider Play Asset Delivery or dynamic features to reduce base module size",
-		}}
-	}
-	return nil
-}
-
-func checkResourcesPresent(entries map[string]*zip.File) []Finding {
-	if _, ok := entries["base/resources.pb"]; ok {
-		return nil
-	}
-	if _, ok := entries["resources.arsc"]; ok {
-		return nil
-	}
-	return []Finding{{
-		Check:    "resources",
-		Severity: SeverityError,
-		Message:  "resources table not found (base/resources.pb or resources.arsc)",
-	}}
-}
-
-func checkNativeLibArchitectures(entries map[string]*zip.File) []Finding {
-	abis := map[string]bool{}
-	for name := range entries {
-		// Native libs live under lib/<abi>/ or base/lib/<abi>/
-		prefix := ""
-		switch {
-		case strings.HasPrefix(name, "lib/"):
-			prefix = "lib/"
-		case strings.HasPrefix(name, "base/lib/"):
-			prefix = "base/lib/"
-		default:
-			continue
-		}
-		rest := name[len(prefix):]
-		slash := strings.Index(rest, "/")
-		if slash <= 0 {
-			continue
-		}
-		abis[rest[:slash]] = true
-	}
-	if len(abis) == 0 {
-		return nil
-	}
-	if !abis["arm64-v8a"] {
-		return []Finding{{
-			Check:    "native_libs",
-			Severity: SeverityError,
-			Message:  "native libs present but arm64-v8a missing",
-			Hint:     "Google Play requires 64-bit support; add arm64-v8a",
-		}}
-	}
-	return nil
-}
-
-func checkDexCount(entries map[string]*zip.File, maxDex int64) []Finding {
-	var dexCount int
-	var findings []Finding
-	for name, f := range entries {
-		if strings.HasSuffix(name, ".dex") {
-			dexCount++
-			if int64(f.UncompressedSize64) > maxDex { // #nosec G115
-				findings = append(findings, Finding{
-					Check:    "dex",
-					Severity: SeverityWarning,
-					Message:  fmt.Sprintf("%s is %d bytes (>%d)", name, f.UncompressedSize64, maxDex),
-					Entry:    name,
-				})
-			}
-		}
-	}
-	if dexCount > 20 {
-		findings = append(findings, Finding{
-			Check:    "dex",
-			Severity: SeverityWarning,
-			Message:  fmt.Sprintf("%d dex files; consider R8 optimization", dexCount),
-		})
-	}
-	return findings
-}
-
-// The binary AndroidManifest is a protobuf in AABs (not decoded here), but
-// attribute names and booleans appear as UTF-8 substrings, which is enough for
-// simple presence checks.
-func checkDebuggableFlag(manifest []byte) []Finding {
-	if len(manifest) == 0 {
-		return nil
-	}
-	if bytes.Contains(manifest, []byte("debuggable")) {
-		// Heuristic: true flag will appear close to the attribute. This is a
-		// best-effort check — report as warning, not error.
-		if bytes.Contains(manifest, []byte("android:debuggable=\"true\"")) ||
-			containsNearby(manifest, []byte("debuggable"), []byte{0x01}, 4) {
-			return []Finding{{
-				Check:    "debuggable",
-				Severity: SeverityError,
-				Message:  "android:debuggable appears to be true",
-				Hint:     "release builds must not be debuggable",
-			}}
-		}
-	}
-	return nil
-}
-
-func checkTestOnly(manifest []byte) []Finding {
-	if len(manifest) == 0 {
-		return nil
-	}
-	if bytes.Contains(manifest, []byte("testOnly")) &&
-		(bytes.Contains(manifest, []byte("testOnly=\"true\"")) ||
-			containsNearby(manifest, []byte("testOnly"), []byte{0x01}, 4)) {
-		return []Finding{{
-			Check:    "test_only",
-			Severity: SeverityError,
-			Message:  "manifest sets android:testOnly=true",
-			Hint:     "remove testOnly before uploading to Play Console",
-		}}
-	}
-	return nil
-}
-
-func checkCleartextTraffic(manifest []byte) []Finding {
-	if len(manifest) == 0 {
-		return nil
-	}
-	if bytes.Contains(manifest, []byte("usesCleartextTraffic")) &&
-		(bytes.Contains(manifest, []byte("usesCleartextTraffic=\"true\"")) ||
-			containsNearby(manifest, []byte("usesCleartextTraffic"), []byte{0x01}, 4)) {
-		return []Finding{{
-			Check:    "cleartext_traffic",
-			Severity: SeverityWarning,
-			Message:  "android:usesCleartextTraffic=true",
-			Hint:     "prefer HTTPS; Play policy flags cleartext traffic in new apps",
-		}}
-	}
-	return nil
-}
-
-var dangerousPermissions = []string{
-	"android.permission.READ_SMS",
-	"android.permission.SEND_SMS",
-	"android.permission.RECEIVE_SMS",
-	"android.permission.READ_CALL_LOG",
-	"android.permission.WRITE_CALL_LOG",
-	"android.permission.PROCESS_OUTGOING_CALLS",
-	"android.permission.MANAGE_EXTERNAL_STORAGE",
-	"android.permission.ACCESS_BACKGROUND_LOCATION",
-	"android.permission.REQUEST_INSTALL_PACKAGES",
-}
-
-func checkDangerousPermissions(manifest []byte) []Finding {
-	if len(manifest) == 0 {
-		return nil
-	}
-	var findings []Finding
-	for _, p := range dangerousPermissions {
-		if bytes.Contains(manifest, []byte(p)) {
-			findings = append(findings, Finding{
-				Check:    "dangerous_permissions",
-				Severity: SeverityInfo,
-				Message:  "uses sensitive permission " + p,
-				Hint:     "expect an extended Play policy review",
-			})
-		}
-	}
-	return findings
-}
-
-// Secret regex patterns. These are intentionally conservative to minimize
-// false positives; they still catch the most common leaks.
-var secretPatterns = map[string]*regexp.Regexp{
-	"google_api_key":    regexp.MustCompile(`AIza[0-9A-Za-z_\-]{35}`),
-	"aws_access_key":    regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
-	"slack_token":       regexp.MustCompile(`xox[baprs]-[0-9A-Za-z\-]+`),
-	"stripe_secret":     regexp.MustCompile(`sk_live_[0-9A-Za-z]{24,}`),
-	"private_key_block": regexp.MustCompile(`-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----`),
-	"firebase_url":      regexp.MustCompile(`https://[a-z0-9\-]+\.firebaseio\.com`),
-	"jwt_token":         regexp.MustCompile(`eyJ[A-Za-z0-9_=\-]{10,}\.[A-Za-z0-9_=\-]{10,}\.[A-Za-z0-9_\.=\-]{10,}`),
-}
-
-func scanForSecrets(files []*zip.File, maxBytes int64) []Finding {
-	var findings []Finding
-	for _, f := range files {
-		// Only scan likely-text and resource files; skip .dex/.so (large and
-		// noisy — secrets there are very rare and expensive to scan well).
-		lower := strings.ToLower(f.Name)
-		if strings.HasSuffix(lower, ".dex") ||
-			strings.HasSuffix(lower, ".so") ||
-			strings.HasSuffix(lower, ".kotlin_module") ||
-			strings.HasSuffix(lower, ".png") ||
-			strings.HasSuffix(lower, ".jpg") ||
-			strings.HasSuffix(lower, ".webp") ||
-			strings.HasSuffix(lower, ".mp3") ||
-			strings.HasSuffix(lower, ".mp4") ||
-			strings.HasSuffix(lower, ".otf") ||
-			strings.HasSuffix(lower, ".ttf") {
-			continue
-		}
-		if int64(f.UncompressedSize64) > maxBytes { // #nosec G115
-			continue
-		}
-		data := readEntry(f, maxBytes)
-		for name, pat := range secretPatterns {
-			if loc := pat.FindIndex(data); loc != nil {
-				findings = append(findings, Finding{
-					Check:    "secrets",
-					Severity: SeverityError,
-					Message:  fmt.Sprintf("%s matched in bundle", name),
-					Entry:    f.Name,
-					Hint:     "remove secrets from shipped code; load via secure storage at runtime",
-				})
-				break
-			}
-		}
-	}
-	return findings
-}
-
-func checkMisplacedFiles(entries map[string]*zip.File) []Finding {
-	var findings []Finding
-	suspicious := []string{".DS_Store", "__MACOSX/", ".git/", ".gitignore", "Thumbs.db"}
-	for name := range entries {
-		for _, sus := range suspicious {
-			if strings.Contains(name, sus) {
-				findings = append(findings, Finding{
-					Check:    "misplaced_files",
-					Severity: SeverityWarning,
-					Message:  "bundle contains developer-environment artifact",
-					Entry:    name,
-				})
-				break
-			}
-		}
-	}
-	return findings
-}
-
-// containsNearby returns true if `needle` appears within `window` bytes of a
-// matching `context` marker. Used to make string-based manifest checks a
-// little less noisy.
-func containsNearby(haystack, context, needle []byte, window int) bool {
-	if len(context) == 0 || len(needle) == 0 {
-		return false
-	}
-	idx := bytes.Index(haystack, context)
-	if idx < 0 {
-		return false
-	}
-	end := idx + len(context) + window + len(needle)
-	if end > len(haystack) {
-		end = len(haystack)
-	}
-	return bytes.Contains(haystack[idx:end], needle)
-}
-
-// HasErrors returns true if the report contains any error-severity findings.
-func (r *Report) HasErrors() bool { return r.Errors > 0 }
-
-// ErrNoErrors is sentinel for CLI to detect clean reports.
+// ErrNoErrors is a sentinel for callers detecting clean reports.
 var ErrNoErrors = errors.New("no errors")

--- a/internal/preflight/scanner_test.go
+++ b/internal/preflight/scanner_test.go
@@ -177,6 +177,35 @@ func TestScanShippedKeystoreIsError(t *testing.T) {
 	}
 }
 
+// The URL-shaped patterns match on host and path without a scheme, so a
+// credential is still caught when the URL was assembled by concatenation or
+// stored without "https://". Both spellings must hit.
+func TestScanURLSecretsMatchWithAndWithoutScheme(t *testing.T) {
+	token := "T00000000/B00000000/" + strings.Repeat("x", 24)
+	for _, tc := range []struct {
+		name, payload string
+	}{
+		{"with scheme", "https://hooks.slack.com/services/" + token},
+		{"without scheme", "hooks.slack.com/services/" + token},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "app.aab")
+			entries := minimalAAB()
+			entries["base/assets/webhook.txt"] = []byte(tc.payload)
+			buildAAB(t, path, entries)
+
+			r, _ := Scan(path, Options{})
+			for _, f := range r.Findings {
+				if f.Check == "secrets" && f.Severity == SeverityError &&
+					strings.Contains(f.Message, "slack_webhook") {
+					return
+				}
+			}
+			t.Errorf("expected slack_webhook error, got %+v", r.Findings)
+		})
+	}
+}
+
 func TestScanSecretDetectionDisabled(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "app.aab")
 	entries := minimalAAB()

--- a/internal/preflight/scanner_test.go
+++ b/internal/preflight/scanner_test.go
@@ -126,8 +126,27 @@ func TestScanDetectsBundleSize(t *testing.T) {
 func TestScanSecretDetection(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "app.aab")
 	entries := minimalAAB()
-	// Planting a Google API key in a resource-ish file.
+	// Planting a Google API key in a resource-ish file. Android apps embed
+	// Maps and Firebase keys legitimately, so this is a warning rather than a
+	// build-failing error; the fix is key restriction, not removal.
 	entries["base/res/values/secrets.xml"] = []byte(`<string name="k">AIza` + strings.Repeat("x", 35) + `</string>`)
+	buildAAB(t, path, entries)
+	r, _ := Scan(path, Options{})
+	has := false
+	for _, f := range r.Findings {
+		if f.Check == "secrets" && f.Severity == SeverityWarning {
+			has = true
+		}
+	}
+	if !has {
+		t.Errorf("expected google_api_key warning, got %+v", r.Findings)
+	}
+}
+
+func TestScanHardCredentialIsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.aab")
+	entries := minimalAAB()
+	entries["base/assets/config.json"] = []byte(`{"type": "service_account", "project_id": "x"}`)
 	buildAAB(t, path, entries)
 	r, _ := Scan(path, Options{})
 	has := false
@@ -137,7 +156,24 @@ func TestScanSecretDetection(t *testing.T) {
 		}
 	}
 	if !has {
-		t.Error("expected secret detection")
+		t.Errorf("expected service account key to be an error, got %+v", r.Findings)
+	}
+}
+
+func TestScanShippedKeystoreIsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.aab")
+	entries := minimalAAB()
+	entries["base/assets/release.keystore"] = []byte("binary")
+	buildAAB(t, path, entries)
+	r, _ := Scan(path, Options{})
+	has := false
+	for _, f := range r.Findings {
+		if f.Check == "credential_file" && f.Severity == SeverityError {
+			has = true
+		}
+	}
+	if !has {
+		t.Errorf("expected shipped keystore to be an error, got %+v", r.Findings)
 	}
 }
 

--- a/internal/preflight/scanners_test.go
+++ b/internal/preflight/scanners_test.go
@@ -1,0 +1,658 @@
+package preflight
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// encodePNG renders a blank PNG of the requested dimensions.
+func encodePNG(t *testing.T, w, h int) []byte {
+	t.Helper()
+	var b bytes.Buffer
+	if err := png.Encode(&b, image.NewRGBA(image.Rect(0, 0, w, h))); err != nil {
+		t.Fatal(err)
+	}
+	return b.Bytes()
+}
+
+// --- fixtures ---------------------------------------------------------------
+
+// cleanManifest is a baseline that produces no errors, so each test can
+// change exactly one thing and attribute the finding to that change.
+func cleanManifest() pbElem {
+	return pbElem{
+		name: "manifest",
+		attrs: []pbAttr{
+			{name: "package", value: "com.acme.app"},
+			{ns: AndroidNS, name: "versionCode", compiled: pbPrimInt(10)},
+			{ns: AndroidNS, name: "versionName", value: "1.0.0"},
+		},
+		children: []pbElem{
+			{name: "uses-sdk", attrs: []pbAttr{
+				{ns: AndroidNS, name: "minSdkVersion", compiled: pbPrimInt(24)},
+				{ns: AndroidNS, name: "targetSdkVersion", compiled: pbPrimInt(35)},
+			}},
+			{name: "application", children: []pbElem{
+				{name: "activity", attrs: []pbAttr{
+					{ns: AndroidNS, name: "name", value: ".MainActivity"},
+					{ns: AndroidNS, name: "exported", compiled: pbPrimBool(true)},
+				}, children: []pbElem{
+					{name: "intent-filter", children: []pbElem{
+						{name: "action", attrs: []pbAttr{{ns: AndroidNS, name: "name", value: "android.intent.action.MAIN"}}},
+						{name: "category", attrs: []pbAttr{{ns: AndroidNS, name: "name", value: "android.intent.category.LAUNCHER"}}},
+					}},
+				}},
+			}},
+		},
+	}
+}
+
+// withPermissions returns a copy of the manifest with permissions prepended.
+func withPermissions(m pbElem, names ...string) pbElem {
+	var perms []pbElem
+	for _, n := range names {
+		perms = append(perms, pbElem{name: "uses-permission", attrs: []pbAttr{
+			{ns: AndroidNS, name: "name", value: n},
+		}})
+	}
+	m.children = append(perms, m.children...)
+	return m
+}
+
+// appNode returns a pointer to the <application> child so tests can mutate it.
+func appNode(m *pbElem) *pbElem {
+	for i := range m.children {
+		if m.children[i].name == "application" {
+			return &m.children[i]
+		}
+	}
+	panic("no application element")
+}
+
+// buildTestBundle writes an AAB containing the given manifest plus extras.
+func buildTestBundle(t *testing.T, manifest []byte, extra map[string][]byte) string {
+	t.Helper()
+	entries := map[string][]byte{
+		"base/manifest/AndroidManifest.xml": manifest,
+		"base/resources.pb":                 []byte("res"),
+		"base/dex/classes.dex":              bytes.Repeat([]byte("a"), 64),
+	}
+	for k, v := range extra {
+		entries[k] = v
+	}
+	path := filepath.Join(t.TempDir(), "app.aab")
+	buildAAB(t, path, entries)
+	return path
+}
+
+// scanClean scans a bundle built from the given manifest and extras.
+func scanFixture(t *testing.T, m pbElem, extra map[string][]byte, opts Options) *Report {
+	t.Helper()
+	r, err := Scan(buildTestBundle(t, pbNode(m), extra), opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return r
+}
+
+// findingFor returns the first finding matching a check name.
+func findingFor(r *Report, check string) (Finding, bool) {
+	for _, f := range r.Findings {
+		if f.Check == check {
+			return f, true
+		}
+	}
+	return Finding{}, false
+}
+
+// requireFinding asserts a check fired at the expected severity.
+func requireFinding(t *testing.T, r *Report, check string, sev Severity) Finding {
+	t.Helper()
+	f, ok := findingFor(r, check)
+	if !ok {
+		t.Fatalf("expected check %q, got %+v", check, r.Findings)
+	}
+	if f.Severity != sev {
+		t.Fatalf("check %q severity = %s, want %s", check, f.Severity, sev)
+	}
+	return f
+}
+
+// requireNoFinding asserts a check did not fire.
+func requireNoFinding(t *testing.T, r *Report, check string) {
+	t.Helper()
+	if f, ok := findingFor(r, check); ok {
+		t.Fatalf("did not expect check %q, got %+v", check, f)
+	}
+}
+
+// --- baseline ---------------------------------------------------------------
+
+func TestCleanBundleHasNoErrors(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), nil, Options{})
+	if r.Errors != 0 {
+		t.Fatalf("expected no errors, got %d: %+v", r.Errors, r.Findings)
+	}
+	if r.Package != "com.acme.app" || r.TargetSdk != 35 || r.VersionCode != 10 {
+		t.Errorf("report metadata = %+v", r)
+	}
+	if r.Format != formatAAB {
+		t.Errorf("format = %q, want aab", r.Format)
+	}
+}
+
+func TestReportRecordsEveryScanner(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), nil, Options{})
+	if len(r.Scanners) != len(ScannerIDs()) {
+		t.Fatalf("scanners recorded = %d, want %d", len(r.Scanners), len(ScannerIDs()))
+	}
+	byID := map[string]ScannerRun{}
+	for _, s := range r.Scanners {
+		byID[s.ID] = s
+	}
+	if !byID["metadata"].Skipped || byID["metadata"].Reason == "" {
+		t.Errorf("metadata should be skipped without --listings-dir: %+v", byID["metadata"])
+	}
+	if byID["manifest"].Skipped {
+		t.Error("manifest scanner should run")
+	}
+}
+
+// --- scanner selection ------------------------------------------------------
+
+func TestScannerSelection(t *testing.T) {
+	m := cleanManifest()
+	appNode(&m).attrs = append(appNode(&m).attrs, pbAttr{
+		ns: AndroidNS, name: "debuggable", compiled: pbPrimBool(true),
+	})
+
+	only := scanFixture(t, m, nil, Options{Only: []string{"policy"}})
+	requireNoFinding(t, only, "debuggable")
+
+	skipped := scanFixture(t, m, nil, Options{Skip: []string{"manifest"}})
+	requireNoFinding(t, skipped, "debuggable")
+
+	both := scanFixture(t, m, nil, Options{})
+	requireFinding(t, both, "debuggable", SeverityError)
+}
+
+func TestUnknownScannerIDRejected(t *testing.T) {
+	path := buildTestBundle(t, pbNode(cleanManifest()), nil)
+	if _, err := Scan(path, Options{Only: []string{"nope"}}); err == nil {
+		t.Error("expected error for unknown --only scanner")
+	}
+	if _, err := Scan(path, Options{Skip: []string{"nope"}}); err == nil {
+		t.Error("expected error for unknown --skip scanner")
+	}
+}
+
+// --- 1. manifest ------------------------------------------------------------
+
+func TestManifestDebuggableAndTestOnly(t *testing.T) {
+	m := cleanManifest()
+	m.attrs = append(m.attrs, pbAttr{ns: AndroidNS, name: "testOnly", compiled: pbPrimBool(true)})
+	appNode(&m).attrs = append(appNode(&m).attrs, pbAttr{ns: AndroidNS, name: "debuggable", compiled: pbPrimBool(true)})
+
+	r := scanFixture(t, m, nil, Options{})
+	requireFinding(t, r, "debuggable", SeverityError)
+	requireFinding(t, r, "test_only", SeverityError)
+}
+
+func TestManifestPlaceholderPackageRejected(t *testing.T) {
+	m := cleanManifest()
+	m.attrs[0] = pbAttr{name: "package", value: "com.example.myapp"}
+	r := scanFixture(t, m, nil, Options{})
+	requireFinding(t, r, "package_name", SeverityError)
+}
+
+func TestManifestExportedWithoutDeclaration(t *testing.T) {
+	m := cleanManifest()
+	// A filtered receiver with no android:exported fails to install on 12+.
+	appNode(&m).children = append(appNode(&m).children, pbElem{
+		name:  "receiver",
+		attrs: []pbAttr{{ns: AndroidNS, name: "name", value: ".BootReceiver"}},
+		children: []pbElem{{name: "intent-filter", children: []pbElem{
+			{name: "action", attrs: []pbAttr{{ns: AndroidNS, name: "name", value: "android.intent.action.BOOT_COMPLETED"}}},
+		}}},
+	})
+	r := scanFixture(t, m, nil, Options{})
+	requireFinding(t, r, "exported_undeclared", SeverityError)
+}
+
+func TestManifestExportedProviderGrantingURIsIsError(t *testing.T) {
+	m := cleanManifest()
+	appNode(&m).children = append(appNode(&m).children, pbElem{
+		name: "provider",
+		attrs: []pbAttr{
+			{ns: AndroidNS, name: "name", value: ".LeakyProvider"},
+			{ns: AndroidNS, name: "exported", compiled: pbPrimBool(true)},
+			{ns: AndroidNS, name: "grantUriPermissions", compiled: pbPrimBool(true)},
+		},
+	})
+	r := scanFixture(t, m, nil, Options{})
+	requireFinding(t, r, "exported_provider", SeverityError)
+	requireFinding(t, r, "exported_component", SeverityWarning)
+}
+
+func TestManifestLauncherActivityIsNotFlagged(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), nil, Options{})
+	requireNoFinding(t, r, "exported_component")
+}
+
+func TestManifestForegroundServiceTypeNeedsPermission(t *testing.T) {
+	m := cleanManifest()
+	appNode(&m).children = append(appNode(&m).children, pbElem{
+		name: "service",
+		attrs: []pbAttr{
+			{ns: AndroidNS, name: "name", value: ".SyncService"},
+			{ns: AndroidNS, name: "foregroundServiceType", value: "dataSync"},
+		},
+	})
+
+	missing := scanFixture(t, m, nil, Options{})
+	f := requireFinding(t, missing, "foreground_service_type", SeverityError)
+	if !strings.Contains(f.Message, "FOREGROUND_SERVICE_DATA_SYNC") {
+		t.Errorf("expected the required permission in the message, got %q", f.Message)
+	}
+
+	granted := scanFixture(t, withPermissions(m, "android.permission.FOREGROUND_SERVICE_DATA_SYNC"), nil, Options{})
+	requireNoFinding(t, granted, "foreground_service_type")
+}
+
+func TestManifestUndecodableFallsBackToHeuristics(t *testing.T) {
+	path := buildTestBundle(t, []byte(`<application android:debuggable="true"/>`), nil)
+	r, err := Scan(path, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requireFinding(t, r, "manifest_undecodable", SeverityWarning)
+	requireFinding(t, r, "debuggable", SeverityError)
+}
+
+// --- 2. permissions ---------------------------------------------------------
+
+func TestPermissionsRestrictedAndSensitive(t *testing.T) {
+	m := withPermissions(
+		cleanManifest(),
+		"android.permission.READ_SMS",
+		"android.permission.CAMERA",
+	)
+	r := scanFixture(t, m, nil, Options{})
+
+	var restricted, sensitive bool
+	for _, f := range r.FindingsFor("permissions") {
+		if f.Entry == "android.permission.READ_SMS" && f.Severity == SeverityWarning {
+			restricted = true
+			if f.Ref == "" {
+				t.Error("restricted permission finding should link to the policy")
+			}
+		}
+		if f.Entry == "android.permission.CAMERA" && f.Severity == SeverityInfo {
+			sensitive = true
+		}
+	}
+	if !restricted || !sensitive {
+		t.Errorf("restricted=%v sensitive=%v: %+v", restricted, sensitive, r.Findings)
+	}
+}
+
+func TestPermissionsLegacyStorageOnModernTarget(t *testing.T) {
+	m := withPermissions(cleanManifest(), "android.permission.WRITE_EXTERNAL_STORAGE")
+	r := scanFixture(t, m, nil, Options{})
+	requireFinding(t, r, "legacy_storage_permission", SeverityWarning)
+}
+
+func TestPermissionsDuplicatesAndDeprecated(t *testing.T) {
+	m := withPermissions(
+		cleanManifest(),
+		"android.permission.INTERNET",
+		"android.permission.INTERNET",
+		"android.permission.GET_TASKS",
+	)
+	r := scanFixture(t, m, nil, Options{})
+	requireFinding(t, r, "duplicate_permission", SeverityInfo)
+	requireFinding(t, r, "deprecated_permission", SeverityInfo)
+}
+
+// --- 3. native_libs ---------------------------------------------------------
+
+// elf64SharedObject builds a minimal AArch64 ELF with one PT_LOAD segment at
+// the given alignment, which is all the page-size check inspects.
+func elf64SharedObject(align uint64) []byte {
+	const (
+		ehsize    = 64
+		phentsize = 56
+	)
+	b := &bytes.Buffer{}
+
+	b.Write([]byte{0x7f, 'E', 'L', 'F'})
+	b.WriteByte(2) // ELFCLASS64
+	b.WriteByte(1) // ELFDATA2LSB
+	b.WriteByte(1) // EV_CURRENT
+	b.WriteByte(0) // ELFOSABI_NONE
+	b.Write(make([]byte, 8))
+
+	write16 := func(v uint16) { _ = binary.Write(b, binary.LittleEndian, v) }
+	write32 := func(v uint32) { _ = binary.Write(b, binary.LittleEndian, v) }
+	write64 := func(v uint64) { _ = binary.Write(b, binary.LittleEndian, v) }
+
+	write16(3)   // ET_DYN
+	write16(183) // EM_AARCH64
+	write32(1)   // EV_CURRENT
+	write64(0)   // e_entry
+	write64(ehsize)
+	write64(0) // e_shoff
+	write32(0) // e_flags
+	write16(ehsize)
+	write16(phentsize)
+	write16(1) // e_phnum
+	write16(64)
+	write16(0) // e_shnum
+	write16(0) // e_shstrndx
+
+	write32(1) // PT_LOAD
+	write32(5) // PF_R|PF_X
+	write64(0) // p_offset
+	write64(0) // p_vaddr
+	write64(0) // p_paddr
+	write64(0x1000)
+	write64(0x1000)
+	write64(align)
+
+	return b.Bytes()
+}
+
+func TestNativeLibsPageAlignment(t *testing.T) {
+	misaligned := map[string][]byte{
+		"base/lib/arm64-v8a/libapp.so": elf64SharedObject(4096),
+	}
+	r := scanFixture(t, cleanManifest(), misaligned, Options{})
+	f := requireFinding(t, r, "page_alignment", SeverityError) // targetSdk 35
+	if f.Entry != "base/lib/arm64-v8a/libapp.so" {
+		t.Errorf("entry = %q", f.Entry)
+	}
+
+	aligned := map[string][]byte{
+		"base/lib/arm64-v8a/libapp.so": elf64SharedObject(16384),
+	}
+	ok := scanFixture(t, cleanManifest(), aligned, Options{})
+	requireNoFinding(t, ok, "page_alignment")
+}
+
+func TestNativeLibsPageAlignmentIsWarningBelowTarget35(t *testing.T) {
+	m := cleanManifest()
+	m.children[0] = pbElem{name: "uses-sdk", attrs: []pbAttr{
+		{ns: AndroidNS, name: "minSdkVersion", compiled: pbPrimInt(24)},
+		{ns: AndroidNS, name: "targetSdkVersion", compiled: pbPrimInt(34)},
+	}}
+	r := scanFixture(t, m, map[string][]byte{
+		"base/lib/arm64-v8a/libapp.so": elf64SharedObject(4096),
+	}, Options{})
+	requireFinding(t, r, "page_alignment", SeverityWarning)
+}
+
+func TestNativeLibs32BitOnlyIsError(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), map[string][]byte{
+		"base/lib/armeabi-v7a/libapp.so": elf64SharedObject(16384),
+	}, Options{})
+	requireFinding(t, r, "native_libs", SeverityError)
+}
+
+func TestNativeLibsExtractNativeLibs(t *testing.T) {
+	m := cleanManifest()
+	appNode(&m).attrs = append(appNode(&m).attrs, pbAttr{
+		ns: AndroidNS, name: "extractNativeLibs", compiled: pbPrimBool(true),
+	})
+	r := scanFixture(t, m, map[string][]byte{
+		"base/lib/arm64-v8a/libapp.so": elf64SharedObject(16384),
+	}, Options{})
+	requireFinding(t, r, "extract_native_libs", SeverityWarning)
+}
+
+// --- 4. metadata ------------------------------------------------------------
+
+// writePNG writes a PNG of the requested dimensions.
+func writePNG(t *testing.T, path string, w, h int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, encodePNG(t, w, h), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeText(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// validListings builds a complete, passing listings tree.
+func validListings(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	locale := filepath.Join(dir, "en-US")
+	writeText(t, filepath.Join(locale, "title.txt"), "Acme App")
+	writeText(t, filepath.Join(locale, "short_description.txt"), "A short description")
+	writeText(t, filepath.Join(locale, "full_description.txt"), "A full description")
+	writePNG(t, filepath.Join(locale, "images", "icon.png"), 512, 512)
+	writePNG(t, filepath.Join(locale, "images", "featureGraphic.png"), 1024, 500)
+	writePNG(t, filepath.Join(locale, "images", "phoneScreenshots", "1.png"), 1080, 1920)
+	writePNG(t, filepath.Join(locale, "images", "phoneScreenshots", "2.png"), 1080, 1920)
+	return dir
+}
+
+func TestMetadataValidListingsPasses(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), nil, Options{ListingsDir: validListings(t)})
+	if got := r.FindingsFor("metadata"); len(got) != 0 {
+		t.Fatalf("expected no metadata findings, got %+v", got)
+	}
+}
+
+func TestMetadataTitleTooLong(t *testing.T) {
+	dir := validListings(t)
+	writeText(t, filepath.Join(dir, "en-US", "title.txt"), strings.Repeat("x", 31))
+	r := scanFixture(t, cleanManifest(), nil, Options{ListingsDir: dir})
+	requireFinding(t, r, "listing_text_length", SeverityError)
+}
+
+func TestMetadataIconWrongDimensions(t *testing.T) {
+	dir := validListings(t)
+	writePNG(t, filepath.Join(dir, "en-US", "images", "icon.png"), 256, 256)
+	r := scanFixture(t, cleanManifest(), nil, Options{ListingsDir: dir})
+	f := requireFinding(t, r, "image_dimensions", SeverityError)
+	if !strings.Contains(f.Message, "256x256") {
+		t.Errorf("message should report actual dimensions, got %q", f.Message)
+	}
+}
+
+func TestMetadataScreenshotTooSmallAndTooTall(t *testing.T) {
+	dir := validListings(t)
+	writePNG(t, filepath.Join(dir, "en-US", "images", "phoneScreenshots", "1.png"), 100, 200)
+	writePNG(t, filepath.Join(dir, "en-US", "images", "phoneScreenshots", "2.png"), 400, 1200)
+	r := scanFixture(t, cleanManifest(), nil, Options{ListingsDir: dir})
+	requireFinding(t, r, "image_dimensions", SeverityError)
+	requireFinding(t, r, "image_ratio", SeverityError)
+}
+
+func TestMetadataTooFewPhoneScreenshots(t *testing.T) {
+	dir := validListings(t)
+	if err := os.Remove(filepath.Join(dir, "en-US", "images", "phoneScreenshots", "2.png")); err != nil {
+		t.Fatal(err)
+	}
+	r := scanFixture(t, cleanManifest(), nil, Options{ListingsDir: dir})
+	requireFinding(t, r, "screenshot_count", SeverityError)
+}
+
+func TestMetadataMissingDirIsReported(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), nil, Options{ListingsDir: filepath.Join(t.TempDir(), "nope")})
+	requireFinding(t, r, "listings_dir", SeverityError)
+}
+
+// --- 6. billing -------------------------------------------------------------
+
+// dexWith builds a fake dex entry containing the given type descriptors.
+func dexWith(markers ...string) []byte {
+	var b bytes.Buffer
+	b.WriteString("dex\n035\x00")
+	b.Write(bytes.Repeat([]byte{0}, 64))
+	for _, m := range markers {
+		b.WriteString(m)
+		b.WriteString("Foo;")
+	}
+	return b.Bytes()
+}
+
+func TestBillingThirdPartyProcessorFlagged(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), map[string][]byte{
+		"base/dex/classes.dex": dexWith("Lcom/stripe/android/"),
+	}, Options{})
+	f := requireFinding(t, r, "third_party_payments", SeverityWarning)
+	if !strings.Contains(f.Message, "Stripe") {
+		t.Errorf("message = %q", f.Message)
+	}
+}
+
+func TestBillingThirdPartyAlongsidePlayBillingIsInfo(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), map[string][]byte{
+		"base/dex/classes.dex": dexWith("Lcom/stripe/android/", "Lcom/android/billingclient/api/"),
+	}, Options{})
+	requireFinding(t, r, "third_party_payments", SeverityInfo)
+	requireFinding(t, r, "play_billing", SeverityInfo)
+}
+
+func TestBillingPermissionWithoutImplementation(t *testing.T) {
+	m := withPermissions(cleanManifest(), billingPermission)
+	r := scanFixture(t, m, nil, Options{})
+	requireFinding(t, r, "billing_permission", SeverityWarning)
+}
+
+// --- 7. privacy -------------------------------------------------------------
+
+func TestPrivacyTrackingSDKRequiresAdID(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), map[string][]byte{
+		"base/dex/classes.dex": dexWith("Lcom/appsflyer/"),
+	}, Options{})
+	f := requireFinding(t, r, "tracking_sdk", SeverityInfo)
+	if !strings.Contains(f.Message, "AppsFlyer") {
+		t.Errorf("message = %q", f.Message)
+	}
+	requireFinding(t, r, "advertising_id", SeverityWarning)
+}
+
+func TestPrivacyAdIDDeclaredWithoutSDK(t *testing.T) {
+	m := withPermissions(cleanManifest(), adIDPermission)
+	r := scanFixture(t, m, nil, Options{})
+	requireFinding(t, r, "advertising_id", SeverityInfo)
+}
+
+func TestPrivacyCleartextWithTrackingSDK(t *testing.T) {
+	m := cleanManifest()
+	appNode(&m).attrs = append(appNode(&m).attrs, pbAttr{
+		ns: AndroidNS, name: "usesCleartextTraffic", compiled: pbPrimBool(true),
+	})
+	r := scanFixture(t, m, map[string][]byte{
+		"base/dex/classes.dex": dexWith("Lcom/appsflyer/"),
+	}, Options{})
+	requireFinding(t, r, "insecure_transit", SeverityWarning)
+}
+
+// --- 8. policy --------------------------------------------------------------
+
+func TestPolicyTargetSDKBelowFloor(t *testing.T) {
+	m := cleanManifest()
+	m.children[0] = pbElem{name: "uses-sdk", attrs: []pbAttr{
+		{ns: AndroidNS, name: "targetSdkVersion", compiled: pbPrimInt(30)},
+	}}
+	r := scanFixture(t, m, nil, Options{})
+	f := requireFinding(t, r, "target_sdk", SeverityError)
+	if !strings.Contains(f.Message, "30") {
+		t.Errorf("message = %q", f.Message)
+	}
+
+	// The floor is configurable so the check survives Play's annual bump.
+	relaxed := scanFixture(t, m, nil, Options{MinTargetSDK: 30})
+	requireNoFinding(t, relaxed, "target_sdk")
+}
+
+func TestPolicyRestrictedService(t *testing.T) {
+	m := cleanManifest()
+	appNode(&m).children = append(appNode(&m).children, pbElem{
+		name: "service",
+		attrs: []pbAttr{
+			{ns: AndroidNS, name: "name", value: ".A11yService"},
+			{ns: AndroidNS, name: "permission", value: "android.permission.BIND_ACCESSIBILITY_SERVICE"},
+		},
+	})
+	r := scanFixture(t, m, nil, Options{})
+	requireFinding(t, r, "restricted_service", SeverityWarning)
+}
+
+func TestPolicyAPKFormatNoted(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "app.apk")
+	buildAAB(t, path, map[string][]byte{
+		"AndroidManifest.xml": pbNode(cleanManifest()),
+		"resources.arsc":      []byte("res"),
+		"classes.dex":         []byte("dex"),
+	})
+	r, err := Scan(path, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Format != formatAPK {
+		t.Fatalf("format = %q, want apk", r.Format)
+	}
+	requireFinding(t, r, "upload_format", SeverityInfo)
+}
+
+func TestPolicyFamiliesNoteWhenAdsPresent(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), map[string][]byte{
+		"base/dex/classes.dex": dexWith("Lcom/google/android/gms/ads/"),
+	}, Options{})
+	requireFinding(t, r, "families_policy", SeverityInfo)
+	requireFinding(t, r, "ads_sdk", SeverityInfo)
+}
+
+// --- 9. size ----------------------------------------------------------------
+
+func TestSizeOverLimitIsError(t *testing.T) {
+	r := scanFixture(t, cleanManifest(), nil, Options{MaxBundleBytes: 1})
+	requireFinding(t, r, "bundle_size", SeverityError)
+}
+
+func TestSizeDexCountWarning(t *testing.T) {
+	extra := map[string][]byte{}
+	for i := 0; i < 25; i++ {
+		extra[filepath.Join("base/dex", "classes"+string(rune('a'+i))+".dex")] = []byte("dex")
+	}
+	r := scanFixture(t, cleanManifest(), extra, Options{})
+	f := requireFinding(t, r, "dex", SeverityWarning)
+	if !strings.Contains(f.Message, "dex files") {
+		t.Errorf("message = %q", f.Message)
+	}
+}
+
+func TestHumanBytes(t *testing.T) {
+	cases := map[int64]string{
+		512:                    "512 B",
+		2048:                   "2.0 KB",
+		5 * 1024 * 1024:        "5.0 MB",
+		3 * 1024 * 1024 * 1024: "3.0 GB",
+	}
+	for in, want := range cases {
+		if got := humanBytes(in); got != want {
+			t.Errorf("humanBytes(%d) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/preflight/sdkdb.go
+++ b/internal/preflight/sdkdb.go
@@ -1,0 +1,279 @@
+package preflight
+
+// SDK signature database.
+//
+// Detection is heuristic: it looks for type descriptors in dex bytecode and
+// for characteristic entry paths. Aggressive code shrinking can rename or
+// remove classes, so a miss is not proof an SDK is absent. Matches, on the
+// other hand, are high confidence — the markers below are package prefixes
+// that only the named SDK uses.
+
+// SDK categories.
+const (
+	categoryBilling  = "billing"
+	categoryPayment  = "payment"
+	categoryTracking = "tracking"
+	categoryAds      = "ads"
+)
+
+// sdkSignature identifies one third-party SDK.
+type sdkSignature struct {
+	ID       string
+	Name     string
+	Category string
+	// Markers are dex type-descriptor prefixes.
+	Markers []string
+	// Paths are substrings matched against archive entry names.
+	Paths []string
+}
+
+// Well-known signature IDs referenced directly by scanners.
+const (
+	sdkPlayBilling = "google_play_billing"
+	sdkAdMob       = "admob"
+	sdkFirebase    = "firebase_analytics"
+)
+
+var sdkSignatures = []sdkSignature{
+	// --- In-app billing -----------------------------------------------------
+	{
+		ID: sdkPlayBilling, Name: "Google Play Billing Library", Category: categoryBilling,
+		Markers: []string{"Lcom/android/billingclient/api/"},
+	},
+	{
+		ID: "revenuecat", Name: "RevenueCat", Category: categoryBilling,
+		Markers: []string{"Lcom/revenuecat/purchases/"},
+	},
+	{
+		ID: "adapty", Name: "Adapty", Category: categoryBilling,
+		Markers: []string{"Lcom/adapty/"},
+	},
+	{
+		ID: "qonversion", Name: "Qonversion", Category: categoryBilling,
+		Markers: []string{"Lcom/qonversion/android/sdk/"},
+	},
+	{
+		ID: "amazon_iap", Name: "Amazon In-App Purchasing", Category: categoryBilling,
+		Markers: []string{"Lcom/amazon/device/iap/"},
+	},
+	{
+		ID: "huawei_iap", Name: "Huawei IAP", Category: categoryBilling,
+		Markers: []string{"Lcom/huawei/hms/iap/"},
+	},
+
+	// --- Third-party payment processors ------------------------------------
+	{
+		ID: "stripe", Name: "Stripe", Category: categoryPayment,
+		Markers: []string{"Lcom/stripe/android/"},
+	},
+	{
+		ID: "braintree", Name: "Braintree", Category: categoryPayment,
+		Markers: []string{"Lcom/braintreepayments/api/"},
+	},
+	{
+		ID: "paypal", Name: "PayPal", Category: categoryPayment,
+		Markers: []string{"Lcom/paypal/checkout/", "Lcom/paypal/android/sdk/"},
+	},
+	{
+		ID: "adyen", Name: "Adyen", Category: categoryPayment,
+		Markers: []string{"Lcom/adyen/checkout/"},
+	},
+	{
+		ID: "square", Name: "Square", Category: categoryPayment,
+		Markers: []string{"Lcom/squareup/sdk/"},
+	},
+	{
+		ID: "razorpay", Name: "Razorpay", Category: categoryPayment,
+		Markers: []string{"Lcom/razorpay/"},
+	},
+	{
+		ID: "paddle", Name: "Paddle", Category: categoryPayment,
+		Markers: []string{"Lcom/paddle/android/"},
+	},
+	{
+		ID: "mercadopago", Name: "Mercado Pago", Category: categoryPayment,
+		Markers: []string{"Lcom/mercadopago/android/"},
+	},
+	{
+		ID: "flutterwave", Name: "Flutterwave", Category: categoryPayment,
+		Markers: []string{"Lcom/flutterwave/raveandroid/"},
+	},
+
+	// --- Analytics, attribution, crash reporting ---------------------------
+	{
+		ID: sdkFirebase, Name: "Firebase Analytics", Category: categoryTracking,
+		Markers: []string{"Lcom/google/firebase/analytics/"},
+	},
+	{
+		ID: "crashlytics", Name: "Firebase Crashlytics", Category: categoryTracking,
+		Markers: []string{"Lcom/google/firebase/crashlytics/"},
+	},
+	{
+		ID: "facebook", Name: "Meta (Facebook) SDK", Category: categoryTracking,
+		Markers: []string{"Lcom/facebook/appevents/", "Lcom/facebook/FacebookSdk;"},
+	},
+	{
+		ID: "appsflyer", Name: "AppsFlyer", Category: categoryTracking,
+		Markers: []string{"Lcom/appsflyer/"},
+	},
+	{
+		ID: "adjust", Name: "Adjust", Category: categoryTracking,
+		Markers: []string{"Lcom/adjust/sdk/"},
+	},
+	{
+		ID: "branch", Name: "Branch", Category: categoryTracking,
+		Markers: []string{"Lio/branch/referral/"},
+	},
+	{
+		ID: "amplitude", Name: "Amplitude", Category: categoryTracking,
+		Markers: []string{"Lcom/amplitude/"},
+	},
+	{
+		ID: "mixpanel", Name: "Mixpanel", Category: categoryTracking,
+		Markers: []string{"Lcom/mixpanel/android/"},
+	},
+	{
+		ID: "segment", Name: "Segment", Category: categoryTracking,
+		Markers: []string{"Lcom/segment/analytics/"},
+	},
+	{
+		ID: "sentry", Name: "Sentry", Category: categoryTracking,
+		Markers: []string{"Lio/sentry/android/"},
+	},
+	{
+		ID: "bugsnag", Name: "Bugsnag", Category: categoryTracking,
+		Markers: []string{"Lcom/bugsnag/android/"},
+	},
+	{
+		ID: "onesignal", Name: "OneSignal", Category: categoryTracking,
+		Markers: []string{"Lcom/onesignal/"},
+	},
+	{
+		ID: "braze", Name: "Braze", Category: categoryTracking,
+		Markers: []string{"Lcom/braze/"},
+	},
+	{
+		ID: "airship", Name: "Airship", Category: categoryTracking,
+		Markers: []string{"Lcom/urbanairship/"},
+	},
+	{
+		ID: "kochava", Name: "Kochava", Category: categoryTracking,
+		Markers: []string{"Lcom/kochava/"},
+	},
+	{
+		ID: "singular", Name: "Singular", Category: categoryTracking,
+		Markers: []string{"Lcom/singular/sdk/"},
+	},
+	{
+		ID: "flurry", Name: "Flurry", Category: categoryTracking,
+		Markers: []string{"Lcom/flurry/android/"},
+	},
+	{
+		ID: "umeng", Name: "Umeng", Category: categoryTracking,
+		Markers: []string{"Lcom/umeng/"},
+	},
+	{
+		ID: "tenjin", Name: "Tenjin", Category: categoryTracking,
+		Markers: []string{"Lcom/tenjin/android/"},
+	},
+	{
+		ID: "clevertap", Name: "CleverTap", Category: categoryTracking,
+		Markers: []string{"Lcom/clevertap/android/sdk/"},
+	},
+	{
+		ID: "moengage", Name: "MoEngage", Category: categoryTracking,
+		Markers: []string{"Lcom/moengage/"},
+	},
+	{
+		ID: "newrelic", Name: "New Relic", Category: categoryTracking,
+		Markers: []string{"Lcom/newrelic/agent/android/"},
+	},
+	{
+		ID: "datadog", Name: "Datadog", Category: categoryTracking,
+		Markers: []string{"Lcom/datadog/android/"},
+	},
+	{
+		ID: "posthog", Name: "PostHog", Category: categoryTracking,
+		Markers: []string{"Lcom/posthog/"},
+	},
+	{
+		ID: "countly", Name: "Countly", Category: categoryTracking,
+		Markers: []string{"Lly/count/android/sdk/"},
+	},
+	{
+		ID: "yandex_metrica", Name: "Yandex AppMetrica", Category: categoryTracking,
+		Markers: []string{"Lcom/yandex/metrica/", "Lio/appmetrica/analytics/"},
+	},
+
+	// --- Advertising --------------------------------------------------------
+	{
+		ID: sdkAdMob, Name: "Google Mobile Ads (AdMob)", Category: categoryAds,
+		Markers: []string{"Lcom/google/android/gms/ads/"},
+	},
+	{
+		ID: "applovin", Name: "AppLovin", Category: categoryAds,
+		Markers: []string{"Lcom/applovin/"},
+	},
+	{
+		ID: "ironsource", Name: "ironSource / Unity LevelPlay", Category: categoryAds,
+		Markers: []string{"Lcom/ironsource/"},
+	},
+	{
+		ID: "unity_ads", Name: "Unity Ads", Category: categoryAds,
+		Markers: []string{"Lcom/unity3d/ads/"},
+	},
+	{
+		ID: "vungle", Name: "Vungle / Liftoff", Category: categoryAds,
+		Markers: []string{"Lcom/vungle/"},
+	},
+	{
+		ID: "chartboost", Name: "Chartboost", Category: categoryAds,
+		Markers: []string{"Lcom/chartboost/"},
+	},
+	{
+		ID: "inmobi", Name: "InMobi", Category: categoryAds,
+		Markers: []string{"Lcom/inmobi/"},
+	},
+	{
+		ID: "pangle", Name: "Pangle (ByteDance)", Category: categoryAds,
+		Markers: []string{"Lcom/bytedance/sdk/openadsdk/"},
+	},
+	{
+		ID: "mintegral", Name: "Mintegral", Category: categoryAds,
+		Markers: []string{"Lcom/mbridge/msdk/"},
+	},
+	{
+		ID: "fyber", Name: "Fyber / Digital Turbine", Category: categoryAds,
+		Markers: []string{"Lcom/fyber/"},
+	},
+	{
+		ID: "moloco", Name: "Moloco", Category: categoryAds,
+		Markers: []string{"Lcom/moloco/sdk/"},
+	},
+	{
+		ID: "meta_audience", Name: "Meta Audience Network", Category: categoryAds,
+		Markers: []string{"Lcom/facebook/ads/"},
+	},
+	{
+		ID: "tapjoy", Name: "Tapjoy", Category: categoryAds,
+		Markers: []string{"Lcom/tapjoy/"},
+	},
+	{
+		ID: "adcolony", Name: "AdColony", Category: categoryAds,
+		Markers: []string{"Lcom/adcolony/sdk/"},
+	},
+	{
+		ID: "smaato", Name: "Smaato", Category: categoryAds,
+		Markers: []string{"Lcom/smaato/sdk/"},
+	},
+}
+
+// sdkNameByID resolves a signature ID to its display name.
+func sdkNameByID(id string) string {
+	for _, s := range sdkSignatures {
+		if s.ID == id {
+			return s.Name
+		}
+	}
+	return id
+}

--- a/internal/preflight/types.go
+++ b/internal/preflight/types.go
@@ -1,0 +1,146 @@
+package preflight
+
+import "strings"
+
+// Severity of a preflight finding.
+type Severity string
+
+const (
+	SeverityInfo    Severity = "info"
+	SeverityWarning Severity = "warning"
+	SeverityError   Severity = "error"
+)
+
+// Finding is a single preflight check result.
+type Finding struct {
+	// Scanner is the ID of the scanner that produced this finding.
+	Scanner string `json:"scanner"`
+	// Check is the stable identifier for the specific rule.
+	Check    string   `json:"check"`
+	Severity Severity `json:"severity"`
+	Message  string   `json:"message"`
+	// Entry is the bundle entry or file the finding refers to.
+	Entry string `json:"entry,omitempty"`
+	// Hint explains how to fix the finding.
+	Hint string `json:"hint,omitempty"`
+	// Ref links to the relevant Play policy or developer documentation.
+	Ref string `json:"ref,omitempty"`
+}
+
+// ScannerRun records what a single scanner did.
+type ScannerRun struct {
+	ID       string `json:"id"`
+	Findings int    `json:"findings"`
+	Skipped  bool   `json:"skipped,omitempty"`
+	Reason   string `json:"reason,omitempty"`
+}
+
+// Report aggregates all findings from a scan.
+type Report struct {
+	Path   string `json:"path"`
+	Format string `json:"format,omitempty"`
+
+	Package     string `json:"package,omitempty"`
+	VersionCode int64  `json:"version_code,omitempty"`
+	VersionName string `json:"version_name,omitempty"`
+	MinSdk      int    `json:"min_sdk,omitempty"`
+	TargetSdk   int    `json:"target_sdk,omitempty"`
+
+	Findings []Finding `json:"findings"`
+	Infos    int       `json:"infos"`
+	Warnings int       `json:"warnings"`
+	Errors   int       `json:"errors"`
+
+	Scanners  []ScannerRun `json:"scanners"`
+	Checks    []string     `json:"checks_run"`
+	TotalSize int64        `json:"total_size_bytes"`
+}
+
+// Options tunes the scan.
+type Options struct {
+	// MaxBundleBytes is the maximum allowed total compressed size
+	// (0 = default 200MB, matching the Play download-size limit).
+	MaxBundleBytes int64
+	// MaxDexBytes is the per-dex warning threshold (0 = default 64MB).
+	MaxDexBytes int64
+	// SkipSecretScan disables secret-pattern matching.
+	SkipSecretScan bool
+	// MaxScanBytesPerEntry caps how many bytes are read per entry
+	// (0 = default 5MB).
+	MaxScanBytesPerEntry int64
+	// MaxDexScanBytes caps how many bytes of each dex are searched for SDK
+	// signatures (0 = default 96MB).
+	MaxDexScanBytes int64
+	// ListingsDir enables the metadata scanner against a Fastlane-style
+	// listings directory. When empty, the metadata scanner is skipped.
+	ListingsDir string
+	// MinTargetSDK is the minimum target SDK Play accepts
+	// (0 = default currentMinTargetSDK).
+	MinTargetSDK int
+	// Only restricts the run to these scanner IDs. Empty means all.
+	Only []string
+	// Skip excludes these scanner IDs.
+	Skip []string
+}
+
+// HasErrors returns true if the report contains any error-severity findings.
+func (r *Report) HasErrors() bool { return r.Errors > 0 }
+
+// severityRank orders severities for threshold comparisons.
+func severityRank(s Severity) int {
+	switch s {
+	case SeverityError:
+		return 3
+	case SeverityWarning:
+		return 2
+	case SeverityInfo:
+		return 1
+	}
+	return 0
+}
+
+// AtOrAbove reports whether the report contains a finding at least as severe
+// as min.
+func (r *Report) AtOrAbove(min Severity) bool {
+	want := severityRank(min)
+	for _, f := range r.Findings {
+		if severityRank(f.Severity) >= want {
+			return true
+		}
+	}
+	return false
+}
+
+// FindingsFor returns the findings produced by a given scanner ID.
+func (r *Report) FindingsFor(scannerID string) []Finding {
+	var out []Finding
+	for _, f := range r.Findings {
+		if f.Scanner == scannerID {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// normalizeIDs lowercases and trims a list of scanner IDs, also splitting
+// comma-separated entries so `--only manifest,secrets` works.
+func normalizeIDs(in []string) []string {
+	var out []string
+	for _, s := range in {
+		for _, part := range strings.Split(s, ",") {
+			if p := strings.ToLower(strings.TrimSpace(part)); p != "" {
+				out = append(out, p)
+			}
+		}
+	}
+	return out
+}
+
+func containsID(list []string, id string) bool {
+	for _, s := range list {
+		if s == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/preflight/xmltree.go
+++ b/internal/preflight/xmltree.go
@@ -1,0 +1,174 @@
+package preflight
+
+import (
+	"strconv"
+	"strings"
+)
+
+// AndroidNS is the XML namespace URI for framework attributes.
+const AndroidNS = "http://schemas.android.com/apk/res/android"
+
+// AttrType describes how an attribute value was encoded in the source manifest.
+//
+// Binary manifests carry typed values, so `android:debuggable` is a real
+// boolean rather than the string "true". Keeping the type lets scanners
+// distinguish "absent", "false", and "not statically determinable" (e.g. a
+// value that is a resource reference resolved at build time).
+type AttrType int
+
+const (
+	// AttrUnknown means the value could not be typed (raw string only).
+	AttrUnknown AttrType = iota
+	// AttrString is a literal string value.
+	AttrString
+	// AttrBool is a typed boolean.
+	AttrBool
+	// AttrInt is a typed integer (decimal or hex).
+	AttrInt
+	// AttrReference is a reference to a resource (@id/foo); the concrete value
+	// lives in the resource table and is not resolvable from the manifest.
+	AttrReference
+)
+
+// Attr is a single decoded manifest attribute.
+type Attr struct {
+	Namespace string
+	Name      string
+	// Value is the raw string form when available. For typed values with no
+	// raw string, it holds a rendered form (e.g. "true", "34").
+	Value string
+	Int   int64
+	Bool  bool
+	Type  AttrType
+}
+
+// Node is a decoded XML element. Both the binary AXML decoder (APK) and the
+// aapt2 protobuf decoder (AAB) produce this shape so scanners stay
+// format-agnostic.
+type Node struct {
+	Name     string
+	Attrs    []Attr
+	Children []*Node
+}
+
+// Attribute returns the attribute matching namespace and name.
+func (n *Node) Attribute(ns, name string) (Attr, bool) {
+	if n == nil {
+		return Attr{}, false
+	}
+	for _, a := range n.Attrs {
+		if a.Name == name && a.Namespace == ns {
+			return a, true
+		}
+	}
+	return Attr{}, false
+}
+
+// Android returns the `android:`-namespaced attribute with the given name.
+func (n *Node) Android(name string) (Attr, bool) { return n.Attribute(AndroidNS, name) }
+
+// Plain returns an attribute with no namespace (e.g. `package` on <manifest>).
+func (n *Node) Plain(name string) (Attr, bool) { return n.Attribute("", name) }
+
+// Child returns the first direct child with the given element name.
+func (n *Node) Child(name string) *Node {
+	for _, c := range n.ChildrenNamed(name) {
+		return c
+	}
+	return nil
+}
+
+// ChildrenNamed returns all direct children with the given element name.
+func (n *Node) ChildrenNamed(name string) []*Node {
+	if n == nil {
+		return nil
+	}
+	var out []*Node
+	for _, c := range n.Children {
+		if c.Name == name {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// Walk invokes fn for this node and every descendant, depth first.
+func (n *Node) Walk(fn func(*Node)) {
+	if n == nil {
+		return
+	}
+	fn(n)
+	for _, c := range n.Children {
+		c.Walk(fn)
+	}
+}
+
+// BoolValue reports the attribute's boolean value. The second return is false
+// when the value is not statically determinable (missing, a resource
+// reference, or an unparseable string).
+func (a Attr) BoolValue() (bool, bool) {
+	switch a.Type {
+	case AttrBool:
+		return a.Bool, true
+	case AttrInt:
+		return a.Int != 0, true
+	case AttrReference:
+		return false, false
+	}
+	switch strings.ToLower(strings.TrimSpace(a.Value)) {
+	case "true", "1":
+		return true, true
+	case "false", "0":
+		return false, true
+	}
+	return false, false
+}
+
+// IntValue reports the attribute's integer value. The second return is false
+// when the value is not statically determinable.
+func (a Attr) IntValue() (int64, bool) {
+	if a.Type == AttrInt {
+		return a.Int, true
+	}
+	if a.Type == AttrReference {
+		return 0, false
+	}
+	v := strings.TrimSpace(a.Value)
+	if v == "" {
+		return 0, false
+	}
+	if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return n, true
+	}
+	return 0, false
+}
+
+// StringValue returns the string form of the attribute.
+func (a Attr) StringValue() string { return a.Value }
+
+// androidBool is a helper for the common "read an android: boolean" case.
+func androidBool(n *Node, name string) (val bool, known bool) {
+	a, ok := n.Android(name)
+	if !ok {
+		return false, false
+	}
+	return a.BoolValue()
+}
+
+// androidInt is a helper for the common "read an android: integer" case.
+func androidInt(n *Node, name string) (val int64, known bool) {
+	a, ok := n.Android(name)
+	if !ok {
+		return 0, false
+	}
+	return a.IntValue()
+}
+
+// androidString returns the string form of an android: attribute, or "".
+func androidString(n *Node, name string) string {
+	a, ok := n.Android(name)
+	if !ok {
+		return ""
+	}
+	return a.Value
+}

--- a/llms.txt
+++ b/llms.txt
@@ -46,7 +46,7 @@
 - `gplay migrate fastlane` — migrate metadata from Fastlane directory structure
 - `gplay release-notes set` — set release notes (plain text auto-assigned to en-US)
 - `gplay validate` — pre-submission validation checks
-- `gplay preflight --file <app.aab>` — offline compliance scan (manifest, size, native ABIs, dex, debuggable/testOnly flags, cleartext, dangerous perms, secret scan); `--fail-on` severity for CI
+- `gplay preflight --file <app.aab>` — offline compliance scan, no API calls. Decodes AndroidManifest.xml (binary AXML for APKs, aapt2 protobuf for AABs) and runs nine scanners: `manifest`, `permissions`, `native_libs` (incl. 16 KB page alignment), `metadata` (with `--listings-dir`), `secrets`, `billing`, `privacy`, `policy`, `size`. Select with `--only`/`--skip`, gate CI with `--fail-on`, list with `--list-scanners`
 - `gplay bundles analyze --file <app.aab>` — offline size breakdown per module/bucket, top largest files
 - `gplay bundles compare --base <a.aab> --candidate <b.aab> --threshold 2M` — size regression gate
 - `gplay audit list/search/clear/path` — local journal of every invocation at `~/.gplay/audit.log` (disable with `GPLAY_AUDIT=0`)


### PR DESCRIPTION
## Summary

Rebuilds `gplay preflight` into a **nine-scanner offline engine** backed by a real `AndroidManifest.xml` decoder. This closes the largest capability gap found in the competitor research: every other Play Console CLI either has no offline scanning at all, or matches substrings against raw bytes.

Before this PR the repo had **zero** manifest decoding — `preflight` inferred `debuggable`, permissions, and cleartext from `strings.Contains` over the compressed archive. It now parses the manifest properly and reads typed attribute values.

## What's included

### Manifest decoding layer

- **`axml.go`** — binary AXML chunk decoder for APK manifests: string pool (UTF-8 and UTF-16 variants, high-bit length continuations), typed `Res_value` attributes, guards against truncated chunks and absurd string counts.
- **`protoxml.go`** — aapt2 protobuf `XmlNode` decoder for App Bundles, via `protowire`. No generated types, no vendored `.proto`; field numbers derived from `Resources.proto` and documented inline. Depth-limited.
- **`xmltree.go` / `manifest.go`** — one format-agnostic tree model and one typed manifest both decoders feed. Optional booleans are `*bool`, so *absent*, *explicitly false*, and *a resource reference we cannot resolve statically* stay distinguishable — the distinction substring matching cannot make.
- A heuristic substring fallback still runs when a manifest cannot be decoded, so obfuscated or malformed inputs degrade rather than go silent.

### The nine scanners

| Scanner | Catches |
|---|---|
| `manifest` | `debuggable`, `testOnly`, exported components missing `android:exported` on `targetSdk` 31+ (a hard install failure), exported providers granting URI permissions, foreground service types without their Android 14 permission (a runtime `SecurityException`), cleartext traffic, `allowBackup`, package/version sanity |
| `permissions` | 23 restricted permissions needing a Play declaration form, 18 sensitive ones needing a Data safety disclosure, legacy storage on modern targets, duplicates, deprecated. Findings carry Play policy doc links |
| `native_libs` | Missing `arm64-v8a`, **16 KB memory page alignment** read from real ELF program headers via `debug/elf`, unstripped debug symbols, `extractNativeLibs="true"` |
| `metadata` | Listing text limits (reusing `internal/validation`) plus **real screenshot pixel dimensions**, aspect ratio, count, and icon/feature-graphic sizes via `image.DecodeConfig`. Enabled by `--listings-dir` |
| `secrets` | 14 credential patterns, shipped keystores and `.pem` files, `.git`/`.env` leakage. Also scans dex string data |
| `billing` | Play Billing vs third-party processors, `com.android.vending.BILLING` declared with no implementation |
| `privacy` | 40+ analytics/attribution/ads SDK signatures, `AD_ID` consistency against `targetSdk` 33+ |
| `policy` | Target API level floor, restricted services (accessibility, VPN, device admin, notification listener), APK-vs-AAB upload format |
| `size` | Download budget, dex fragmentation, payload breakdown by bucket |

### CLI

New flags: `--listings-dir`, `--only`, `--skip`, `--list-scanners`, `--min-target-sdk`. Text output now groups findings per scanner, reporting `ok`, `skipped (reason)`, or the finding count for every scanner that ran, with a header carrying package, version, and SDK levels.

Legacy check names (`manifest`, `resources`, `native_libs`, `bundle_size`, `secrets`, `debuggable`, `dangerous_permissions`, `misplaced_files`) are preserved, so existing JSON consumers keep working.

### Performance

Dex and entry scanning streams in bounded 1 MB chunks with boundary overlap, so memory stays flat regardless of entry size. The archive is indexed once and the manifest decoded once per run; the SDK index is computed lazily behind a `sync.Once`.

## Usage

```bash
gplay preflight --file app.aab
gplay preflight --file app.aab --listings-dir ./fastlane/metadata/android --fail-on warning
gplay preflight --file app.aab --only manifest,permissions,native_libs
gplay preflight --file app.aab --skip size --output json --pretty | jq .
gplay preflight --list-scanners
```

## Behavior change worth a second look

The `google_api_key` pattern drops from **error to warning**, and its existing test was updated to match.

Android apps embed Maps and Firebase `AIza…` keys by design. As an error, this made `--fail-on error` unusable as a CI gate for most real apps. The defence is key restriction in Cloud Console, not absence from the binary — the hint now says exactly that. Hard credentials (private keys, service-account JSON, `sk_live_`, GitHub/Slack tokens) remain errors, and two new tests pin that down.

Separately, `scan_policy.go` carries `currentMinTargetSDK = 35` with a comment noting Google raises it each August. `--min-target-sdk` overrides it without a rebuild.

## Known limitation

The decoder ignores obfuscated AXML where attribute *names* are stripped and only resource IDs remain. Shipping a hardcoded resource-ID table risked wrong IDs producing silently wrong results, so it was deliberately left out — aapt2 emits attribute names for normal builds, so this only affects deliberately anti-analysis APKs.

## Validation

- [x] `make build` — clean
- [x] `make test` — full suite passes
- [x] `make check-docs` — GPLAY.md up to date
- [x] `golangci-lint run ./...` — 0 issues
- [x] Pre-commit hook passed (credential scan, format, lint, docs)
- [x] 65 tests, **82.8%** statement coverage in `internal/preflight`
- [x] Mutation-tested: breaking `isPageAligned` fails 2 tests, stubbing dex marker search fails 5 — the tests are not vacuous
- [x] End-to-end smoke run on a synthetic AAB: 4 errors / 6 warnings / 3 info across 8 scanners, exit 1
- [x] Binary help renders at command level with all new flags

## Docs updated

`README.md` (highlight + comparison row), `docs/releasing.md` (full scanner table), `docs/ci-cd.md` (gate recipes), `llms.txt`, `Agents.md`, `CHANGELOG.md`, `GPLAY.md` (regenerated).
