### PR TITLE
test: add hermetic sandbox for binary black-box tests

### DIFF
--- a/internal/cmdtest/sandbox_workflow_test.go
+++ b/internal/cmdtest/sandbox_workflow_test.go
@@ -1,0 +1,126 @@
+package cmdtest_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/cmdtest"
+	"github.com/tamtom/play-console-cli/internal/sandbox"
+	"github.com/tamtom/play-console-cli/internal/testutil"
+)
+
+// These tests run the compiled gplay binary against the in-memory sandbox
+// API server. They cover the full edit workflow — authentication, flags,
+// JSON output, readback, commit, and error behavior — with no credentials,
+// no network beyond localhost, and no quota.
+
+func startSandbox(t *testing.T) {
+	t.Helper()
+	srv, _, err := sandbox.Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Close)
+	t.Setenv("GPLAY_API_BASE_URL", srv.URL)
+	t.Setenv("GPLAY_SERVICE_ACCOUNT_JSON", testutil.SandboxServiceAccount(t, srv.URL+"/token"))
+}
+
+func sandboxJSON(t *testing.T, args ...string) map[string]any {
+	t.Helper()
+	r := cmdtest.Run(t, args...)
+	if r.ExitCode != 0 {
+		t.Fatalf("%v: exit %d\nstderr: %s", args, r.ExitCode, r.Stderr)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(r.Stdout), &parsed); err != nil {
+		t.Fatalf("%v: stdout is not JSON: %v\nstdout: %s", args, err, r.Stdout)
+	}
+	return parsed
+}
+
+func TestSandboxWorkflow_FullEditFlow(t *testing.T) {
+	cmdtest.Build(t)
+	startSandbox(t)
+	pkg := sandbox.Package
+
+	created := sandboxJSON(t, "edits", "create", "--package", pkg)
+	editID, _ := created["id"].(string)
+	if editID == "" {
+		t.Fatalf("edits create returned no id: %v", created)
+	}
+
+	tracks := sandboxJSON(t, "tracks", "list", "--package", pkg, "--edit", editID)
+	raw, _ := json.Marshal(tracks)
+	if !strings.Contains(string(raw), "internal") || !strings.Contains(string(raw), "production") {
+		t.Fatalf("tracks list must show the seeded tracks: %s", raw)
+	}
+
+	track := sandboxJSON(t, "tracks", "get", "--package", pkg, "--edit", editID, "--track", "internal")
+	if track["track"] != "internal" {
+		t.Fatalf("tracks get: %v", track)
+	}
+
+	updated := sandboxJSON(t, "listings", "update", "--package", pkg, "--edit", editID,
+		"--locale", "en-US", "--title", "Black-box Title")
+	if updated["title"] != "Black-box Title" {
+		t.Fatalf("listings update: %v", updated)
+	}
+
+	readback := sandboxJSON(t, "listings", "get", "--package", pkg, "--edit", editID, "--locale", "en-US")
+	if readback["title"] != "Black-box Title" {
+		t.Fatalf("readback title = %v, want the updated title", readback["title"])
+	}
+
+	sandboxJSON(t, "edits", "validate", "--package", pkg, "--edit", editID)
+	sandboxJSON(t, "edits", "commit", "--package", pkg, "--edit", editID)
+
+	// The committed edit is gone: a follow-up call must fail.
+	r := cmdtest.Run(t, "edits", "get", "--package", pkg, "--edit", editID)
+	if r.ExitCode == 0 {
+		t.Fatalf("edits get after commit must fail\nstdout: %s", r.Stdout)
+	}
+}
+
+func TestSandboxWorkflow_ReviewsList(t *testing.T) {
+	cmdtest.Build(t)
+	startSandbox(t)
+
+	reviews := sandboxJSON(t, "reviews", "list", "--package", sandbox.Package)
+	raw, _ := json.Marshal(reviews)
+	if !strings.Contains(string(raw), "sandbox-review-1") {
+		t.Fatalf("reviews list must show the seeded review: %s", raw)
+	}
+}
+
+func TestSandboxWorkflow_ErrorBehavior(t *testing.T) {
+	cmdtest.Build(t)
+	startSandbox(t)
+	pkg := sandbox.Package
+
+	t.Run("unknown package fails with 404 on stderr", func(t *testing.T) {
+		r := cmdtest.Run(t, "edits", "create", "--package", "com.other.app")
+		if r.ExitCode == 0 {
+			t.Fatalf("must fail\nstdout: %s", r.Stdout)
+		}
+		if !strings.Contains(r.Stderr, "404") && !strings.Contains(r.Stderr, "not found") && !strings.Contains(r.Stderr, "Package not found") {
+			t.Fatalf("stderr must carry the API error, got: %s", r.Stderr)
+		}
+	})
+
+	t.Run("invalid edit ID fails", func(t *testing.T) {
+		r := cmdtest.Run(t, "tracks", "list", "--package", pkg, "--edit", "bogus-edit")
+		if r.ExitCode == 0 {
+			t.Fatalf("must fail\nstdout: %s", r.Stdout)
+		}
+	})
+
+	t.Run("unknown track fails", func(t *testing.T) {
+		created := sandboxJSON(t, "edits", "create", "--package", pkg)
+		editID := created["id"].(string)
+		r := cmdtest.Run(t, "tracks", "get", "--package", pkg, "--edit", editID, "--track", "wildcard")
+		if r.ExitCode == 0 {
+			t.Fatalf("must fail\nstdout: %s", r.Stdout)
+		}
+	})
+}

