### PR TITLE
fix: use listings patch in the live smoke mutation test

### DIFF
--- a/internal/livesmoke/live_test.go
+++ b/internal/livesmoke/live_test.go
@@ -222,15 +222,18 @@ func TestLive_DisposableEditWorkflow(t *testing.T) {
 		mustJSON(t, runCLI(t, "listings", "list", "--package", pkg, "--edit", editID, "--output", "json"), "listings list")
 	})
 
-	t.Run("listing update and readback inside edit", func(t *testing.T) {
+	t.Run("listing patch and readback inside edit", func(t *testing.T) {
 		marker := ResourceName(runID, "t")
 		if len(marker) > 30 {
 			marker = marker[:30] // Play listing titles are capped at 30 chars
 		}
-		update := runCLI(t, "listings", "update", "--package", pkg, "--edit", editID,
+		// listings update is a full PUT and would wipe the descriptions
+		// inside the edit, which then fails edits validate. Patch changes
+		// only the title.
+		update := runCLI(t, "listings", "patch", "--package", pkg, "--edit", editID,
 			"--locale", "en-US", "--title", marker)
 		if update.ExitCode != 0 {
-			t.Fatalf("listings update: %s", update.Stderr)
+			t.Fatalf("listings patch: %s", update.Stderr)
 		}
 
 		got := mustJSON(t, runCLI(t, "listings", "get", "--package", pkg, "--edit", editID, "--locale", "en-US", "--output", "json"), "listings get")


### PR DESCRIPTION
## Summary

The first live run of the Layer 2 mutation path failed in `edits validate`. This PR fixes the test to use `listings patch` instead of `listings update`.

## Why

`listings update` is a full PUT. It replaced the whole en-US listing inside the disposable edit and wiped both descriptions. `edits validate` then failed with `403: This app has no short description for language en-US`. The store was never affected — the edit is deleted without commit.

## Validation

- [x] The full live suite now passes locally against the real API with the compiled binary, including the mutation workflow: 5/5 subtests.
- [x] The disposable edit was deleted after every run; no listing change persists.