### PR TITLE
fix(deobfuscation): send exact API casing for --type nativeCode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [GitHub Releases](https://github.com/tamtom/play-console-cli/releases).
 
 
+## [Unreleased]
+
+### Fixed
+
+- `gplay deobfuscation upload --type nativeCode` no longer fails with HTTP 400.
+  The type was lowercased for validation and the lowercased value was then reused
+  to build the request, so the API received `nativecode` and rejected it. `--type`
+  is still matched case-insensitively, but the value is now sent in the exact
+  casing the API defines. `--type proguard` was unaffected. ([#253](https://github.com/tamtom/play-console-cli/issues/253))
+
 ## [0.8.0] - 2026-07-26
 
 ### Added

--- a/internal/cli/deobfuscation/deobfuscation.go
+++ b/internal/cli/deobfuscation/deobfuscation.go
@@ -15,6 +15,28 @@ import (
 	"github.com/tamtom/play-console-cli/internal/playclient"
 )
 
+// newPlayService is the test seam for injecting a mock Play API service.
+var newPlayService = playclient.NewService
+
+// deobfuscationTypes maps a lowercased --type value to the exact casing the
+// Play API expects. The type is interpolated into the request URL as the
+// {deobfuscationFileType} path segment, so casing is load-bearing: sending
+// "nativecode" fails with HTTP 400 "Invalid value at 'deobfuscation_file_type'".
+var deobfuscationTypes = map[string]string{
+	"proguard":   "proguard",
+	"nativecode": "nativeCode",
+}
+
+// canonicalDeobfuscationType validates --type case-insensitively and returns
+// the value in the casing the API requires.
+func canonicalDeobfuscationType(raw string) (string, error) {
+	apiType, ok := deobfuscationTypes[strings.ToLower(strings.TrimSpace(raw))]
+	if !ok {
+		return "", fmt.Errorf("--type must be 'proguard' or 'nativeCode'")
+	}
+	return apiType, nil
+}
+
 func DeobfuscationCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("deobfuscation", flag.ExitOnError)
 	return &ffcli.Command{
@@ -65,10 +87,12 @@ func UploadCommand() *ffcli.Command {
 				return fmt.Errorf("--file is required")
 			}
 
-			// Validate deobfuscation type
-			deobType := strings.ToLower(strings.TrimSpace(*deobfuscationType))
-			if deobType != "proguard" && deobType != "nativecode" {
-				return fmt.Errorf("--type must be 'proguard' or 'nativeCode'")
+			// Validate deobfuscation type. Accept any casing from the user, but
+			// send the exact casing the API defines: the value becomes a URL
+			// path segment and the API rejects "nativecode" with HTTP 400.
+			deobType, err := canonicalDeobfuscationType(*deobfuscationType)
+			if err != nil {
+				return err
 			}
 
 			// Parse version code
@@ -77,7 +101,7 @@ func UploadCommand() *ffcli.Command {
 				return fmt.Errorf("invalid --apk-version: %w", err)
 			}
 
-			service, err := playclient.NewService(ctx)
+			service, err := newPlayService(ctx)
 			if err != nil {
 				return err
 			}

--- a/internal/cli/deobfuscation/deobfuscation_test.go
+++ b/internal/cli/deobfuscation/deobfuscation_test.go
@@ -1,0 +1,181 @@
+package deobfuscation
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/playclient"
+)
+
+func TestDeobfuscationCommand_NoArgsReturnsHelp(t *testing.T) {
+	cmd := DeobfuscationCommand()
+	if err := cmd.Exec(context.Background(), nil); !errors.Is(err, flag.ErrHelp) {
+		t.Fatalf("expected flag.ErrHelp, got %v", err)
+	}
+}
+
+// TestUploadCommand_SendsExactAPICasing pins the casing of the
+// deobfuscationFileType path segment. The Play API rejects a lowercased
+// "nativecode" with HTTP 400, so --type must be matched case-insensitively but
+// sent in the exact casing the API defines.
+func TestUploadCommand_SendsExactAPICasing(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagType string
+		wantPath string
+	}{
+		{name: "nativeCode as documented", flagType: "nativeCode", wantPath: "nativeCode"},
+		{name: "nativecode lowercased by user", flagType: "nativecode", wantPath: "nativeCode"},
+		{name: "NATIVECODE uppercased by user", flagType: "NATIVECODE", wantPath: "nativeCode"},
+		{name: "proguard", flagType: "proguard", wantPath: "proguard"},
+		{name: "ProGuard mixed case", flagType: "ProGuard", wantPath: "proguard"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			installMockDeobfuscationPlayService(t, func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"deobfuscationFile":{"symbolType":"nativeCode"}}`)
+			})
+
+			cmd := UploadCommand()
+			if err := cmd.FlagSet.Parse([]string{
+				"--package", "com.example.app",
+				"--edit", "edit-1",
+				"--apk-version", "42",
+				"--file", writeTempMappingFile(t),
+				"--type", tc.flagType,
+			}); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+
+			if _, err := captureDeobfuscationStdout(func() error {
+				return cmd.Exec(context.Background(), nil)
+			}); err != nil {
+				t.Fatalf("exec: %v", err)
+			}
+
+			wantSuffix := "/deobfuscationFiles/" + tc.wantPath
+			if !strings.HasSuffix(gotPath, wantSuffix) {
+				t.Fatalf("request path %q does not end with %q", gotPath, wantSuffix)
+			}
+		})
+	}
+}
+
+func TestUploadCommand_RejectsUnknownType(t *testing.T) {
+	cmd := UploadCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--package", "com.example.app",
+		"--edit", "edit-1",
+		"--apk-version", "42",
+		"--file", writeTempMappingFile(t),
+		"--type", "bogus",
+	}); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "--type must be") {
+		t.Fatalf("expected --type validation error, got %v", err)
+	}
+}
+
+func TestUploadCommand_RequiredFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing edit",
+			args:    []string{"--package", "com.example.app", "--apk-version", "42", "--file", "x"},
+			wantErr: "--edit is required",
+		},
+		{
+			name:    "missing apk-version",
+			args:    []string{"--package", "com.example.app", "--edit", "edit-1", "--file", "x"},
+			wantErr: "--apk-version is required",
+		},
+		{
+			name:    "missing file",
+			args:    []string{"--package", "com.example.app", "--edit", "edit-1", "--apk-version", "42"},
+			wantErr: "--file is required",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := UploadCommand()
+			if err := cmd.FlagSet.Parse(tc.args); err != nil {
+				t.Fatalf("parse flags: %v", err)
+			}
+			err := cmd.Exec(context.Background(), nil)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected %q, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func writeTempMappingFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "mapping.txt")
+	if err := os.WriteFile(path, []byte("com.example.Foo -> a:\n"), 0o600); err != nil {
+		t.Fatalf("writing temp mapping file: %v", err)
+	}
+	return path
+}
+
+func installMockDeobfuscationPlayService(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	original := newPlayService
+	newPlayService = func(ctx context.Context) (*playclient.Service, error) {
+		return playclient.NewServiceWithClient(ctx, server.Client(), server.URL+"/")
+	}
+	t.Cleanup(func() {
+		newPlayService = original
+	})
+}
+
+func captureDeobfuscationStdout(fn func() error) (string, error) {
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = wOut
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, rOut)
+	}()
+
+	runErr := fn()
+
+	_ = wOut.Close()
+	os.Stdout = origStdout
+	wg.Wait()
+	_ = rOut.Close()
+
+	return buf.String(), runErr
+}


### PR DESCRIPTION
## Summary

Fixes #253. `gplay deobfuscation upload --type nativeCode` failed every time with HTTP 400; `--type proguard` worked. The reporter's diagnosis was correct.

## Root Cause

`--type` was lowercased for validation and the lowercased copy was then reused to build the call:

```go
deobType := strings.ToLower(strings.TrimSpace(*deobfuscationType))
if deobType != "proguard" && deobType != "nativecode" { ... }
...
call := service.API.Edits.Deobfuscationfiles.Upload(pkg, *editID, int64(versionCode), deobType)
```

The value is interpolated into the request URL as the `{deobfuscationFileType}` path segment:

```
/upload/androidpublisher/v3/applications/{packageName}/edits/{editId}/apks/{apkVersionCode}/deobfuscationFiles/{deobfuscationFileType}
```

so casing is load-bearing. The API received `nativecode` and rejected it with `Invalid value at 'deobfuscation_file_type'`. `proguard` was unaffected only because it is already lowercase.

## What Changed

- `--type` is still matched case-insensitively, but now maps through `canonicalDeobfuscationType` to the exact casing the API defines before the call is built.
- Added `newPlayService` test seam, matching the convention already used in `tracks`, `iap`, `purchases`, and `expansion`.
- Added the package's first test file.

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes)
- [ ] Documentation update

## Implementation Checklist

### Command & Registration
- [x] No new command; `deobfuscation` is already registered in `internal/cli/registry/registry.go`
- [x] `UsageFunc: shared.DefaultUsageFunc` unchanged
- [x] Required flags validated with stderr error messages (now covered by tests)
- [x] `shared.ContextWithUploadTimeout` usage unchanged

### Tests
- [x] Written TDD — the casing test was confirmed failing for the right reason before the fix (asserted `nativecode` on the wire), then green after
- [x] Casing contract pinned for both types, including mixed-case user input (`NATIVECODE`, `ProGuard`)
- [x] Error paths tested explicitly (unknown `--type`, and each missing required flag asserted on the error message, not just `flag.ErrHelp`)

### Docs & Help
- [x] `--help` text already documented `nativeCode`; no change needed
- [x] `make check-docs` — GPLAY.md up to date
- [x] `CHANGELOG.md` updated under `[Unreleased]`

## Validation

```
go build ./...                       ok
go vet ./...                         ok
make test                            pass (all packages, exit 0)
go test -race ./internal/cli/deobfuscation/   pass
make lint                            0 issues (via pre-commit hook)
make check-docs                      GPLAY.md up to date
```

Before the fix:

```
--- FAIL: TestUploadCommand_SendsExactAPICasing/nativeCode_as_documented
    request path ".../deobfuscationFiles/nativecode" does not end with ".../deobfuscationFiles/nativeCode"
```

After: all 5 casing cases pass.