--- a/internal/playclient/baseurl_test.go
+++ b/internal/playclient/baseurl_test.go
@@ -1,0 +1,59 @@
+package playclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/testutil"
+)
+
+// GPLAY_API_BASE_URL points the generated client at a local sandbox server.
+// The override exists for hermetic black-box tests only.
+
+func TestNewService_HonorsBaseURLOverride(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"sandbox","token_type":"Bearer","expires_in":3600}`))
+			return
+		}
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"androidpublisher#appsListResponse"}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("GPLAY_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("GPLAY_SERVICE_ACCOUNT_JSON", testutil.SandboxServiceAccount(t, srv.URL+"/token"))
+	t.Setenv("GPLAY_API_BASE_URL", srv.URL)
+
+	service, err := NewService(context.Background())
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	if _, err := service.API.Users.List("developers/1").Do(); err != nil {
+		t.Fatalf("call through override: %v", err)
+	}
+	if gotPath == "" {
+		t.Fatal("the request did not reach the sandbox server")
+	}
+}
+
+func TestNewService_NoOverrideKeepsGoogleBasePath(t *testing.T) {
+	t.Setenv("GPLAY_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+	t.Setenv("GPLAY_SERVICE_ACCOUNT_JSON", testutil.SandboxServiceAccount(t, "https://oauth2.googleapis.com/token"))
+	t.Setenv("GPLAY_API_BASE_URL", "")
+
+	service, err := NewService(context.Background())
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	if service.API.BasePath != "https://androidpublisher.googleapis.com/" {
+		t.Fatalf("BasePath = %q, want the Google default", service.API.BasePath)
+	}
+}

--- a/internal/playclient/service.go
+++ b/internal/playclient/service.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"strings"
 
 	"golang.org/x/oauth2"
 	"google.golang.org/api/androidpublisher/v3"
@@ -50,7 +51,24 @@ func NewService(ctx context.Context) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	if base := sandboxBaseURL(); base != "" {
+		api.BasePath = base
+	}
 	return &Service{API: api, Cfg: cfg}, nil
+}
+
+// sandboxBaseURL returns the GPLAY_API_BASE_URL override, normalized to end
+// with a slash. The override points the client at a local sandbox server for
+// hermetic black-box tests. It is not a supported production setting.
+func sandboxBaseURL() string {
+	base := strings.TrimSpace(os.Getenv("GPLAY_API_BASE_URL"))
+	if base == "" {
+		return ""
+	}
+	if !strings.HasSuffix(base, "/") {
+		base += "/"
+	}
+	return base
 }
 
 // NewAuthenticatedClient returns an HTTP client authenticated with the

--- a/internal/sandbox/handlers.go
+++ b/internal/sandbox/handlers.go
@@ -1,0 +1,307 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// endpointHandlers maps official discovery method IDs to sandbox behavior.
+// Add entries here as the black-box suite grows; an unknown ID fails loudly
+// with 501 instead of faking success.
+func endpointHandlers() map[string]func(s *Server, w http.ResponseWriter, r *http.Request, params map[string]string) {
+	return map[string]func(s *Server, w http.ResponseWriter, r *http.Request, params map[string]string){
+		"androidpublisher.edits.insert":          editsInsert,
+		"androidpublisher.edits.get":             editsGet,
+		"androidpublisher.edits.delete":          editsDelete,
+		"androidpublisher.edits.validate":        editsValidate,
+		"androidpublisher.edits.commit":          editsCommit,
+		"androidpublisher.edits.tracks.list":     tracksList,
+		"androidpublisher.edits.tracks.get":      tracksGet,
+		"androidpublisher.edits.tracks.update":   tracksUpdate,
+		"androidpublisher.edits.listings.list":   listingsList,
+		"androidpublisher.edits.listings.get":    listingsGet,
+		"androidpublisher.edits.listings.update": listingsUpdate,
+		"androidpublisher.edits.listings.delete": listingsDelete,
+		"androidpublisher.edits.bundles.list":    bundlesList,
+		"androidpublisher.edits.bundles.upload":  bundlesUpload,
+		"androidpublisher.reviews.list":          reviewsList,
+		"androidpublisher.inappproducts.list":    inappproductsList,
+	}
+}
+
+func requirePackage(w http.ResponseWriter, params map[string]string) bool {
+	if params["packageName"] != Package {
+		writeError(w, http.StatusNotFound, "NOT_FOUND",
+			fmt.Sprintf("Package not found: %s.", params["packageName"]))
+		return false
+	}
+	return true
+}
+
+func (s *Server) edit(w http.ResponseWriter, params map[string]string) (*editState, bool) {
+	e, ok := s.edits[params["editId"]]
+	if !ok || e.pkg != params["packageName"] {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT",
+			fmt.Sprintf("Invalid edit ID: %s.", params["editId"]))
+		return nil, false
+	}
+	return e, true
+}
+
+// newEditState seeds a fresh edit with the app baseline: two tracks with one
+// release each and one en-US listing.
+func newEditState() *editState {
+	return &editState{
+		pkg: Package,
+		tracks: map[string]map[string]any{
+			"internal": {
+				"track": "internal",
+				"releases": []any{map[string]any{
+					"name": "9 (1.9)", "status": "completed",
+					"versionCodes": []any{"9"},
+				}},
+			},
+			"production": {
+				"track": "production",
+				"releases": []any{map[string]any{
+					"name": "8 (1.8)", "status": "completed",
+					"versionCodes": []any{"8"},
+				}},
+			},
+		},
+		listings: map[string]map[string]any{
+			"en-US": {
+				"language":         "en-US",
+				"title":            "Sandbox App",
+				"shortDescription": "A seeded sandbox listing.",
+				"fullDescription":  "The sandbox server seeds this listing for tests.",
+			},
+		},
+	}
+}
+
+func editsInsert(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	s.nextEdit++
+	id := fmt.Sprintf("sandbox-edit-%d", s.nextEdit)
+	s.edits[id] = newEditState()
+	writeJSON(w, map[string]any{"id": id, "expiryTimeSeconds": "9999999999"})
+}
+
+func editsGet(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	if _, ok := s.edit(w, params); !ok {
+		return
+	}
+	writeJSON(w, map[string]any{"id": params["editId"], "expiryTimeSeconds": "9999999999"})
+}
+
+func editsDelete(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	if _, ok := s.edit(w, params); !ok {
+		return
+	}
+	delete(s.edits, params["editId"])
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func editsValidate(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	if _, ok := s.edit(w, params); !ok {
+		return
+	}
+	writeJSON(w, map[string]any{"id": params["editId"], "expiryTimeSeconds": "9999999999"})
+}
+
+func editsCommit(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	if _, ok := s.edit(w, params); !ok {
+		return
+	}
+	// A committed edit is gone: later calls on it must fail like the real API.
+	delete(s.edits, params["editId"])
+	writeJSON(w, map[string]any{"id": params["editId"], "expiryTimeSeconds": "9999999999"})
+}
+
+func tracksList(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	e, ok := s.edit(w, params)
+	if !ok {
+		return
+	}
+	tracks := []any{}
+	for _, tr := range e.tracks {
+		tracks = append(tracks, tr)
+	}
+	writeJSON(w, map[string]any{"kind": "androidpublisher#tracksListResponse", "tracks": tracks})
+}
+
+func tracksGet(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	e, ok := s.edit(w, params)
+	if !ok {
+		return
+	}
+	tr, ok := e.tracks[params["track"]]
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND",
+			fmt.Sprintf("Track not found: %s.", params["track"]))
+		return
+	}
+	writeJSON(w, tr)
+}
+
+func tracksUpdate(s *Server, w http.ResponseWriter, r *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	e, ok := s.edit(w, params)
+	if !ok {
+		return
+	}
+	if _, ok := e.tracks[params["track"]]; !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND",
+			fmt.Sprintf("Track not found: %s.", params["track"]))
+		return
+	}
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "Invalid track body.")
+		return
+	}
+	body["track"] = params["track"]
+	e.tracks[params["track"]] = body
+	writeJSON(w, body)
+}
+
+func listingsList(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	e, ok := s.edit(w, params)
+	if !ok {
+		return
+	}
+	listings := []any{}
+	for _, l := range e.listings {
+		listings = append(listings, l)
+	}
+	writeJSON(w, map[string]any{"kind": "androidpublisher#listingsListResponse", "listings": listings})
+}
+
+func listingsGet(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	e, ok := s.edit(w, params)
+	if !ok {
+		return
+	}
+	l, ok := e.listings[params["language"]]
+	if !ok {
+		writeError(w, http.StatusNotFound, "NOT_FOUND",
+			fmt.Sprintf("Listing not found: %s.", params["language"]))
+		return
+	}
+	writeJSON(w, l)
+}
+
+func listingsUpdate(s *Server, w http.ResponseWriter, r *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	e, ok := s.edit(w, params)
+	if !ok {
+		return
+	}
+	var body map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_ARGUMENT", "Invalid listing body.")
+		return
+	}
+	body["language"] = params["language"]
+	e.listings[params["language"]] = body
+	writeJSON(w, body)
+}
+
+func listingsDelete(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	e, ok := s.edit(w, params)
+	if !ok {
+		return
+	}
+	delete(e.listings, params["language"])
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func bundlesList(s *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	e, ok := s.edit(w, params)
+	if !ok {
+		return
+	}
+	writeJSON(w, map[string]any{"kind": "androidpublisher#bundlesListResponse", "bundles": e.bundles})
+}
+
+func bundlesUpload(s *Server, w http.ResponseWriter, r *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	e, ok := s.edit(w, params)
+	if !ok {
+		return
+	}
+	// Consume the upload body; content is not inspected. The version code
+	// grows monotonically from the seeded internal release.
+	_ = r.Body.Close()
+	bundle := map[string]any{
+		"versionCode": 10 + len(e.bundles),
+		"sha256":      fmt.Sprintf("sandbox-sha-%d", len(e.bundles)+1),
+	}
+	e.bundles = append(e.bundles, bundle)
+	writeJSON(w, bundle)
+}
+
+func reviewsList(_ *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	writeJSON(w, map[string]any{"reviews": []any{
+		map[string]any{
+			"reviewId":   "sandbox-review-1",
+			"authorName": "Sandbox Tester",
+			"comments": []any{map[string]any{
+				"userComment": map[string]any{"text": "Works great.", "starRating": 5},
+			}},
+		},
+	}})
+}
+
+func inappproductsList(_ *Server, w http.ResponseWriter, _ *http.Request, params map[string]string) {
+	if !requirePackage(w, params) {
+		return
+	}
+	writeJSON(w, map[string]any{
+		"kind":         "androidpublisher#inappproductsListResponse",
+		"inappproduct": []any{},
+	})
+}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -1,0 +1,158 @@
+// Package sandbox is a local, in-memory fake of the Google Play Android
+// Publisher API for hermetic black-box tests. Every incoming request is
+// matched against the embedded official discovery catalog: a request whose
+// method and path do not exist in the catalog fails with 404, and a known
+// method without a sandbox implementation fails with 501. This keeps the
+// fake honest — it can never accept a call the real API would reject as
+// nonexistent.
+//
+// Point the compiled CLI at a sandbox server with GPLAY_API_BASE_URL and a
+// service-account file whose token_uri targets the server's /token endpoint
+// (see testutil.SandboxServiceAccount).
+package sandbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"strings"
+	"sync"
+
+	"github.com/tamtom/play-console-cli/internal/apischema"
+)
+
+// Package is the seeded application every sandbox server knows about.
+const Package = "com.sandbox.app"
+
+type route struct {
+	id      string
+	method  string
+	pattern *regexp.Regexp
+	params  []string
+}
+
+// Server is one in-memory sandbox instance. Create it with New and serve it
+// with Start; state is per-instance, so parallel tests stay isolated.
+type Server struct {
+	mu       sync.Mutex
+	routes   []route
+	handlers map[string]func(s *Server, w http.ResponseWriter, r *http.Request, params map[string]string)
+	edits    map[string]*editState
+	nextEdit int
+}
+
+type editState struct {
+	pkg      string
+	tracks   map[string]map[string]any
+	listings map[string]map[string]any
+	bundles  []map[string]any
+}
+
+var paramPattern = regexp.MustCompile(`\{([a-zA-Z]+)\}`)
+
+// New builds a sandbox with routes compiled from the embedded catalog.
+func New() (*Server, error) {
+	index, err := apischema.Load()
+	if err != nil {
+		return nil, err
+	}
+	s := &Server{
+		edits:    map[string]*editState{},
+		handlers: endpointHandlers(),
+	}
+	for _, e := range index.Endpoints {
+		if e.API != "androidpublisher" {
+			continue
+		}
+		s.routes = append(s.routes, compileRoute(e.ID, e.HTTPMethod, "/"+e.Path))
+		if e.MediaUpload != nil && e.MediaUpload.SimplePath != "" {
+			s.routes = append(s.routes, compileRoute(e.ID, e.HTTPMethod, e.MediaUpload.SimplePath))
+		}
+	}
+	return s, nil
+}
+
+// Start returns a running test server. The caller owns Close; httptest
+// binds to 127.0.0.1 only.
+func Start() (*httptest.Server, *Server, error) {
+	s, err := New()
+	if err != nil {
+		return nil, nil, err
+	}
+	return httptest.NewServer(s), s, nil
+}
+
+func compileRoute(id, method, path string) route {
+	var params []string
+	escaped := regexp.QuoteMeta(path)
+	// QuoteMeta escapes { and } as \{ and \}.
+	rx := regexp.MustCompile(`\\\{([a-zA-Z]+)\\\}`).ReplaceAllStringFunc(escaped, func(m string) string {
+		params = append(params, paramPattern.FindStringSubmatch(strings.ReplaceAll(m, `\`, ""))[1])
+		return `([^/:]+)`
+	})
+	return route{
+		id:      id,
+		method:  method,
+		pattern: regexp.MustCompile("^" + rx + "$"),
+		params:  params,
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/token" {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"sandbox-token","token_type":"Bearer","expires_in":3600}`))
+		return
+	}
+
+	for _, rt := range s.routes {
+		if rt.method != r.Method {
+			continue
+		}
+		m := rt.pattern.FindStringSubmatch(r.URL.Path)
+		if m == nil {
+			continue
+		}
+		params := map[string]string{}
+		for i, name := range rt.params {
+			params[name] = m[i+1]
+		}
+		handler, ok := s.handlers[rt.id]
+		if !ok {
+			writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED",
+				fmt.Sprintf("sandbox: method %s is in the official catalog but has no sandbox implementation", rt.id))
+			return
+		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		handler(s, w, r, params)
+		return
+	}
+
+	writeError(w, http.StatusNotFound, "NOT_FOUND",
+		fmt.Sprintf("sandbox: no official androidpublisher method matches %s %s", r.Method, r.URL.Path))
+}
+
+// writeError emits the googleapi error JSON shape so the generated client
+// surfaces code and message exactly like the real API.
+func writeError(w http.ResponseWriter, code int, status, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+			"status":  status,
+			"errors": []map[string]any{
+				{"message": message, "reason": strings.ToLower(status)},
+			},
+		},
+	})
+}
+
+func writeJSON(w http.ResponseWriter, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -1,0 +1,126 @@
+package sandbox
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func startServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv, _, err := Start()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func do(t *testing.T, method, url string, body string) (int, map[string]any) {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+	parsed := map[string]any{}
+	_ = json.Unmarshal(raw, &parsed)
+	return resp.StatusCode, parsed
+}
+
+func TestSandbox_TokenEndpoint(t *testing.T) {
+	srv := startServer(t)
+	code, body := do(t, "POST", srv.URL+"/token", "grant_type=jwt")
+	if code != 200 || body["access_token"] != "sandbox-token" {
+		t.Fatalf("token endpoint: code=%d body=%v", code, body)
+	}
+}
+
+func TestSandbox_UnknownPathIs404(t *testing.T) {
+	srv := startServer(t)
+	code, body := do(t, "GET", srv.URL+"/androidpublisher/v3/applications/"+Package+"/nonexistent", "")
+	if code != 404 {
+		t.Fatalf("unknown path: code=%d body=%v", code, body)
+	}
+	errObj, _ := body["error"].(map[string]any)
+	msg, _ := errObj["message"].(string)
+	if !strings.Contains(msg, "no official androidpublisher method") {
+		t.Fatalf("unknown path must name the catalog check, got: %v", body)
+	}
+}
+
+func TestSandbox_KnownButUnimplementedIs501(t *testing.T) {
+	srv := startServer(t)
+	// dataSafety is in the catalog but has no sandbox handler.
+	code, body := do(t, "POST", srv.URL+"/androidpublisher/v3/applications/"+Package+"/dataSafety", "{}")
+	if code != 501 {
+		t.Fatalf("unimplemented method: code=%d body=%v", code, body)
+	}
+}
+
+func TestSandbox_UnknownPackageIs404(t *testing.T) {
+	srv := startServer(t)
+	code, _ := do(t, "POST", srv.URL+"/androidpublisher/v3/applications/com.other.app/edits", "")
+	if code != 404 {
+		t.Fatalf("foreign package must 404, got %d", code)
+	}
+}
+
+func TestSandbox_EditLifecycle(t *testing.T) {
+	srv := startServer(t)
+	base := srv.URL + "/androidpublisher/v3/applications/" + Package
+
+	code, created := do(t, "POST", base+"/edits", "")
+	if code != 200 || created["id"] == nil {
+		t.Fatalf("insert: code=%d body=%v", code, created)
+	}
+	editID := created["id"].(string)
+
+	code, tracks := do(t, "GET", base+"/edits/"+editID+"/tracks", "")
+	if code != 200 {
+		t.Fatalf("tracks list: code=%d body=%v", code, tracks)
+	}
+	if n := len(tracks["tracks"].([]any)); n != 2 {
+		t.Fatalf("want 2 seeded tracks, got %d", n)
+	}
+
+	code, _ = do(t, "PUT", base+"/edits/"+editID+"/listings/en-US", `{"title":"New Title","language":"en-US"}`)
+	if code != 200 {
+		t.Fatalf("listing update: code=%d", code)
+	}
+	code, listing := do(t, "GET", base+"/edits/"+editID+"/listings/en-US", "")
+	if code != 200 || listing["title"] != "New Title" {
+		t.Fatalf("listing readback: code=%d body=%v", code, listing)
+	}
+
+	code, _ = do(t, "POST", base+"/edits/"+editID+":commit", "")
+	if code != 200 {
+		t.Fatalf("commit: code=%d", code)
+	}
+
+	// A committed edit is gone.
+	code, _ = do(t, "GET", base+"/edits/"+editID, "")
+	if code != 400 {
+		t.Fatalf("get after commit must fail with 400, got %d", code)
+	}
+}
+
+func TestSandbox_InvalidEditIs400(t *testing.T) {
+	srv := startServer(t)
+	code, _ := do(t, "GET", srv.URL+"/androidpublisher/v3/applications/"+Package+"/edits/bogus/tracks", "")
+	if code != 400 {
+		t.Fatalf("invalid edit must 400, got %d", code)
+	}
+}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -1,7 +1,11 @@
 package testutil
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,6 +55,39 @@ func MockServiceAccount(t *testing.T) string {
 	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "service-account.json")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// SandboxServiceAccount writes a service-account JSON file whose private key
+// is a freshly generated, valid RSA key and whose token_uri points at the
+// given URL. The OAuth JWT flow then signs locally and fetches its token from
+// a local sandbox server, so authentication works fully offline.
+func SandboxServiceAccount(t *testing.T, tokenURL string) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+	sa := map[string]string{
+		"type":         "service_account",
+		"project_id":   "sandbox-project",
+		"private_key":  string(keyPEM),
+		"client_email": "sandbox@sandbox-project.iam.gserviceaccount.com",
+		"client_id":    "0",
+		"token_uri":    tokenURL,
+	}
+	data, err := json.MarshalIndent(sa, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "sandbox-service-account.json")
 	if err := os.WriteFile(path, data, 0o600); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

This is Layer 1 of the test strategy. The compiled `gplay` binary now runs full workflows against a local fake Play API server on every PR. No credentials, no external network, no quota.

## Why

The live smoke suite (PR #264) runs weekly and burns quota. PRs need the same black-box confidence at zero cost. Google offers no sandbox environment, so we host our own fake.

## What Changed

- **`internal/sandbox`**: an in-memory Android Publisher fake. Every request is matched against the embedded official discovery catalog (218 methods). A path outside the catalog returns 404. A catalog method without a sandbox handler returns 501. The fake can never invent success for a call the real API does not have.
- **Offline auth**: the sandbox serves `/token`. `testutil.SandboxServiceAccount` generates a real RSA key whose `token_uri` points at the sandbox, so the standard JWT flow signs and exchanges locally.
- **`GPLAY_API_BASE_URL`**: `playclient.NewService` honors this override and normalizes the trailing slash. Without it, the Google base path stays. Two unit tests pin both behaviors.
- **Black-box workflow suite** in `internal/cmdtest`: the compiled binary runs `edits create` → `tracks list/get` → `listings update` → readback → `edits validate` → `edits commit`, and the committed edit then correctly rejects further calls. Error paths cover unknown package, invalid edit, and unknown track. The suite runs in normal CI on every PR.

## Validation

- [x] `go test -race ./... -count=1` — pass
- [x] `go vet`, golangci-lint v2.13.1 — 0 issues
- [x] `make format-check`, `make check-docs` — pass
- [x] TDD: the override test failed with "Invalid Credentials" against real Google before the override existed, then passed

## Notes

- The sandbox seeds one package, `com.sandbox.app`, with internal/production tracks and an en-US listing. Handlers exist for edits, tracks, listings, bundles, reviews, and IAP list; more endpoints get handlers as the suite grows.
- Bundle upload black-box coverage (resumable protocol) and the Layer 3 command-coverage manifest are follow-ups.