### PR TITLE
test: add command-coverage manifest with CI gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ vendor/
 !internal/apischema/schema-index.json
 !docs/api/google-play-api-manifest.json
 !docs/api/discovery.json
+!docs/testing/command-coverage.json
 !go.mod
 !go.sum
 service-account*.json

--- a/Agents.md
+++ b/Agents.md
@@ -77,6 +77,14 @@ make dev        # format + lint + test + build
 - For new features, begin with CLI-level tests (flags, output, errors) and add unit tests for core logic.
 - Verify the test fails for the right reason before implementing; keep tests green incrementally.
 
+### Command coverage manifest
+
+Every command carries a test-coverage class in `docs/testing/command-coverage.json`:
+`sandbox` (hermetic fake-API black-box), `live` (weekly live smoke), `offline`
+(cmdtest/unit only), or `manual`. The CI gate `internal/covgate` fails when a
+command has no class. After you add or remove a command, run
+`go run ./tools/covmanifest` to refresh the manifest.
+
 ## CLI Implementation Checklist
 
 - Register new commands in `internal/cli/registry/registry.go`.

--- a/docs/testing/command-coverage.json
+++ b/docs/testing/command-coverage.json
@@ -1,0 +1,896 @@
+{
+  "android build": {
+    "class": "offline"
+  },
+  "android screenshots capture": {
+    "class": "offline"
+  },
+  "android signing inspect": {
+    "class": "offline"
+  },
+  "android signing verify": {
+    "class": "offline"
+  },
+  "apks addexternallyhosted": {
+    "class": "offline"
+  },
+  "apks list": {
+    "class": "offline"
+  },
+  "apks upload": {
+    "class": "offline"
+  },
+  "app-signing apply": {
+    "class": "offline"
+  },
+  "app-signing plan-enroll": {
+    "class": "offline"
+  },
+  "app-signing plan-rotation": {
+    "class": "offline"
+  },
+  "app-stores create-app": {
+    "class": "offline"
+  },
+  "app-stores publish-status": {
+    "class": "offline"
+  },
+  "app-stores recent-app-view": {
+    "class": "offline"
+  },
+  "app-stores recent-update-events": {
+    "class": "offline"
+  },
+  "app-stores update-app": {
+    "class": "offline"
+  },
+  "app-stores upload-apk": {
+    "class": "offline"
+  },
+  "app-stores upload-image": {
+    "class": "offline"
+  },
+  "app-stores upload-policy-file": {
+    "class": "offline"
+  },
+  "apps list": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "audit clear": {
+    "class": "offline"
+  },
+  "audit list": {
+    "class": "offline"
+  },
+  "audit path": {
+    "class": "offline"
+  },
+  "audit search": {
+    "class": "offline"
+  },
+  "auth doctor": {
+    "class": "offline"
+  },
+  "auth init": {
+    "class": "offline"
+  },
+  "auth login": {
+    "class": "offline"
+  },
+  "auth logout": {
+    "class": "offline"
+  },
+  "auth setup": {
+    "class": "offline"
+  },
+  "auth status": {
+    "class": "offline"
+  },
+  "auth switch": {
+    "class": "offline"
+  },
+  "availability get": {
+    "class": "offline"
+  },
+  "baseplans activate": {
+    "class": "offline"
+  },
+  "baseplans batch-migrate-prices": {
+    "class": "offline"
+  },
+  "baseplans batch-update-states": {
+    "class": "offline"
+  },
+  "baseplans deactivate": {
+    "class": "offline"
+  },
+  "baseplans delete": {
+    "class": "offline"
+  },
+  "baseplans migrate-prices": {
+    "class": "offline"
+  },
+  "bootstrap plan": {
+    "class": "offline"
+  },
+  "bundles analyze": {
+    "class": "offline"
+  },
+  "bundles compare": {
+    "class": "offline"
+  },
+  "bundles list": {
+    "class": "offline"
+  },
+  "bundles upload": {
+    "class": "offline"
+  },
+  "capabilities": {
+    "class": "offline"
+  },
+  "checks analyze": {
+    "class": "offline"
+  },
+  "checks apps get": {
+    "class": "offline"
+  },
+  "checks apps list": {
+    "class": "offline"
+  },
+  "checks classify": {
+    "class": "offline"
+  },
+  "checks content classify": {
+    "class": "offline"
+  },
+  "checks operations cancel": {
+    "class": "offline"
+  },
+  "checks operations delete": {
+    "class": "offline"
+  },
+  "checks operations get": {
+    "class": "offline"
+  },
+  "checks operations list": {
+    "class": "offline"
+  },
+  "checks operations wait": {
+    "class": "offline"
+  },
+  "checks repo-scans generate": {
+    "class": "offline"
+  },
+  "checks repo-scans get": {
+    "class": "offline"
+  },
+  "checks repo-scans list": {
+    "class": "offline"
+  },
+  "checks repo-scans operation": {
+    "class": "offline"
+  },
+  "checks reports get": {
+    "class": "offline"
+  },
+  "checks reports list": {
+    "class": "offline"
+  },
+  "checks upload": {
+    "class": "offline"
+  },
+  "completion bash": {
+    "class": "offline"
+  },
+  "completion fish": {
+    "class": "offline"
+  },
+  "completion powershell": {
+    "class": "offline"
+  },
+  "completion zsh": {
+    "class": "offline"
+  },
+  "custom-apps create": {
+    "class": "offline"
+  },
+  "data-safety update": {
+    "class": "offline"
+  },
+  "deobfuscation upload": {
+    "class": "offline"
+  },
+  "details get": {
+    "class": "offline"
+  },
+  "details patch": {
+    "class": "offline"
+  },
+  "details update": {
+    "class": "offline"
+  },
+  "device-tiers create": {
+    "class": "offline"
+  },
+  "device-tiers get": {
+    "class": "offline"
+  },
+  "device-tiers list": {
+    "class": "offline"
+  },
+  "docs generate": {
+    "class": "offline"
+  },
+  "docs list": {
+    "class": "offline"
+  },
+  "docs show": {
+    "class": "offline"
+  },
+  "doctor": {
+    "class": "offline"
+  },
+  "edits commit": {
+    "class": "sandbox",
+    "note": "hermetic sandbox black-box"
+  },
+  "edits create": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "edits delete": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "edits get": {
+    "class": "sandbox",
+    "note": "hermetic sandbox black-box"
+  },
+  "edits validate": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "expansion get": {
+    "class": "offline"
+  },
+  "expansion patch": {
+    "class": "offline"
+  },
+  "expansion update": {
+    "class": "offline"
+  },
+  "expansion upload": {
+    "class": "offline"
+  },
+  "experiments apply-winner": {
+    "class": "offline"
+  },
+  "experiments support": {
+    "class": "offline"
+  },
+  "external-transactions create": {
+    "class": "offline"
+  },
+  "external-transactions get": {
+    "class": "offline"
+  },
+  "external-transactions refund": {
+    "class": "offline"
+  },
+  "games achievements create": {
+    "class": "offline"
+  },
+  "games achievements delete": {
+    "class": "offline"
+  },
+  "games achievements get": {
+    "class": "offline"
+  },
+  "games achievements list": {
+    "class": "offline"
+  },
+  "games achievements reset": {
+    "class": "offline"
+  },
+  "games achievements reset-all": {
+    "class": "offline"
+  },
+  "games achievements reset-all-for-all-players": {
+    "class": "offline"
+  },
+  "games achievements reset-for-all-players": {
+    "class": "offline"
+  },
+  "games achievements reset-multiple-for-all-players": {
+    "class": "offline"
+  },
+  "games achievements update": {
+    "class": "offline"
+  },
+  "games events reset": {
+    "class": "offline"
+  },
+  "games events reset-all": {
+    "class": "offline"
+  },
+  "games events reset-all-for-all-players": {
+    "class": "offline"
+  },
+  "games events reset-for-all-players": {
+    "class": "offline"
+  },
+  "games events reset-multiple-for-all-players": {
+    "class": "offline"
+  },
+  "games leaderboards create": {
+    "class": "offline"
+  },
+  "games leaderboards delete": {
+    "class": "offline"
+  },
+  "games leaderboards get": {
+    "class": "offline"
+  },
+  "games leaderboards list": {
+    "class": "offline"
+  },
+  "games leaderboards update": {
+    "class": "offline"
+  },
+  "games players hide": {
+    "class": "offline"
+  },
+  "games players list-hidden": {
+    "class": "offline"
+  },
+  "games players unhide": {
+    "class": "offline"
+  },
+  "games scores reset": {
+    "class": "offline"
+  },
+  "games scores reset-all": {
+    "class": "offline"
+  },
+  "games scores reset-all-for-all-players": {
+    "class": "offline"
+  },
+  "games scores reset-for-all-players": {
+    "class": "offline"
+  },
+  "games scores reset-multiple-for-all-players": {
+    "class": "offline"
+  },
+  "generated-apks download": {
+    "class": "offline"
+  },
+  "generated-apks list": {
+    "class": "offline"
+  },
+  "grants create": {
+    "class": "offline"
+  },
+  "grants delete": {
+    "class": "offline"
+  },
+  "grants update": {
+    "class": "offline"
+  },
+  "iap batch-delete": {
+    "class": "offline"
+  },
+  "iap batch-get": {
+    "class": "offline"
+  },
+  "iap batch-update": {
+    "class": "offline"
+  },
+  "iap create": {
+    "class": "offline"
+  },
+  "iap delete": {
+    "class": "offline"
+  },
+  "iap get": {
+    "class": "offline"
+  },
+  "iap list": {
+    "class": "offline"
+  },
+  "iap patch": {
+    "class": "offline"
+  },
+  "iap update": {
+    "class": "offline"
+  },
+  "images delete": {
+    "class": "offline"
+  },
+  "images delete-all": {
+    "class": "offline"
+  },
+  "images list": {
+    "class": "offline"
+  },
+  "images plan": {
+    "class": "offline"
+  },
+  "images pull": {
+    "class": "offline"
+  },
+  "images sync": {
+    "class": "offline"
+  },
+  "images upload": {
+    "class": "offline"
+  },
+  "init": {
+    "class": "offline"
+  },
+  "insights daily": {
+    "class": "offline"
+  },
+  "insights weekly": {
+    "class": "offline"
+  },
+  "install-skills": {
+    "class": "offline"
+  },
+  "integrity decode": {
+    "class": "offline"
+  },
+  "integrity decode-pc": {
+    "class": "offline"
+  },
+  "integrity device-recall-write": {
+    "class": "offline"
+  },
+  "internal-sharing upload-apk": {
+    "class": "offline"
+  },
+  "internal-sharing upload-bundle": {
+    "class": "offline"
+  },
+  "listings delete": {
+    "class": "offline"
+  },
+  "listings delete-all": {
+    "class": "offline"
+  },
+  "listings get": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "listings list": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "listings locales": {
+    "class": "offline"
+  },
+  "listings patch": {
+    "class": "offline"
+  },
+  "listings update": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "metadata pull": {
+    "class": "offline"
+  },
+  "metadata push": {
+    "class": "offline"
+  },
+  "metadata validate": {
+    "class": "offline"
+  },
+  "migrate fastlane": {
+    "class": "offline"
+  },
+  "notify send": {
+    "class": "offline"
+  },
+  "offers activate": {
+    "class": "offline"
+  },
+  "offers batch-get": {
+    "class": "offline"
+  },
+  "offers batch-update": {
+    "class": "offline"
+  },
+  "offers batch-update-states": {
+    "class": "offline"
+  },
+  "offers create": {
+    "class": "offline"
+  },
+  "offers deactivate": {
+    "class": "offline"
+  },
+  "offers delete": {
+    "class": "offline"
+  },
+  "offers get": {
+    "class": "offline"
+  },
+  "offers list": {
+    "class": "offline"
+  },
+  "offers update": {
+    "class": "offline"
+  },
+  "onetimeproducts batch-delete": {
+    "class": "offline"
+  },
+  "onetimeproducts batch-get": {
+    "class": "offline"
+  },
+  "onetimeproducts batch-update": {
+    "class": "offline"
+  },
+  "onetimeproducts create": {
+    "class": "offline"
+  },
+  "onetimeproducts delete": {
+    "class": "offline"
+  },
+  "onetimeproducts get": {
+    "class": "offline"
+  },
+  "onetimeproducts list": {
+    "class": "offline"
+  },
+  "onetimeproducts patch": {
+    "class": "offline"
+  },
+  "orders batch-get": {
+    "class": "offline"
+  },
+  "orders get": {
+    "class": "offline"
+  },
+  "orders refund": {
+    "class": "offline"
+  },
+  "orders review-refund": {
+    "class": "offline"
+  },
+  "otp-offers activate": {
+    "class": "offline"
+  },
+  "otp-offers batch-delete": {
+    "class": "offline"
+  },
+  "otp-offers batch-get": {
+    "class": "offline"
+  },
+  "otp-offers batch-update": {
+    "class": "offline"
+  },
+  "otp-offers batch-update-states": {
+    "class": "offline"
+  },
+  "otp-offers cancel": {
+    "class": "offline"
+  },
+  "otp-offers deactivate": {
+    "class": "offline"
+  },
+  "otp-offers list": {
+    "class": "offline"
+  },
+  "preflight": {
+    "class": "offline"
+  },
+  "pricing convert": {
+    "class": "offline"
+  },
+  "pricing regions-version": {
+    "class": "offline"
+  },
+  "promote": {
+    "class": "offline"
+  },
+  "publish track": {
+    "class": "offline"
+  },
+  "purchase-options batch-delete": {
+    "class": "offline"
+  },
+  "purchase-options batch-update-states": {
+    "class": "offline"
+  },
+  "purchases products acknowledge": {
+    "class": "offline"
+  },
+  "purchases products consume": {
+    "class": "offline"
+  },
+  "purchases products get": {
+    "class": "offline"
+  },
+  "purchases productsv2 get": {
+    "class": "offline"
+  },
+  "purchases subscriptions acknowledge": {
+    "class": "offline"
+  },
+  "purchases subscriptions cancel": {
+    "class": "offline"
+  },
+  "purchases subscriptions defer": {
+    "class": "offline"
+  },
+  "purchases subscriptions get": {
+    "class": "offline"
+  },
+  "purchases subscriptions revoke": {
+    "class": "offline"
+  },
+  "purchases subscriptionsv2 cancel": {
+    "class": "offline"
+  },
+  "purchases subscriptionsv2 defer": {
+    "class": "offline"
+  },
+  "purchases subscriptionsv2 get": {
+    "class": "offline"
+  },
+  "purchases subscriptionsv2 revoke": {
+    "class": "offline"
+  },
+  "purchases voided list": {
+    "class": "offline"
+  },
+  "quota status": {
+    "class": "offline"
+  },
+  "recovery add-targeting": {
+    "class": "offline"
+  },
+  "recovery cancel": {
+    "class": "offline"
+  },
+  "recovery create": {
+    "class": "offline"
+  },
+  "recovery deploy": {
+    "class": "offline"
+  },
+  "recovery list": {
+    "class": "offline"
+  },
+  "release": {
+    "class": "offline"
+  },
+  "release-notes generate": {
+    "class": "offline"
+  },
+  "reports financial download": {
+    "class": "offline"
+  },
+  "reports financial list": {
+    "class": "offline"
+  },
+  "reports stats download": {
+    "class": "offline"
+  },
+  "reports stats list": {
+    "class": "offline"
+  },
+  "reviews get": {
+    "class": "offline"
+  },
+  "reviews list": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "reviews reply": {
+    "class": "offline"
+  },
+  "rollout complete": {
+    "class": "offline"
+  },
+  "rollout halt": {
+    "class": "offline"
+  },
+  "rollout resume": {
+    "class": "offline"
+  },
+  "rollout update": {
+    "class": "offline"
+  },
+  "rtdn decode": {
+    "class": "offline"
+  },
+  "rtdn setup": {
+    "class": "offline"
+  },
+  "rtdn status": {
+    "class": "offline"
+  },
+  "schema": {
+    "class": "offline"
+  },
+  "search": {
+    "class": "offline"
+  },
+  "setup": {
+    "class": "offline"
+  },
+  "snitch flush": {
+    "class": "offline"
+  },
+  "status": {
+    "class": "offline"
+  },
+  "subscriptions archive": {
+    "class": "offline"
+  },
+  "subscriptions batch-get": {
+    "class": "offline"
+  },
+  "subscriptions batch-update": {
+    "class": "offline"
+  },
+  "subscriptions create": {
+    "class": "offline"
+  },
+  "subscriptions delete": {
+    "class": "offline"
+  },
+  "subscriptions get": {
+    "class": "offline"
+  },
+  "subscriptions list": {
+    "class": "offline"
+  },
+  "subscriptions update": {
+    "class": "offline"
+  },
+  "sync apply": {
+    "class": "offline"
+  },
+  "sync diff-listings": {
+    "class": "offline"
+  },
+  "sync export-images": {
+    "class": "offline"
+  },
+  "sync export-listings": {
+    "class": "offline"
+  },
+  "sync import-images": {
+    "class": "offline"
+  },
+  "sync import-listings": {
+    "class": "offline"
+  },
+  "sync plan": {
+    "class": "offline"
+  },
+  "sync run": {
+    "class": "offline"
+  },
+  "system-apks create": {
+    "class": "offline"
+  },
+  "system-apks download": {
+    "class": "offline"
+  },
+  "system-apks get": {
+    "class": "offline"
+  },
+  "system-apks list": {
+    "class": "offline"
+  },
+  "testers get": {
+    "class": "offline"
+  },
+  "testers patch": {
+    "class": "offline"
+  },
+  "testers update": {
+    "class": "offline"
+  },
+  "tracks create": {
+    "class": "offline"
+  },
+  "tracks get": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "tracks list": {
+    "class": "live",
+    "note": "weekly live smoke, compiled binary"
+  },
+  "tracks patch": {
+    "class": "offline"
+  },
+  "tracks releases list": {
+    "class": "offline"
+  },
+  "tracks update": {
+    "class": "offline"
+  },
+  "update": {
+    "class": "offline"
+  },
+  "users create": {
+    "class": "offline"
+  },
+  "users delete": {
+    "class": "offline"
+  },
+  "users list": {
+    "class": "offline"
+  },
+  "users update": {
+    "class": "offline"
+  },
+  "validate app-content": {
+    "class": "offline"
+  },
+  "validate bundle": {
+    "class": "offline"
+  },
+  "validate listing": {
+    "class": "offline"
+  },
+  "validate screenshots": {
+    "class": "offline"
+  },
+  "validate submission": {
+    "class": "offline"
+  },
+  "verification status": {
+    "class": "offline"
+  },
+  "version": {
+    "class": "offline"
+  },
+  "vitals crashes anomalies": {
+    "class": "offline"
+  },
+  "vitals crashes query": {
+    "class": "offline"
+  },
+  "vitals errors issues": {
+    "class": "offline"
+  },
+  "vitals errors reports": {
+    "class": "offline"
+  },
+  "vitals metric-sets get": {
+    "class": "offline"
+  },
+  "vitals metric-sets query": {
+    "class": "offline"
+  },
+  "vitals performance battery": {
+    "class": "offline"
+  },
+  "vitals performance rendering": {
+    "class": "offline"
+  },
+  "vitals performance startup": {
+    "class": "offline"
+  },
+  "vitals release-filters": {
+    "class": "offline"
+  },
+  "web open": {
+    "class": "offline"
+  },
+  "workflow list": {
+    "class": "offline"
+  },
+  "workflow run": {
+    "class": "offline"
+  },
+  "workflow validate": {
+    "class": "offline"
+  }
+}

