### PR TITLE
fix: compute fixture version code from used bundle codes

### DIFF
--- a/test/fixtureapp/release-internal.sh
+++ b/test/fixtureapp/release-internal.sh
@@ -21,21 +21,34 @@ for var in FIXTURE_KEYSTORE FIXTURE_KEYSTORE_PASSWORD FIXTURE_KEY_ALIAS FIXTURE_
   fi
 done
 
-# Version code: live readback of the internal track, plus one. This keeps
-# the version sequence of the app monotonic and small.
-echo "Reading current version codes on the $TRACK track..."
-RELEASES_JSON="$("$GPLAY" tracks releases list --package "$FIXTURE_PACKAGE" --track "$TRACK" --output json)"
-MAX_CODE="$(printf '%s' "$RELEASES_JSON" | python3 -c '
+# Version code: the store rejects any code that was ever uploaded, not only
+# the codes that are active on a track. The bundle and APK lists inside an
+# edit are the authoritative record of used codes, so we read those through
+# one disposable edit and delete the edit immediately.
+echo "Reading used version codes (bundles and APKs)..."
+EDIT_ID="$("$GPLAY" edits create --package "$FIXTURE_PACKAGE" --output json | python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])')"
+cleanup_edit() {
+  "$GPLAY" edits delete --package "$FIXTURE_PACKAGE" --edit "$EDIT_ID" --confirm >/dev/null 2>&1 || true
+}
+trap cleanup_edit EXIT
+
+BUNDLES_JSON="$("$GPLAY" bundles list --package "$FIXTURE_PACKAGE" --edit "$EDIT_ID" --output json)"
+APKS_JSON="$("$GPLAY" apks list --package "$FIXTURE_PACKAGE" --edit "$EDIT_ID" --output json)"
+cleanup_edit
+trap - EXIT
+
+MAX_CODE="$(printf '%s\n---\n%s' "$BUNDLES_JSON" "$APKS_JSON" | python3 -c '
 import json, sys
-data = json.load(sys.stdin)
+bundles_raw, apks_raw = sys.stdin.read().split("\n---\n")
 codes = []
-for release in data.get("releases") or []:
-    for code in release.get("versionCodes") or []:
-        codes.append(int(code))
+for artifact in (json.loads(bundles_raw).get("bundles") or []):
+    codes.append(int(artifact["versionCode"]))
+for artifact in (json.loads(apks_raw).get("apks") or []):
+    codes.append(int(artifact["versionCode"]))
 print(max(codes) if codes else 0)
 ')"
 NEXT_CODE=$((MAX_CODE + 1))
-echo "Max version code on $TRACK: $MAX_CODE; building $NEXT_CODE"
+echo "Max used version code: $MAX_CODE; building $NEXT_CODE"
 
 echo "Building fixture AAB..."
 (cd "$APP_DIR" && gradle --no-daemon bundleRelease "-PfixtureVersionCode=$NEXT_CODE")
@@ -57,8 +70,8 @@ import json, sys
 data = json.load(sys.stdin)
 codes = set()
 for release in data.get('releases') or []:
-    for code in release.get('versionCodes') or []:
-        codes.add(int(code))
+    for artifact in release.get('activeArtifacts') or []:
+        codes.add(int(artifact['versionCode']))
 expected = $NEXT_CODE
 if expected not in codes:
     raise SystemExit(f'readback failed: version code {expected} not on track, saw {sorted(codes)}')


### PR DESCRIPTION
## Summary
The first fixture-release run (32771441484) failed at the upload step with `403: Version code 1 has already been used`. The Gradle build and the signing worked. The version-code readback returned 0, so the script built code 1.

## Why
Two defects caused the wrong code:
1. The script parsed `releases[].versionCodes`. The real `tracks releases list` response carries `releases[].activeArtifacts[].versionCode`. The parser found no codes.
2. Active track codes are not sufficient. The store rejects every version code that was ever uploaded, active or not.

## What Changed
- The script now creates one disposable edit and reads `bundles list` and `apks list`. These lists are the authoritative record of used codes. The script deletes the edit immediately (trap on EXIT covers failures).
- The final readback verification now parses `activeArtifacts[].versionCode`.

## Quota
The version readback adds one edit per fixture-release run. The edit is deleted without a commit. The fixture-release job runs only on manual dispatch.

## Validation
- [x] Ran the version-code computation against the live app: `MAX_CODE=9 NEXT_CODE=10`. Codes 1-9 exist as bundles; the APK list is empty.
- [x] `bash -n` passes.
- [x] Pre-commit hook (format, lint, docs) passes.
- [ ] Fixture-release job passes on a fresh dispatch (will verify after merge).