### PR TITLE
fix: embed release version metadata (v0.9.1 hotfix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,15 @@ jobs:
 
           echo "Built: $BINARY_NAME"
 
+          if [ "${{ matrix.os }}" = "linux" ] && [ "${{ matrix.arch }}" = "amd64" ]; then
+            EXPECTED="$VERSION (commit: $COMMIT, date: $DATE)"
+            ACTUAL=$(./"$BINARY_NAME" --version)
+            if [ "$ACTUAL" != "$EXPECTED" ]; then
+              echo "release version mismatch: got '$ACTUAL', want '$EXPECTED'" >&2
+              exit 1
+            fi
+          fi
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Release notes for **0.5.0 – 0.7.1** were auto-generated and live in
 > [GitHub Releases](https://github.com/tamtom/play-console-cli/releases).
 
+## [0.9.1] - 2026-08-24
+
+### Fixed
+
+- Release binaries now read the canonical linker-injected version, commit, and
+  build date instead of reporting `dev (commit: unknown, date: unknown)`.
+  v0.9.1 supersedes the affected v0.9.0 binaries; command behavior and API
+  compatibility are otherwise unchanged.
+
+### Testing
+
+- Added a black-box regression test that builds and executes the real CLI with
+  release linker metadata.
+- The release workflow now executes the Linux amd64 artifact and requires its
+  exact version output before publishing any release.
+
 ## [0.9.0] - 2026-08-24
 
 ### Added

--- a/docs/api/google-play-api-manifest.json
+++ b/docs/api/google-play-api-manifest.json
@@ -5,7 +5,7 @@
       "methods": [
         "androiddeveloperidstatus.packages.packageRegistrationStatus.check"
       ],
-      "revision": "20260820",
+      "revision": "20260823",
       "version": "v1"
     },
     "androidpublisher": {

--- a/docs/research/developer-id-status-api-drift-2026-08-24.md
+++ b/docs/research/developer-id-status-api-drift-2026-08-24.md
@@ -1,0 +1,89 @@
+# Android Developer ID Status API discovery drift review — 2026-08-24
+
+## Conclusion
+
+Android Developer ID Status API `v1` drift from revision `20260820` to
+`20260823` is a revision-only metadata change. There are no method, endpoint,
+parameter, response, or schema changes. No `gplay` production-code, dependency,
+or drift-driven test changes are required.
+
+The repository follow-up is only to advance this API's revision in the reviewed
+manifest and embedded schema index together to `20260823`. This investigation
+does not update either artifact.
+
+## Evidence
+
+Primary sources compared:
+
+- Google's [live Android Developer ID Status `v1` discovery document](https://androiddeveloperidstatus.googleapis.com/$discovery/rest?version=v1),
+  which reported revision `20260823` during this review.
+- The repository's committed `main` baseline at `0db97553`: the reviewed
+  [API manifest](https://github.com/tamtom/play-console-cli/blob/0db97553b01c2e507ebd59e20809975c4e2372fc/docs/api/google-play-api-manifest.json#L3-L9)
+  and embedded [schema index metadata](https://github.com/tamtom/play-console-cli/blob/0db97553b01c2e507ebd59e20809975c4e2372fc/internal/apischema/schema-index.json#L3-L9),
+  both at revision `20260820`, plus the indexed
+  [endpoint](https://github.com/tamtom/play-console-cli/blob/0db97553b01c2e507ebd59e20809975c4e2372fc/internal/apischema/schema-index.json#L68-L95)
+  and [response schema](https://github.com/tamtom/play-console-cli/blob/0db97553b01c2e507ebd59e20809975c4e2372fc/internal/apischema/schema-index.json#L7934-L7970).
+- Google's official `google-api-go-client` `v0.293.0`
+  [discovery artifact](https://github.com/googleapis/google-api-go-client/blob/v0.293.0/androiddeveloperidstatus/v1/androiddeveloperidstatus-api.json)
+  and [generated Go source](https://github.com/googleapis/google-api-go-client/blob/v0.293.0/androiddeveloperidstatus/v1/androiddeveloperidstatus-gen.go).
+  The repository pins that version in [`go.mod`](../../go.mod).
+
+Exact comparison results:
+
+| Surface | Reviewed `20260820` | Live `20260823` | Difference |
+| --- | --- | --- | --- |
+| Revision | `20260820` | `20260823` | Revision string only |
+| Method set | One method: `androiddeveloperidstatus.packages.packageRegistrationStatus.check` | Same | None |
+| Base/service path | `https://androiddeveloperidstatus.googleapis.com/`; empty service path | Same | None |
+| HTTP endpoint | `GET v1/{+name}:check` | Same | None |
+| Flat path | `v1/packages/{packagesId}/packageRegistrationStatus:check` | Same | None |
+| Required parameter | Path `name`, pattern `^packages/[^/]+/packageRegistrationStatus$` | Same | None |
+| Optional parameter | Query string `certificateFingerprint` | Same | None |
+| Response | `PackageRegistrationStatus` | Same | None |
+| Schemas | One type with three properties | Same full definition | None |
+
+`PackageRegistrationStatus` remains unchanged: `name` is a string;
+`certificateFingerprint` is a read-only string; and `state` is a read-only
+string with the same four values: `REGISTRATION_STATE_UNSPECIFIED`, `REGISTERED`,
+`NOT_REGISTERED`, and `REGISTERED_WITH_ANOTHER_CERTIFICATE_FINGERPRINT`.
+Descriptions, enum descriptions, read-only markers, parameter order, and the
+response reference also match exactly.
+
+As an independent completeness check, Google's `v0.293.0` discovery artifact
+reports the older revision `20260804`, but its complete discovery JSON becomes
+identical to live `20260823` after removing only the top-level `revision`
+property. Canonical JSON produced with `jq -cS` has the same SHA-256 for both:
+`65a0e23feb7ec4fb2369c8150a1157904e79e4a50977b93c6c8cd5d8df76f797`.
+The generated source already exposes `Check(name)`, the optional
+`CertificateFingerprint` setter, the `GET v1/{+name}:check` request, and all
+three response fields. A `google.golang.org/api` upgrade is therefore not
+needed for this drift.
+
+## Code and test impact
+
+The existing `gplay verification status` implementation already builds the
+required resource name, converts package-name dots to hyphens, calls the
+generated `Check` method, and conditionally sends `certificateFingerprint`.
+Existing endpoint tests cover the required API key, fingerprint validation,
+official path, optional query parameter, and API-error propagation. No behavior
+or fixture change is required by this revision bump.
+
+One optional, unrelated hardening improvement remains: the unit test's success
+body currently uses an unknown `packageName` property and does not assert
+decoding of `name`, `certificateFingerprint`, or `state`. Replacing it with a
+schema-valid response and asserting emitted JSON would improve response-contract
+coverage, but it is not necessary to accept this drift.
+
+## Verification
+
+The relevant implementation, generated-client boundary, embedded schema, and
+production-root CLI tests remain green:
+
+```text
+go test ./internal/cli/verification ./internal/developeridclient ./internal/apischema
+go test ./internal/cmdtest -run 'TestOfficialParityFamilies_RunThroughProductionRoot/developer_verification|TestParityCommands_ProductionRootFailurePaths/verification' -count=1
+python3 scripts/gen-schema-index.py --check
+```
+
+This review added only this research note; it did not modify the manifest,
+schema index, dependency, production code, or tests.

--- a/docs/research/release-handover-2026-08-24.md
+++ b/docs/research/release-handover-2026-08-24.md
@@ -1,0 +1,152 @@
+# Release handover — 2026-08-24
+
+## Immediate state
+
+- Repository: `tamtom/play-console-cli`
+- Working branch: `codex/release-metadata-hotfix`
+- Base: `0db97553b01c2e507ebd59e20809975c4e2372fc` (`v0.9.0`, merged PR #262)
+- Do **not** discard the uncommitted changes on this branch.
+- Goal: finish and publish immutable hotfix `v0.9.1`.
+
+Expected working-tree changes:
+
+```text
+M  .github/workflows/release.yml
+M  CHANGELOG.md
+M  docs/api/google-play-api-manifest.json
+M  internal/apischema/schema-index.json
+M  main.go
+?? release_metadata_test.go
+?? docs/research/developer-id-status-api-drift-2026-08-24.md
+?? docs/research/release-handover-2026-08-24.md
+```
+
+## Why v0.9.1 is required
+
+Release `v0.9.0` is published and its five binaries match the published checksums, but a downloaded macOS ARM64 binary reports:
+
+```text
+dev (commit: unknown, date: unknown)
+```
+
+The release build injected `internal/version.Version`, `Commit`, and `BuildDate`, while `main.go` printed unrelated variables in package `main`. This also makes update/version comparisons unreliable in the released binary.
+
+Do not delete, move, or rewrite the `v0.9.0` tag. Publish `v0.9.1`, then mark the `v0.9.0` release as superseded.
+
+## Hotfix already implemented (uncommitted)
+
+1. `main.go` now prints `internal/version.Version`, `Commit`, and `BuildDate` without changing the output format.
+2. `release_metadata_test.go` builds and executes the real CLI with linker metadata and asserts the exact result. It failed before the fix and passes after it.
+3. `.github/workflows/release.yml` executes the Linux AMD64 artifact before publication and fails unless `--version` exactly matches the tag, commit, and build date.
+4. `CHANGELOG.md` contains the `0.9.1` hotfix entry and explains that it supersedes `0.9.0`.
+5. Official Android Developer ID Status discovery revisions were synchronized from `20260820` to `20260823` in the manifest and embedded schema index.
+
+Developer ID Status drift is revision-only. The live API still has one identical GET method and an identical response schema; `google.golang.org/api v0.293.0` exposes the full live contract. No client or command change is needed.
+
+The independent primary-source comparison is recorded in `docs/research/developer-id-status-api-drift-2026-08-24.md`.
+
+## Validation already completed
+
+- Regression test: pass
+- `go test -race ./... -count=1`: pass before the final revision-only manifest refresh
+- `go vet ./...`: pass
+- golangci-lint v2.13.1: 0 issues
+- `make format-check`: pass
+- `make check-docs`: pass
+- `make check-api-drift`: pass after manifest refresh
+- Developer ID/schema targeted tests: pass
+- `make build-all VERSION=v0.9.1`: all five platforms built
+- Local executable reports: `v0.9.1 (commit: localtest, date: 2026-08-24T18:30:00Z)`
+- `govulncheck`: 0 reachable vulnerabilities
+
+Before committing, rerun the complete final gate because the Developer ID revision refresh happened after the full race run:
+
+```bash
+GOTOOLCHAIN=go1.25.13 go test -race ./... -count=1
+GOTOOLCHAIN=go1.25.13 go vet ./...
+GOTOOLCHAIN=auto go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.13.1 run
+GOTOOLCHAIN=go1.25.13 make format-check
+GOTOOLCHAIN=go1.25.13 make check-docs
+GOTOOLCHAIN=go1.25.13 make check-api-drift
+GOTOOLCHAIN=go1.25.13 make build-all VERSION=v0.9.1
+GOTOOLCHAIN=go1.25.13 go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+git diff --check
+```
+
+## Exact release continuation
+
+1. Inspect `git diff` and confirm only the files above changed.
+2. Run the final gate.
+3. Commit on `codex/release-metadata-hotfix`, suggested message: `fix: embed release version metadata`.
+4. Push the branch and open one PR to `main`; do not split the work.
+5. Wait for all PR checks, merge, then wait for main-branch and CodeQL checks.
+6. Optionally run the official live integration workflow once on the merged commit.
+7. Tag and push `v0.9.1`.
+8. Wait for the release workflow and Homebrew tap update.
+9. Download every release asset and verify `checksums.txt`.
+10. Execute the native binary and assert it reports the exact `v0.9.1` metadata.
+11. Confirm the `v0.9.1` release body uses the changelog entry.
+12. Add a warning at the top of the `v0.9.0` release body: superseded by `v0.9.1` because `v0.9.0` binaries reported development metadata. Keep all `v0.9.0` assets and its tag immutable.
+
+## Completed v0.9.0 work
+
+- PR #262: <https://github.com/tamtom/play-console-cli/pull/262>
+- Release: <https://github.com/tamtom/play-console-cli/releases/tag/v0.9.0>
+- All six PR checks, main CI, CodeQL, release packaging, checksums, and Homebrew dispatch passed.
+- Manual live integration on merged `main` passed: <https://github.com/tamtom/play-console-cli/actions/runs/32762203804>
+- Five release binaries and checksums were downloaded and verified.
+
+The release contains the policy-safe ASC parity work and official Google API coverage. Dependencies are `google.golang.org/api v0.293.0`, protobuf `v1.36.12`, and Go `1.25.13`. The embedded catalog covers 218 methods and 566 types across eight Play-specific APIs.
+
+## Policy boundary
+
+All implemented and live-tested Google integrations use official APIs. There are no private Play Console RPCs, cookie/session reuse, authenticated browser automation, or automated legal acceptance.
+
+Keep these manual unless Google publishes an official API:
+
+- initial public Play app creation
+- first upload/onboarding steps that the official API cannot perform
+- ordinary Play App Signing enrollment and legal agreements
+- experiment creation/lifecycle/results
+
+The live integration app is `com.itdeveapps.stepsshare`, authorized by the user as a test app. Never mutate a production track, issue real refunds, delete users/grants, accept agreements, or exercise third-party app-store/KMS features in live CI without dedicated disposable infrastructure.
+
+## Current live integration coverage and gaps
+
+`.github/workflows/integration.yml` runs official Android Publisher API tests weekly and manually. It currently covers edit create/delete, tracks list/get, listings list/get, reviews list, invalid identifiers, regional-price conversion, and creation/cleanup of a unique one-time product. It does not upload an AAB, publish a track, call unofficial APIs, or cover every CLI command.
+
+Known workflow gap: four auth integration tests check `GPLAY_SERVICE_ACCOUNT`, while the workflow supplies `GPLAY_SERVICE_ACCOUNT_JSON`, so those tests skip.
+
+Recommended next test work after `v0.9.1`:
+
+1. Invoke the built `gplay` binary black-box in live CI, not only Go clients.
+2. Fix the auth environment mismatch and isolate `HOME`.
+3. Add a command-coverage manifest: every command must be classified as live-tested, mocked-contract-tested, offline-tested, or manual/scope-gated.
+4. Add safe read-only CLI smoke coverage for apps, tracks, listings, reviews, reporting, and vitals where data exists.
+5. Exercise listing/image mutations inside a disposable edit and delete it without commit.
+6. With a dedicated fixture app and monotonically increasing AAB, upload and publish only to the internal track, then verify readback.
+7. Expand disposable monetization coverage where cleanup is safe.
+8. Add concurrency locking, unique run IDs, an exact package allowlist, resource ledger, and always-run cleanup/janitor.
+
+## Broader ASC parity follow-up
+
+The latest audited ASC CLI was `4.9.0` (2026-08-23). High-value, policy-safe follow-up work:
+
+- rooted and symlink-safe filesystem operations
+- richer offline metadata validation with stable check IDs and strict mode
+- deterministic structured metadata diffing
+- local command search
+- bounded workflow timeouts/retries with safe resume and ambiguity handling
+- exact-decimal subscription regional-price derivation
+- risk-focused CLI black-box coverage
+
+Explicitly exclude ASC web sessions, cookie authentication, private endpoints, browser-driven legal acceptance, and other unofficial surfaces.
+
+## Useful release identifiers
+
+- `v0.9.0` merge/tag commit: `0db97553b01c2e507ebd59e20809975c4e2372fc`
+- Main Branch run: `32762015271`
+- CodeQL run: `32762015184`
+- Live integration run: `32762203804`
+- Release run: `32762371025`
+- Homebrew tap run: `32762549088`

--- a/internal/apischema/schema-index.json
+++ b/internal/apischema/schema-index.json
@@ -4,7 +4,7 @@
       "base_url": "https://androiddeveloperidstatus.googleapis.com/",
       "discovery_url": "https://androiddeveloperidstatus.googleapis.com/$discovery/rest?version=v1",
       "name": "androiddeveloperidstatus",
-      "revision": "20260820",
+      "revision": "20260823",
       "service_path": "",
       "version": "v1"
     },

--- a/main.go
+++ b/main.go
@@ -5,16 +5,11 @@ import (
 	"os"
 
 	"github.com/tamtom/play-console-cli/cmd"
-)
-
-var (
-	version = "dev"
-	commit  = "unknown"
-	date    = "unknown"
+	buildversion "github.com/tamtom/play-console-cli/internal/version"
 )
 
 func versionInfo() string {
-	return fmt.Sprintf("%s (commit: %s, date: %s)", version, commit, date)
+	return fmt.Sprintf("%s (commit: %s, date: %s)", buildversion.Version, buildversion.Commit, buildversion.BuildDate)
 }
 
 func main() {

--- a/release_metadata_test.go
+++ b/release_metadata_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestReleaseBuildEmbedsVersionMetadata(t *testing.T) {
+	binary := filepath.Join(t.TempDir(), "gplay")
+	if runtime.GOOS == "windows" {
+		binary += ".exe"
+	}
+
+	const (
+		wantVersion = "v9.8.7"
+		wantCommit  = "abc123"
+		wantDate    = "2026-08-24T18:00:00Z"
+	)
+	ldflags := strings.Join([]string{
+		"-X github.com/tamtom/play-console-cli/internal/version.Version=" + wantVersion,
+		"-X github.com/tamtom/play-console-cli/internal/version.Commit=" + wantCommit,
+		"-X github.com/tamtom/play-console-cli/internal/version.BuildDate=" + wantDate,
+	}, " ")
+
+	build := exec.Command("go", "build", "-trimpath", "-ldflags", ldflags, "-o", binary, ".") // #nosec G204 -- fixed build arguments exercise the release boundary
+	if output, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("build release binary: %v\n%s", err, output)
+	}
+
+	output, err := exec.Command(binary, "--version").CombinedOutput() // #nosec G204 -- binary is built into t.TempDir
+	if err != nil {
+		t.Fatalf("run release binary: %v\n%s", err, output)
+	}
+	got := strings.TrimSpace(string(output))
+	want := wantVersion + " (commit: " + wantCommit + ", date: " + wantDate + ")"
+	if got != want {
+		t.Fatalf("release binary version = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

The v0.9.0 release binaries report `dev (commit: unknown, date: unknown)`. This PR makes the CLI print the real release metadata. It prepares the immutable hotfix release v0.9.1.

## Why

The release build injects `internal/version.Version`, `Commit`, and `BuildDate`. But `main.go` printed unrelated variables in package `main`. The released binary showed development metadata. This also made update and version comparisons unreliable.

## What Changed

- `main.go` now prints `internal/version.Version`, `Commit`, and `BuildDate`. The output format is unchanged.
- `release_metadata_test.go` builds the real CLI with linker metadata. It asserts the exact `--version` output. The test failed before the fix.
- `.github/workflows/release.yml` executes the Linux amd64 artifact before publication. The job fails on a version mismatch.
- `CHANGELOG.md` contains the 0.9.1 entry. It states that 0.9.1 supersedes 0.9.0.
- The Developer ID Status discovery revision moves from `20260820` to `20260823` in the manifest and the embedded schema index. The drift is revision-only. The API contract is identical. See `docs/research/developer-id-status-api-drift-2026-08-24.md`.

## Alternatives Considered

- Rewrite or move the `v0.9.0` tag: rejected. Tags stay immutable. `v0.9.1` supersedes `v0.9.0`.
- Point the linker flags at package `main`: rejected. `internal/version` is the canonical location, and the update code reads it.

## Implementation Checklist

- [x] No new command. No registration change.
- [x] Black-box regression test with linker metadata.
- [x] Release workflow gate for the built artifact.
- [x] Changelog entry for 0.9.1.

## Validation

- [x] `go test -race ./... -count=1` — pass
- [x] `go vet ./...` — pass
- [x] golangci-lint v2.13.1 — 0 issues
- [x] `make format-check` — pass
- [x] `make check-docs` — pass
- [x] `make check-api-drift` — pass
- [x] `make build-all VERSION=v0.9.1` — five platforms build
- [x] The native binary reports `v0.9.1 (commit: 0db9755, date: ...)`
- [x] `govulncheck` — 0 reachable vulnerabilities

## Notes

- The release-workflow gate covers only the Linux amd64 artifact. The other artifacts use the same build path.
- The handover document `docs/research/release-handover-2026-08-24.md` records the full release plan.