--- a/internal/covgate/covgate.go
+++ b/internal/covgate/covgate.go
@@ -1,0 +1,100 @@
+// Package covgate enforces the command-coverage manifest: every CLI command
+// must carry an explicit test-coverage class. CI fails when a command is
+// added without classifying how it is tested.
+package covgate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/peterbourgon/ff/v3/ffcli"
+
+	"github.com/tamtom/play-console-cli/internal/cli/registry"
+)
+
+// Classes a command can declare. "sandbox" and "live" both imply the command
+// also has offline coverage.
+const (
+	ClassSandbox = "sandbox" // black-box against the hermetic sandbox API
+	ClassLive    = "live"    // exercised by the weekly live smoke suite
+	ClassOffline = "offline" // offline cmdtest/unit coverage only
+	ClassManual  = "manual"  // no automation possible or allowed; tested by hand
+)
+
+// Entry is one command's declared coverage.
+type Entry struct {
+	Class string `json:"class"`
+	Note  string `json:"note,omitempty"`
+}
+
+// Manifest maps a full command path ("tracks list") to its coverage entry.
+type Manifest map[string]Entry
+
+// LoadManifest reads and validates the manifest file.
+func LoadManifest(path string) (Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	for cmd, e := range m {
+		switch e.Class {
+		case ClassSandbox, ClassLive, ClassOffline, ClassManual:
+		default:
+			return nil, fmt.Errorf("command %q has unknown class %q", cmd, e.Class)
+		}
+	}
+	return m, nil
+}
+
+// LeafCommands returns the sorted full paths of every runnable leaf command
+// in the registry.
+func LeafCommands() []string {
+	var leaves []string
+	for _, cmd := range registry.Subcommands("dev") {
+		walk("", cmd, &leaves)
+	}
+	sort.Strings(leaves)
+	return leaves
+}
+
+func walk(prefix string, cmd *ffcli.Command, out *[]string) {
+	path := cmd.Name
+	if prefix != "" {
+		path = prefix + " " + cmd.Name
+	}
+	if len(cmd.Subcommands) == 0 {
+		*out = append(*out, path)
+		return
+	}
+	for _, sub := range cmd.Subcommands {
+		walk(path, sub, out)
+	}
+}
+
+// Diff compares the registry against the manifest. Missing holds commands
+// without a manifest entry; stale holds manifest entries whose command no
+// longer exists.
+func Diff(m Manifest) (missing, stale []string) {
+	leaves := LeafCommands()
+	seen := map[string]bool{}
+	for _, leaf := range leaves {
+		seen[leaf] = true
+		if _, ok := m[leaf]; !ok {
+			missing = append(missing, leaf)
+		}
+	}
+	for cmd := range m {
+		if !seen[cmd] {
+			stale = append(stale, cmd)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(stale)
+	return missing, stale
+}

--- a/internal/covgate/covgate_test.go
+++ b/internal/covgate/covgate_test.go
@@ -1,0 +1,56 @@
+package covgate
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const manifestPath = "../../docs/testing/command-coverage.json"
+
+// TestCommandCoverageManifest is the CI gate: every command must carry a
+// coverage class, and the manifest must not list removed commands.
+func TestCommandCoverageManifest(t *testing.T) {
+	m, err := LoadManifest(manifestPath)
+	if err != nil {
+		t.Fatalf("loading manifest: %v\nRegenerate with: go run ./tools/covmanifest", err)
+	}
+
+	missing, stale := Diff(m)
+	if len(missing) > 0 {
+		t.Errorf("commands without a coverage class (add them to %s):\n  %s",
+			manifestPath, strings.Join(missing, "\n  "))
+	}
+	if len(stale) > 0 {
+		t.Errorf("manifest entries for removed commands (delete them from %s):\n  %s",
+			manifestPath, strings.Join(stale, "\n  "))
+	}
+	if t.Failed() {
+		t.Log("Regenerate with: go run ./tools/covmanifest")
+	}
+}
+
+func TestLeafCommands_NotEmptyAndSorted(t *testing.T) {
+	leaves := LeafCommands()
+	if len(leaves) < 50 {
+		t.Fatalf("expected a substantial command tree, got %d leaves", len(leaves))
+	}
+	for i := 1; i < len(leaves); i++ {
+		if leaves[i-1] >= leaves[i] {
+			t.Fatalf("leaves must be sorted and unique: %q >= %q", leaves[i-1], leaves[i])
+		}
+	}
+}
+
+func TestLoadManifest_RejectsUnknownClass(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "m.json")
+	bad, _ := json.Marshal(Manifest{"tracks list": {Class: "vibes"}})
+	if err := os.WriteFile(path, bad, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadManifest(path); err == nil {
+		t.Fatal("unknown class must be rejected")
+	}
+}

--- a/tools/covmanifest/main.go
+++ b/tools/covmanifest/main.go
@@ -1,0 +1,49 @@
+// Command covmanifest refreshes docs/testing/command-coverage.json.
+// Existing classifications are kept. New commands get the class "offline",
+// because every command has at least offline cmdtest coverage. Entries for
+// removed commands are dropped.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/tamtom/play-console-cli/internal/covgate"
+)
+
+const manifestPath = "docs/testing/command-coverage.json"
+
+func main() {
+	existing, err := covgate.LoadManifest(manifestPath)
+	if errors.Is(err, os.ErrNotExist) {
+		existing = covgate.Manifest{}
+	} else if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	fresh := covgate.Manifest{}
+	added := 0
+	for _, cmd := range covgate.LeafCommands() {
+		if entry, ok := existing[cmd]; ok {
+			fresh[cmd] = entry
+			continue
+		}
+		fresh[cmd] = covgate.Entry{Class: covgate.ClassOffline}
+		added++
+	}
+
+	data, err := json.MarshalIndent(fresh, "", "  ")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(manifestPath, append(data, '\n'), 0o644); err != nil { // #nosec G306 -- checked-in docs file
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	fmt.Printf("wrote %s: %d commands (%d new, %d removed)\n",
+		manifestPath, len(fresh), added, len(existing)-(len(fresh)-added))
+}


### PR DESCRIPTION
## Summary

This is Layer 3 of the test strategy. Every CLI command now declares its test-coverage class, and CI fails when a new command ships without one.

## Why

The strategy needs an inventory: which commands the sandbox covers, which the live smoke covers, and which have only offline coverage. Without a gate, new commands ship unclassified and the inventory rots.

## What Changed

- `docs/testing/command-coverage.json`: all 294 leaf commands mapped to `sandbox`, `live`, `offline`, or `manual`.
- `internal/covgate`: walks the command registry and diffs it against the manifest. Missing or stale entries fail `go test ./...`, so the gate runs on every PR with no CI change.
- `tools/covmanifest`: regenerates the manifest after command changes. It keeps existing classes and defaults new commands to `offline`.
- `.gitignore`: an exception for the manifest under the credential `*.json` rule.
- `Agents.md`: documents the workflow for future command authors.

Starting classes: 10 commands `live` (weekly smoke, compiled binary), 2 `sandbox` (hermetic black-box), 282 `offline`. The numbers improve as the sandbox suite grows.

## Validation

- [x] Gate test written first; it failed without the manifest, then passed.
- [x] Generator is idempotent: a second run reports 0 new, 0 removed and keeps upgrades.
- [x] `go test -race`, vet, golangci-lint, `make format-check`, `make check-docs` — all pass.

## Notes

- `manual` is reserved for commands that cannot or must not be automated (policy-gated flows). Nothing uses it yet.