### PR TITLE
feat(vitals): add --from/--to date range flags to errors issues/reports

### DIFF
--- a/GPLAY.md
+++ b/GPLAY.md
@@ -3321,20 +3321,27 @@ Supported --order-by fields:
   errorReportCount desc, errorReportCount asc,
   distinctUsers desc, distinctUsers asc
 
+Date range:
+  --from and --to accept YYYY-MM-DD dates (both inclusive, interpreted as UTC).
+  If neither is set, the API defaults to the last 24 hours.
+
 Examples:
   gplay vitals errors issues --package com.example.app
   gplay vitals errors issues --package com.example.app --filter "errorIssueType = CRASH"
   gplay vitals errors issues --package com.example.app --order-by "errorReportCount desc" --page-size 10
+  gplay vitals errors issues --package com.example.app --from 2025-01-01 --to 2025-01-31
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--filter` | AIP-160 filter expression (e.g. 'errorIssueType = CRASH') | `` |
+| `--from` | Start date, inclusive (UTC, YYYY-MM-DD) | `` |
 | `--order-by` | Order results (e.g. 'errorReportCount desc') | `` |
 | `--output` | Output format: json (default), table, markdown | `json` |
 | `--package` | Package name (applicationId) | `` |
 | `--page-size` | Max results per page (1-1000) | `50` |
 | `--paginate` | Fetch all pages | `false` |
 | `--pretty` | Pretty-print JSON output | `false` |
+| `--to` | End date, inclusive (UTC, YYYY-MM-DD) | `` |
 
 ---
 
@@ -3355,19 +3362,26 @@ Supported --filter fields:
   errorIssueType (CRASH, ANR, NON_FATAL), errorIssueId, errorReportId,
   appProcessState (FOREGROUND, BACKGROUND), isUserPerceived
 
+Date range:
+  --from and --to accept YYYY-MM-DD dates (both inclusive, interpreted as UTC).
+  If neither is set, the API defaults to the last 24 hours.
+
 Examples:
   gplay vitals errors reports --package com.example.app
   gplay vitals errors reports --package com.example.app --filter "errorIssueType = CRASH"
   gplay vitals errors reports --package com.example.app --filter "errorIssueId = 12345" --page-size 10
+  gplay vitals errors reports --package com.example.app --from 2025-01-01 --to 2025-01-31
 
 | Flag | Description | Default |
 |------|-------------|---------|
 | `--filter` | AIP-160 filter expression (e.g. 'errorIssueType = CRASH') | `` |
+| `--from` | Start date, inclusive (UTC, YYYY-MM-DD) | `` |
 | `--output` | Output format: json (default), table, markdown | `json` |
 | `--package` | Package name (applicationId) | `` |
 | `--page-size` | Max results per page (1-100) | `50` |
 | `--paginate` | Fetch all pages | `false` |
 | `--pretty` | Pretty-print JSON output | `false` |
+| `--to` | End date, inclusive (UTC, YYYY-MM-DD) | `` |
 
 ---
 

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -14,9 +14,12 @@ gplay vitals performance startup --package com.example.app
 gplay vitals performance rendering --package com.example.app
 gplay vitals performance battery --package com.example.app
 
-# ANR / error tracking
+# ANR / error tracking (defaults to the last 24 hours)
 gplay vitals errors issues --package com.example.app
 gplay vitals errors reports --package com.example.app
+
+# Error tracking over a date range (UTC, inclusive)
+gplay vitals errors issues --package com.example.app --from 2025-01-01 --to 2025-01-31
 ```
 
 ## Reviews

