### PR TITLE
test: expand live smoke coverage to 20 commands

### DIFF
--- a/docs/testing/command-coverage.json
+++ b/docs/testing/command-coverage.json
@@ -15,7 +15,7 @@
     "class": "offline"
   },
   "apks list": {
-    "class": "offline"
+    "class": "live"
   },
   "apks upload": {
     "class": "offline"
@@ -91,7 +91,7 @@
     "class": "offline"
   },
   "availability get": {
-    "class": "offline"
+    "class": "live"
   },
   "baseplans activate": {
     "class": "offline"
@@ -121,7 +121,7 @@
     "class": "offline"
   },
   "bundles list": {
-    "class": "offline"
+    "class": "live"
   },
   "bundles upload": {
     "class": "offline"
@@ -202,7 +202,7 @@
     "class": "offline"
   },
   "details get": {
-    "class": "offline"
+    "class": "live"
   },
   "details patch": {
     "class": "offline"
@@ -411,7 +411,7 @@
     "class": "offline"
   },
   "images list": {
-    "class": "offline"
+    "class": "live"
   },
   "images plan": {
     "class": "offline"
@@ -453,7 +453,7 @@
     "class": "offline"
   },
   "listings delete": {
-    "class": "offline"
+    "class": "live"
   },
   "listings delete-all": {
     "class": "offline"
@@ -470,7 +470,7 @@
     "class": "offline"
   },
   "listings patch": {
-    "class": "offline"
+    "class": "live"
   },
   "listings update": {
     "class": "live",
@@ -540,7 +540,7 @@
     "class": "offline"
   },
   "onetimeproducts list": {
-    "class": "offline"
+    "class": "live"
   },
   "onetimeproducts patch": {
     "class": "offline"
@@ -787,7 +787,7 @@
     "class": "offline"
   },
   "testers get": {
-    "class": "offline"
+    "class": "live"
   },
   "testers patch": {
     "class": "offline"
@@ -810,7 +810,7 @@
     "class": "offline"
   },
   "tracks releases list": {
-    "class": "offline"
+    "class": "live"
   },
   "tracks update": {
     "class": "offline"

--- a/internal/livesmoke/guard.go
+++ b/internal/livesmoke/guard.go
@@ -39,3 +39,14 @@ func ResourceName(runID, kind string) string {
 func IsManagedResourceName(name string) bool {
 	return strings.HasPrefix(name, NamePrefix+"-")
 }
+
+// ContractTestPrefix marks one-time products that the Go contract test
+// creates (see internal/cli/monetizationpricing/integration_test.go).
+const ContractTestPrefix = "ci_otp_"
+
+// IsJanitorTarget reports whether the janitor may delete the resource with
+// this name. Only names created by the live suite or the contract tests
+// qualify. Every other name is a foreign resource and must survive.
+func IsJanitorTarget(name string) bool {
+	return IsManagedResourceName(name) || strings.HasPrefix(name, ContractTestPrefix)
+}

--- a/internal/livesmoke/guard_test.go
+++ b/internal/livesmoke/guard_test.go
@@ -46,6 +46,33 @@ func TestResourceName_ContainsPrefixAndRunID(t *testing.T) {
 	}
 }
 
+func TestIsJanitorTarget(t *testing.T) {
+	targets := []string{
+		ResourceName("123", "product"),
+		"lsmoke-456-iap",
+		"ci_otp_20260824120000",
+	}
+	for _, name := range targets {
+		if !IsJanitorTarget(name) {
+			t.Fatalf("name %q must be a janitor target", name)
+		}
+	}
+	foreign := []string{
+		"",
+		"premium_upgrade",
+		"coins_100",
+		"sku_livesmoke",
+		"otp_ci_backwards",
+		"my_ci_otp_lookalike",
+		"lsmoke", // bare prefix without separator
+	}
+	for _, name := range foreign {
+		if IsJanitorTarget(name) {
+			t.Fatalf("foreign name %q must not be a janitor target", name)
+		}
+	}
+}
+
 func TestIsManagedResourceName(t *testing.T) {
 	if !IsManagedResourceName(ResourceName("123", "product")) {
 		t.Fatal("generated names must be recognized as managed")

--- a/internal/livesmoke/live_test.go
+++ b/internal/livesmoke/live_test.go
@@ -87,17 +87,31 @@ type result struct {
 // developer credentials cannot leak into test behavior or output.
 func runCLI(t *testing.T, args ...string) result {
 	t.Helper()
+	return runCLIEnv(t, nil, args...)
+}
+
+// runCLIEnv is runCLI with per-test environment overrides. A key in overrides
+// replaces the default value; the environment stays minimal and explicit.
+func runCLIEnv(t *testing.T, overrides map[string]string, args ...string) result {
+	t.Helper()
 	cmdtest.Build(t)
 
+	env := map[string]string{
+		"PATH":                       os.Getenv("PATH"),
+		"HOME":                       homeDir,
+		"GPLAY_CONFIG_PATH":          filepath.Join(homeDir, "config.json"),
+		"GPLAY_SERVICE_ACCOUNT_JSON": keyPath,
+		"GPLAY_SERVICE_ACCOUNT":      keyPath,
+		"GPLAY_NO_UPDATE":            "1",
+		"GPLAY_TIMEOUT":              "60s",
+	}
+	for k, v := range overrides {
+		env[k] = v
+	}
+
 	cmd := exec.Command(cmdtest.BinaryPath, args...)
-	cmd.Env = []string{
-		"PATH=" + os.Getenv("PATH"),
-		"HOME=" + homeDir,
-		"GPLAY_CONFIG_PATH=" + filepath.Join(homeDir, "config.json"),
-		"GPLAY_SERVICE_ACCOUNT_JSON=" + keyPath,
-		"GPLAY_SERVICE_ACCOUNT=" + keyPath,
-		"GPLAY_NO_UPDATE=1",
-		"GPLAY_TIMEOUT=60s",
+	for k, v := range env {
+		cmd.Env = append(cmd.Env, k+"="+v)
 	}
 
 	var stdout, stderr strings.Builder
@@ -123,6 +137,20 @@ func mustJSON(t *testing.T, r result, args ...string) map[string]any {
 	var parsed map[string]any
 	if err := json.Unmarshal([]byte(r.Stdout), &parsed); err != nil {
 		t.Fatalf("%v: stdout is not JSON: %v\nstdout: %s", args, err, r.Stdout)
+	}
+	return parsed
+}
+
+// mustJSONArray parses list output. Paginated list commands print a JSON
+// array (or null when empty), not an object.
+func mustJSONArray(t *testing.T, r result, args ...string) []map[string]any {
+	t.Helper()
+	if r.ExitCode != 0 {
+		t.Fatalf("%v: exit %d\nstderr: %s", args, r.ExitCode, r.Stderr)
+	}
+	var parsed []map[string]any
+	if err := json.Unmarshal([]byte(r.Stdout), &parsed); err != nil {
+		t.Fatalf("%v: stdout is not a JSON array: %v\nstdout: %s", args, err, r.Stdout)
 	}
 	return parsed
 }
@@ -167,6 +195,83 @@ func TestLive_InvalidEditID_FailsWithError(t *testing.T) {
 	}
 	if strings.TrimSpace(r.Stderr) == "" {
 		t.Fatal("failure must print an error on stderr")
+	}
+}
+
+func TestLive_TracksReleasesList_Shape(t *testing.T) {
+	parsed := mustJSON(t, runCLI(t, "tracks", "releases", "list", "--package", AllowedMutationPackage, "--track", "internal", "--output", "json"), "tracks releases list")
+
+	// The fixture-release script depends on this shape. A drift here broke
+	// the first fixture release (versionCodes vs activeArtifacts).
+	releases, _ := parsed["releases"].([]any)
+	if len(releases) == 0 {
+		t.Fatal("internal track must have at least one release")
+	}
+	release, _ := releases[0].(map[string]any)
+	artifacts, _ := release["activeArtifacts"].([]any)
+	if len(artifacts) == 0 {
+		t.Fatalf("release must carry activeArtifacts: %v", release)
+	}
+	artifact, _ := artifacts[0].(map[string]any)
+	if code, ok := artifact["versionCode"].(float64); !ok || code < 1 {
+		t.Fatalf("activeArtifacts[0].versionCode must be a positive number: %v", artifact)
+	}
+}
+
+func TestLive_OneTimeProductsList_ReturnsJSON(t *testing.T) {
+	mustJSON(t, runCLI(t, "onetimeproducts", "list", "--package", AllowedMutationPackage, "--output", "json"), "onetimeproducts list")
+}
+
+// --- Behavior smoke: safety promises against the real transport ---
+
+func TestLive_DryRun_InterceptsWrite(t *testing.T) {
+	r := runCLI(t, "--dry-run", "edits", "create", "--package", AllowedMutationPackage, "--output", "json")
+	if r.ExitCode != 0 {
+		t.Fatalf("dry-run must succeed: %s", r.Stderr)
+	}
+	if !strings.Contains(r.Stderr, "[DRY RUN]") || !strings.Contains(r.Stderr, "POST") {
+		t.Fatalf("stderr must log the intercepted POST: %s", r.Stderr)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(r.Stdout), &parsed); err != nil {
+		t.Fatalf("stdout must stay JSON: %v", err)
+	}
+	if id, _ := parsed["id"].(string); id != "" {
+		t.Fatalf("dry-run must not create an edit, got id %q", id)
+	}
+}
+
+func TestLive_CorruptKey_FailsCleanly(t *testing.T) {
+	corrupt := filepath.Join(homeDir, "corrupt-key.json")
+	if err := os.WriteFile(corrupt, []byte(`{"type":"service_account","private_key":"not-a-key"`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r := runCLIEnv(t, map[string]string{
+		"GPLAY_SERVICE_ACCOUNT_JSON": corrupt,
+		"GPLAY_SERVICE_ACCOUNT":      corrupt,
+	}, "apps", "list", "--output", "json")
+	if r.ExitCode == 0 {
+		t.Fatalf("a corrupt key must fail\nstdout: %s", r.Stdout)
+	}
+	if strings.TrimSpace(r.Stderr) == "" {
+		t.Fatal("failure must print an error on stderr")
+	}
+	if strings.Contains(r.Stderr, "not-a-key") || strings.Contains(r.Stdout, "not-a-key") {
+		t.Fatal("output must never echo key material")
+	}
+}
+
+func TestLive_TinyTimeout_FailsCleanly(t *testing.T) {
+	r := runCLIEnv(t, map[string]string{"GPLAY_TIMEOUT": "1ms"},
+		"reviews", "list", "--package", AllowedMutationPackage, "--output", "json")
+	if r.ExitCode == 0 {
+		t.Fatalf("a 1ms timeout must fail\nstdout: %s", r.Stdout)
+	}
+	if strings.TrimSpace(r.Stderr) == "" {
+		t.Fatal("timeout must print an error on stderr, not panic silently")
+	}
+	if strings.Contains(r.Stderr, "panic:") {
+		t.Fatalf("timeout must not panic: %s", r.Stderr)
 	}
 }
 
@@ -222,6 +327,46 @@ func TestLive_DisposableEditWorkflow(t *testing.T) {
 		mustJSON(t, runCLI(t, "listings", "list", "--package", pkg, "--edit", editID, "--output", "json"), "listings list")
 	})
 
+	t.Run("bundles list has used version codes", func(t *testing.T) {
+		parsed := mustJSON(t, runCLI(t, "bundles", "list", "--package", pkg, "--edit", editID, "--output", "json"), "bundles list")
+		// The fixture-release script computes the next version code from
+		// this list. The bundles must carry integer versionCode fields.
+		bundles, _ := parsed["bundles"].([]any)
+		if len(bundles) == 0 {
+			t.Fatal("the fixture app must have at least one uploaded bundle")
+		}
+		first, _ := bundles[0].(map[string]any)
+		if _, ok := first["versionCode"].(float64); !ok {
+			t.Fatalf("bundles[0].versionCode must be a number: %v", first)
+		}
+	})
+
+	t.Run("apks list", func(t *testing.T) {
+		mustJSON(t, runCLI(t, "apks", "list", "--package", pkg, "--edit", editID, "--output", "json"), "apks list")
+	})
+
+	t.Run("details get", func(t *testing.T) {
+		parsed := mustJSON(t, runCLI(t, "details", "get", "--package", pkg, "--edit", editID, "--output", "json"), "details get")
+		if lang, _ := parsed["defaultLanguage"].(string); lang == "" {
+			t.Fatalf("details must carry a default language: %v", parsed)
+		}
+	})
+
+	t.Run("testers get internal", func(t *testing.T) {
+		mustJSON(t, runCLI(t, "testers", "get", "--package", pkg, "--edit", editID, "--track", "internal", "--output", "json"), "testers get")
+	})
+
+	t.Run("availability get production", func(t *testing.T) {
+		// The API rejects the internal track for country availability, so
+		// this reads the production track. It is a read-only call; the
+		// suite never mutates the production track.
+		mustJSON(t, runCLI(t, "availability", "get", "--package", pkg, "--edit", editID, "--track", "production", "--output", "json"), "availability get")
+	})
+
+	t.Run("images list", func(t *testing.T) {
+		mustJSON(t, runCLI(t, "images", "list", "--package", pkg, "--edit", editID, "--locale", "en-US", "--type", "phoneScreenshots", "--output", "json"), "images list")
+	})
+
 	t.Run("listing patch and readback inside edit", func(t *testing.T) {
 		marker := ResourceName(runID, "t")
 		if len(marker) > 30 {
@@ -239,6 +384,36 @@ func TestLive_DisposableEditWorkflow(t *testing.T) {
 		got := mustJSON(t, runCLI(t, "listings", "get", "--package", pkg, "--edit", editID, "--locale", "en-US", "--output", "json"), "listings get")
 		if title, _ := got["title"].(string); title != marker {
 			t.Fatalf("readback title = %q, want %q", got["title"], marker)
+		}
+	})
+
+	t.Run("scratch locale create and delete inside edit", func(t *testing.T) {
+		// de-DE does not exist on the fixture app. Create it inside the
+		// disposable edit, read it back, then delete it again so the edit
+		// still validates (a title-only listing would fail validation).
+		marker := ResourceName(runID, "loc")
+		if len(marker) > 30 {
+			marker = marker[:30]
+		}
+		created := runCLI(t, "listings", "update", "--package", pkg, "--edit", editID,
+			"--locale", "de-DE", "--title", marker)
+		if created.ExitCode != 0 {
+			t.Fatalf("listings update de-DE: %s", created.Stderr)
+		}
+
+		got := mustJSON(t, runCLI(t, "listings", "get", "--package", pkg, "--edit", editID, "--locale", "de-DE", "--output", "json"), "listings get de-DE")
+		if title, _ := got["title"].(string); title != marker {
+			t.Fatalf("readback title = %q, want %q", got["title"], marker)
+		}
+
+		deleted := runCLI(t, "listings", "delete", "--package", pkg, "--edit", editID, "--locale", "de-DE", "--confirm")
+		if deleted.ExitCode != 0 {
+			t.Fatalf("listings delete de-DE: %s", deleted.Stderr)
+		}
+
+		after := runCLI(t, "listings", "get", "--package", pkg, "--edit", editID, "--locale", "de-DE", "--output", "json")
+		if after.ExitCode == 0 {
+			t.Fatalf("de-DE must be gone after delete\nstdout: %s", after.Stdout)
 		}
 	})
 
@@ -278,6 +453,9 @@ func TestLive_Cleanup(t *testing.T) {
 		case "iap":
 			r := runCLI(t, "iap", "delete", "--package", res.Package, "--sku", res.ID, "--confirm")
 			t.Logf("cleanup iap %s: exit %d", res.ID, r.ExitCode)
+		case "onetimeproduct":
+			r := runCLI(t, "onetimeproducts", "delete", "--package", res.Package, "--product-id", res.ID, "--confirm")
+			t.Logf("cleanup onetimeproduct %s: exit %d", res.ID, r.ExitCode)
 		default:
 			t.Errorf("ledger entry with unknown kind %q: manual cleanup needed for %+v", res.Kind, res)
 		}
@@ -293,22 +471,47 @@ func TestLive_Janitor(t *testing.T) {
 		t.Skip("skipping janitor; set GPLAY_LIVE_SMOKE_JANITOR=1")
 	}
 	pkg := AllowedMutationPackage
-	parsed := mustJSON(t, runCLI(t, "iap", "list", "--package", pkg, "--paginate", "--output", "json"), "iap list")
-
-	products, _ := parsed["inappproduct"].([]any)
 	removed := 0
-	for _, p := range products {
-		product, _ := p.(map[string]any)
-		sku, _ := product["sku"].(string)
-		if !IsManagedResourceName(sku) {
+
+	// Legacy in-app products created by the live suite (lsmoke-*). The
+	// fixture app uses the new monetization model, so the legacy
+	// inappproducts API refuses all calls with 403. That leaves nothing
+	// to sweep; skip instead of failing.
+	iapList := runCLI(t, "iap", "list", "--package", pkg, "--paginate", "--output", "json")
+	if iapList.ExitCode != 0 && strings.Contains(iapList.Stderr, "migrate to the new publishing API") {
+		t.Log("janitor: legacy iap API is unavailable for this app; skipping the legacy sweep")
+	} else {
+		for _, product := range mustJSONArray(t, iapList, "iap list") {
+			sku, _ := product["sku"].(string)
+			if !IsJanitorTarget(sku) {
+				continue
+			}
+			if err := EnsureMutationAllowed(pkg); err != nil {
+				t.Fatal(err)
+			}
+			r := runCLI(t, "iap", "delete", "--package", pkg, "--sku", sku, "--confirm")
+			if r.ExitCode != 0 {
+				t.Errorf("janitor: deleting %s failed: %s", sku, r.Stderr)
+				continue
+			}
+			removed++
+		}
+	}
+
+	// One-time products: the Go contract test creates ci_otp_* fixtures
+	// (see internal/cli/monetizationpricing). A crashed run leaks them.
+	otps := mustJSONArray(t, runCLI(t, "onetimeproducts", "list", "--package", pkg, "--paginate", "--output", "json"), "onetimeproducts list")
+	for _, product := range otps {
+		productID, _ := product["productId"].(string)
+		if !IsJanitorTarget(productID) {
 			continue
 		}
 		if err := EnsureMutationAllowed(pkg); err != nil {
 			t.Fatal(err)
 		}
-		r := runCLI(t, "iap", "delete", "--package", pkg, "--sku", sku, "--confirm")
+		r := runCLI(t, "onetimeproducts", "delete", "--package", pkg, "--product-id", productID, "--confirm")
 		if r.ExitCode != 0 {
-			t.Errorf("janitor: deleting %s failed: %s", sku, r.Stderr)
+			t.Errorf("janitor: deleting one-time product %s failed: %s", productID, r.Stderr)
 			continue
 		}
 		removed++


### PR DESCRIPTION
## Summary
The live smoke suite now covers 20 commands (was 10). The quota cost stays at one disposable edit per run. Two latent janitor defects are fixed.

## What Changed
**Disposable edit — six new read subtests, zero extra quota:**
`bundles list` (asserts the versionCode shape the fixture-release script depends on), `apks list`, `details get`, `testers get`, `availability get` (production track — the API rejects internal for country availability), `images list`.

**Scratch locale cycle inside the edit:** create a de-DE listing with `listings update`, read it back, delete it with `listings delete`. The delete runs before `edits validate`, so the edit still validates.

**New read-only tests:** `tracks releases list` shape assertion (`activeArtifacts[].versionCode` — the drift that broke the first fixture release), `onetimeproducts list`.

**New behavior tests:** `--dry-run` intercepts the write and creates no edit; a corrupt key fails cleanly with no key material in the output; a 1ms timeout fails cleanly without a panic.

**Janitor:** now sweeps one-time products with the `lsmoke-` and `ci_otp_` prefixes. `IsJanitorTarget` in the guard enforces the allowlist (TDD, hermetic test).

**Two janitor bugs fixed:**
1. Paginated list commands print a JSON array, not an object. The old parse would crash on the first real sweep.
2. The legacy `iap` API returns 403 for apps on the new monetization model. The sweep now skips it with a log line.

## Coverage manifest
Ten commands move from `offline` to `live`. Total: 20 live, 2 sandbox, 272 offline.

## Safety
- The suite still creates exactly one edit and never commits it.
- The mutation guard still refuses every package except the fixture app.
- The availability read on the production track is read-only; no production mutation exists in the suite.

## Validation
- [x] Guard test written first and failed for the right reason, then passed.
- [x] All read-only and behavior tests passed live (9/9).
- [x] The disposable edit workflow passed live with 12 subtests.
- [x] The janitor passed live (legacy sweep skipped, OTP sweep ran).
- [x] `make dev` passes (format, lint, tests, build).
- [x] Pre-commit hook passes.