--- a/internal/cli/vitals/errors/errors_test.go
+++ b/internal/cli/vitals/errors/errors_test.go
@@ -83,7 +83,7 @@ func TestIssuesCommand_Structure(t *testing.T) {
 
 func TestIssuesCommand_Flags(t *testing.T) {
 	cmd := IssuesCommand()
-	expectedFlags := []string{"package", "filter", "order-by", "page-size", "paginate", "output", "pretty"}
+	expectedFlags := []string{"package", "filter", "order-by", "from", "to", "page-size", "paginate", "output", "pretty"}
 	for _, name := range expectedFlags {
 		f := cmd.FlagSet.Lookup(name)
 		if f == nil {
@@ -176,7 +176,7 @@ func TestReportsCommand_Structure(t *testing.T) {
 
 func TestReportsCommand_Flags(t *testing.T) {
 	cmd := ReportsCommand()
-	expectedFlags := []string{"package", "filter", "page-size", "paginate", "output", "pretty"}
+	expectedFlags := []string{"package", "filter", "from", "to", "page-size", "paginate", "output", "pretty"}
 	for _, name := range expectedFlags {
 		f := cmd.FlagSet.Lookup(name)
 		if f == nil {

--- a/internal/cli/vitals/errors/interval.go
+++ b/internal/cli/vitals/errors/interval.go
@@ -1,0 +1,95 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/api/playdeveloperreporting/v1beta1"
+
+	"github.com/tamtom/play-console-cli/internal/reportingclient"
+)
+
+var newReportingService = reportingclient.NewService
+
+// searchInterval holds UTC bounds for an error search. The end bound is
+// already converted to the exclusive midnight after the inclusive --to date.
+type searchInterval struct {
+	start time.Time
+	end   time.Time
+}
+
+// buildSearchInterval parses --from/--to (YYYY-MM-DD, interpreted as UTC)
+// into a searchInterval. Returns nil when neither flag is set. The API
+// requires hour-aligned UTC bounds; midnight date bounds satisfy that.
+func buildSearchInterval(from, to string) (*searchInterval, error) {
+	start, err := parseSearchDateFlag("--from", from)
+	if err != nil {
+		return nil, err
+	}
+	end, err := parseSearchDateFlag("--to", to)
+	if err != nil {
+		return nil, err
+	}
+	if !start.IsZero() && !end.IsZero() && start.After(end) {
+		return nil, fmt.Errorf("--from must be on or before --to")
+	}
+	if start.IsZero() && end.IsZero() {
+		return nil, nil
+	}
+	interval := &searchInterval{start: start}
+	if !end.IsZero() {
+		interval.end = end.AddDate(0, 0, 1)
+	}
+	return interval, nil
+}
+
+func parseSearchDateFlag(flagName, value string) (time.Time, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return time.Time{}, nil
+	}
+	parsed, err := time.Parse("2006-01-02", trimmed)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid %s date %q: expected YYYY-MM-DD", flagName, value)
+	}
+	return parsed, nil
+}
+
+func applyIssuesInterval(call *playdeveloperreporting.VitalsErrorsIssuesSearchCall, interval *searchInterval) *playdeveloperreporting.VitalsErrorsIssuesSearchCall {
+	if interval == nil {
+		return call
+	}
+	if !interval.start.IsZero() {
+		call = call.
+			IntervalStartTimeYear(int64(interval.start.Year())).
+			IntervalStartTimeMonth(int64(interval.start.Month())).
+			IntervalStartTimeDay(int64(interval.start.Day()))
+	}
+	if !interval.end.IsZero() {
+		call = call.
+			IntervalEndTimeYear(int64(interval.end.Year())).
+			IntervalEndTimeMonth(int64(interval.end.Month())).
+			IntervalEndTimeDay(int64(interval.end.Day()))
+	}
+	return call
+}
+
+func applyReportsInterval(call *playdeveloperreporting.VitalsErrorsReportsSearchCall, interval *searchInterval) *playdeveloperreporting.VitalsErrorsReportsSearchCall {
+	if interval == nil {
+		return call
+	}
+	if !interval.start.IsZero() {
+		call = call.
+			IntervalStartTimeYear(int64(interval.start.Year())).
+			IntervalStartTimeMonth(int64(interval.start.Month())).
+			IntervalStartTimeDay(int64(interval.start.Day()))
+	}
+	if !interval.end.IsZero() {
+		call = call.
+			IntervalEndTimeYear(int64(interval.end.Year())).
+			IntervalEndTimeMonth(int64(interval.end.Month())).
+			IntervalEndTimeDay(int64(interval.end.Day()))
+	}
+	return call
+}

--- a/internal/cli/vitals/errors/interval_test.go
+++ b/internal/cli/vitals/errors/interval_test.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -130,11 +131,14 @@ func TestIssuesCommand_IntervalQueryParams(t *testing.T) {
 
 	cmd := IssuesCommand()
 	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--from", "2025-01-01", "--to", "2025-01-31"})
-	_, err := captureErrorsStdout(func() error {
+	stdout, err := captureErrorsStdout(func() error {
 		return cmd.Exec(context.Background(), nil)
 	})
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !json.Valid([]byte(stdout)) {
+		t.Fatalf("expected JSON output, got %q", stdout)
 	}
 
 	want := map[string]string{
@@ -162,11 +166,14 @@ func TestIssuesCommand_NoIntervalParamsByDefault(t *testing.T) {
 
 	cmd := IssuesCommand()
 	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app"})
-	_, err := captureErrorsStdout(func() error {
+	stdout, err := captureErrorsStdout(func() error {
 		return cmd.Exec(context.Background(), nil)
 	})
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !json.Valid([]byte(stdout)) {
+		t.Fatalf("expected JSON output, got %q", stdout)
 	}
 	if strings.Contains(gotRawQuery, "interval.") {
 		t.Errorf("expected no interval params without --from/--to, got query: %s", gotRawQuery)
@@ -186,11 +193,14 @@ func TestReportsCommand_IntervalQueryParams(t *testing.T) {
 
 	cmd := ReportsCommand()
 	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--from", "2025-06-15", "--to", "2025-06-15"})
-	_, err := captureErrorsStdout(func() error {
+	stdout, err := captureErrorsStdout(func() error {
 		return cmd.Exec(context.Background(), nil)
 	})
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !json.Valid([]byte(stdout)) {
+		t.Fatalf("expected JSON output, got %q", stdout)
 	}
 
 	want := map[string]string{

--- a/internal/cli/vitals/errors/interval_test.go
+++ b/internal/cli/vitals/errors/interval_test.go
@@ -1,0 +1,227 @@
+package errors
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tamtom/play-console-cli/internal/reportingclient"
+)
+
+func TestBuildSearchInterval_Empty(t *testing.T) {
+	interval, err := buildSearchInterval("", "  ")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if interval != nil {
+		t.Errorf("expected nil interval when no dates given, got %+v", interval)
+	}
+}
+
+func TestBuildSearchInterval_BothDates(t *testing.T) {
+	interval, err := buildSearchInterval("2025-01-01", "2025-01-31")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if interval == nil {
+		t.Fatal("expected interval, got nil")
+	}
+	wantStart := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	if !interval.start.Equal(wantStart) {
+		t.Errorf("expected start %v, got %v", wantStart, interval.start)
+	}
+	// Inclusive --to date becomes an exclusive next-day bound.
+	wantEnd := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	if !interval.end.Equal(wantEnd) {
+		t.Errorf("expected exclusive end %v, got %v", wantEnd, interval.end)
+	}
+}
+
+func TestBuildSearchInterval_FromOnly(t *testing.T) {
+	interval, err := buildSearchInterval("2025-01-01", "")
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if interval == nil {
+		t.Fatal("expected interval, got nil")
+	}
+	if interval.start.IsZero() {
+		t.Error("expected start to be set")
+	}
+	if !interval.end.IsZero() {
+		t.Errorf("expected zero end, got %v", interval.end)
+	}
+}
+
+func TestBuildSearchInterval_InvalidDate(t *testing.T) {
+	if _, err := buildSearchInterval("01/02/2025", ""); err == nil || !strings.Contains(err.Error(), "YYYY-MM-DD") {
+		t.Errorf("expected YYYY-MM-DD format error, got: %v", err)
+	}
+	if _, err := buildSearchInterval("", "not-a-date"); err == nil || !strings.Contains(err.Error(), "YYYY-MM-DD") {
+		t.Errorf("expected YYYY-MM-DD format error, got: %v", err)
+	}
+}
+
+func TestBuildSearchInterval_FromAfterTo(t *testing.T) {
+	_, err := buildSearchInterval("2025-02-01", "2025-01-01")
+	if err == nil || !strings.Contains(err.Error(), "--from must be on or before --to") {
+		t.Errorf("expected ordering error, got: %v", err)
+	}
+}
+
+func installMockErrorsReportingService(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	original := newReportingService
+	newReportingService = func(ctx context.Context) (*reportingclient.Service, error) {
+		return reportingclient.NewServiceWithClient(ctx, server.Client(), server.URL+"/")
+	}
+	t.Cleanup(func() {
+		newReportingService = original
+	})
+}
+
+func captureErrorsStdout(fn func() error) (string, error) {
+	origStdout := os.Stdout
+	rOut, wOut, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+
+	os.Stdout = wOut
+
+	var buf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(&buf, rOut)
+	}()
+
+	execErr := fn()
+
+	wOut.Close()
+	os.Stdout = origStdout
+	wg.Wait()
+
+	return buf.String(), execErr
+}
+
+func TestIssuesCommand_IntervalQueryParams(t *testing.T) {
+	var gotQuery map[string]string
+	installMockErrorsReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = map[string]string{}
+		for key, values := range r.URL.Query() {
+			gotQuery[key] = values[0]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"errorIssues":[]}`)
+	})
+
+	cmd := IssuesCommand()
+	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--from", "2025-01-01", "--to", "2025-01-31"})
+	_, err := captureErrorsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	want := map[string]string{
+		"interval.startTime.year":  "2025",
+		"interval.startTime.month": "1",
+		"interval.startTime.day":   "1",
+		"interval.endTime.year":    "2025",
+		"interval.endTime.month":   "2",
+		"interval.endTime.day":     "1",
+	}
+	for key, value := range want {
+		if gotQuery[key] != value {
+			t.Errorf("expected query param %s=%s, got %q", key, value, gotQuery[key])
+		}
+	}
+}
+
+func TestIssuesCommand_NoIntervalParamsByDefault(t *testing.T) {
+	var gotRawQuery string
+	installMockErrorsReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotRawQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"errorIssues":[]}`)
+	})
+
+	cmd := IssuesCommand()
+	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app"})
+	_, err := captureErrorsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if strings.Contains(gotRawQuery, "interval.") {
+		t.Errorf("expected no interval params without --from/--to, got query: %s", gotRawQuery)
+	}
+}
+
+func TestReportsCommand_IntervalQueryParams(t *testing.T) {
+	var gotQuery map[string]string
+	installMockErrorsReportingService(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = map[string]string{}
+		for key, values := range r.URL.Query() {
+			gotQuery[key] = values[0]
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"errorReports":[]}`)
+	})
+
+	cmd := ReportsCommand()
+	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--from", "2025-06-15", "--to", "2025-06-15"})
+	_, err := captureErrorsStdout(func() error {
+		return cmd.Exec(context.Background(), nil)
+	})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+
+	want := map[string]string{
+		"interval.startTime.year":  "2025",
+		"interval.startTime.month": "6",
+		"interval.startTime.day":   "15",
+		"interval.endTime.year":    "2025",
+		"interval.endTime.month":   "6",
+		"interval.endTime.day":     "16",
+	}
+	for key, value := range want {
+		if gotQuery[key] != value {
+			t.Errorf("expected query param %s=%s, got %q", key, value, gotQuery[key])
+		}
+	}
+}
+
+func TestIssuesCommand_InvalidFromDate(t *testing.T) {
+	cmd := IssuesCommand()
+	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--from", "bad-date"})
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "YYYY-MM-DD") {
+		t.Errorf("expected date format error, got: %v", err)
+	}
+}
+
+func TestReportsCommand_FromAfterTo(t *testing.T) {
+	cmd := ReportsCommand()
+	_ = cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--from", "2025-02-01", "--to", "2025-01-01"})
+	err := cmd.Exec(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "--from must be on or before --to") {
+		t.Errorf("expected ordering error, got: %v", err)
+	}
+}

--- a/internal/cli/vitals/errors/issues.go
+++ b/internal/cli/vitals/errors/issues.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/api/playdeveloperreporting/v1beta1"
 
 	"github.com/tamtom/play-console-cli/internal/cli/shared"
-	"github.com/tamtom/play-console-cli/internal/reportingclient"
 )
 
 // IssuesCommand returns the `gplay vitals errors issues` subcommand.
@@ -19,6 +18,8 @@ func IssuesCommand() *ffcli.Command {
 	packageName := fs.String("package", "", "Package name (applicationId)")
 	filter := fs.String("filter", "", "AIP-160 filter expression (e.g. 'errorIssueType = CRASH')")
 	orderBy := fs.String("order-by", "", "Order results (e.g. 'errorReportCount desc')")
+	from := fs.String("from", "", "Start date, inclusive (UTC, YYYY-MM-DD)")
+	to := fs.String("to", "", "End date, inclusive (UTC, YYYY-MM-DD)")
 	pageSize := fs.Int64("page-size", 50, "Max results per page (1-1000)")
 	paginate := fs.Bool("paginate", false, "Fetch all pages")
 	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
@@ -39,17 +40,26 @@ Supported --order-by fields:
   errorReportCount desc, errorReportCount asc,
   distinctUsers desc, distinctUsers asc
 
+Date range:
+  --from and --to accept YYYY-MM-DD dates (both inclusive, interpreted as UTC).
+  If neither is set, the API defaults to the last 24 hours.
+
 Examples:
   gplay vitals errors issues --package com.example.app
   gplay vitals errors issues --package com.example.app --filter "errorIssueType = CRASH"
-  gplay vitals errors issues --package com.example.app --order-by "errorReportCount desc" --page-size 10`,
+  gplay vitals errors issues --package com.example.app --order-by "errorReportCount desc" --page-size 10
+  gplay vitals errors issues --package com.example.app --from 2025-01-01 --to 2025-01-31`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
 				return err
 			}
-			service, err := reportingclient.NewService(ctx)
+			interval, err := buildSearchInterval(*from, *to)
+			if err != nil {
+				return err
+			}
+			service, err := newReportingService(ctx)
 			if err != nil {
 				return err
 			}
@@ -73,6 +83,7 @@ Examples:
 				if strings.TrimSpace(*orderBy) != "" {
 					call = call.OrderBy(*orderBy)
 				}
+				call = applyIssuesInterval(call, interval)
 				resp, err := call.Do()
 				if err != nil {
 					return shared.WrapGoogleAPIError("search error issues", err)
@@ -90,6 +101,7 @@ Examples:
 			if strings.TrimSpace(*orderBy) != "" {
 				call = call.OrderBy(*orderBy)
 			}
+			call = applyIssuesInterval(call, interval)
 			err = call.Pages(ctx, func(resp *playdeveloperreporting.GooglePlayDeveloperReportingV1beta1SearchErrorIssuesResponse) error {
 				all = append(all, resp.ErrorIssues...)
 				return nil

--- a/internal/cli/vitals/errors/reports.go
+++ b/internal/cli/vitals/errors/reports.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/api/playdeveloperreporting/v1beta1"
 
 	"github.com/tamtom/play-console-cli/internal/cli/shared"
-	"github.com/tamtom/play-console-cli/internal/reportingclient"
 )
 
 // ReportsCommand returns the `gplay vitals errors reports` subcommand.
@@ -18,6 +17,8 @@ func ReportsCommand() *ffcli.Command {
 	fs := flag.NewFlagSet("vitals errors reports", flag.ExitOnError)
 	packageName := fs.String("package", "", "Package name (applicationId)")
 	filter := fs.String("filter", "", "AIP-160 filter expression (e.g. 'errorIssueType = CRASH')")
+	from := fs.String("from", "", "Start date, inclusive (UTC, YYYY-MM-DD)")
+	to := fs.String("to", "", "End date, inclusive (UTC, YYYY-MM-DD)")
 	pageSize := fs.Int64("page-size", 50, "Max results per page (1-100)")
 	paginate := fs.Bool("paginate", false, "Fetch all pages")
 	outputFlag := fs.String("output", "json", "Output format: json (default), table, markdown")
@@ -36,17 +37,26 @@ Supported --filter fields:
   errorIssueType (CRASH, ANR, NON_FATAL), errorIssueId, errorReportId,
   appProcessState (FOREGROUND, BACKGROUND), isUserPerceived
 
+Date range:
+  --from and --to accept YYYY-MM-DD dates (both inclusive, interpreted as UTC).
+  If neither is set, the API defaults to the last 24 hours.
+
 Examples:
   gplay vitals errors reports --package com.example.app
   gplay vitals errors reports --package com.example.app --filter "errorIssueType = CRASH"
-  gplay vitals errors reports --package com.example.app --filter "errorIssueId = 12345" --page-size 10`,
+  gplay vitals errors reports --package com.example.app --filter "errorIssueId = 12345" --page-size 10
+  gplay vitals errors reports --package com.example.app --from 2025-01-01 --to 2025-01-31`,
 		FlagSet:   fs,
 		UsageFunc: shared.DefaultUsageFunc,
 		Exec: func(ctx context.Context, args []string) error {
 			if err := shared.ValidateOutputFlags(*outputFlag, *pretty); err != nil {
 				return err
 			}
-			service, err := reportingclient.NewService(ctx)
+			interval, err := buildSearchInterval(*from, *to)
+			if err != nil {
+				return err
+			}
+			service, err := newReportingService(ctx)
 			if err != nil {
 				return err
 			}
@@ -67,6 +77,7 @@ Examples:
 				if strings.TrimSpace(*filter) != "" {
 					call = call.Filter(*filter)
 				}
+				call = applyReportsInterval(call, interval)
 				resp, err := call.Do()
 				if err != nil {
 					return shared.WrapGoogleAPIError("search error reports", err)
@@ -81,6 +92,7 @@ Examples:
 			if strings.TrimSpace(*filter) != "" {
 				call = call.Filter(*filter)
 			}
+			call = applyReportsInterval(call, interval)
 			err = call.Pages(ctx, func(resp *playdeveloperreporting.GooglePlayDeveloperReportingV1beta1SearchErrorReportsResponse) error {
 				all = append(all, resp.ErrorReports...)
 				return nil


### PR DESCRIPTION
## Summary

`vitals errors issues` and `vitals errors reports` currently send no `interval` to the Reporting API, and the API then defaults to **the last 24 hours** ([docs](https://developers.google.com/play/developer/reporting/reference/rest/v1beta1/vitals.errors.reports/search#query-parameters)) — so any error older than a day is unreachable from the CLI, and there is no way to narrow a search either.

This adds `--from` / `--to` flags to both commands, wiring them to the `interval.startTime.*` / `interval.endTime.*` query parameters:

- Same UX as the existing `vitals crashes query --from/--to`: `YYYY-MM-DD`, both bounds inclusive, `--to` converted to an exclusive next-day midnight bound.
- Dates are interpreted as UTC midnights, which satisfies the API's hour-aligned-UTC requirement for these endpoints.
- Either flag can be used on its own; `--from` after `--to` and malformed dates fail fast with clear errors before any network call.
- `newReportingService` is now a package var in the errors package (same pattern as the `vitals` package) so the new behavior is tested against a mock server.

## Example

```bash
gplay vitals errors issues --package com.example.app \
  --filter "errorIssueType = CRASH" --from 2025-01-01 --to 2025-01-31
```

## Test plan

- [x] Unit tests for interval parsing (empty, one-sided, inclusive→exclusive end conversion, invalid format, from>to)
- [x] httptest-based wire tests asserting the exact `interval.startTime.*`/`interval.endTime.*` query params for both commands, and that no interval params are sent when the flags are absent
- [x] `make dev` (format + lint + test + build) passes
- [x] `make docs` regenerated GPLAY.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)