### PR TITLE
fix: send the official applications parent for external transaction create

### DIFF
--- a/internal/cli/externaltx/externaltx.go
+++ b/internal/cli/externaltx/externaltx.go
@@ -112,7 +112,9 @@ For recurring subscriptions, use "recurringTransaction" instead of "oneTimeTrans
 			ctx, cancel := shared.ContextWithTimeout(ctx, service.Cfg)
 			defer cancel()
 
-			resp, err := service.API.Externaltransactions.Createexternaltransaction(pkg, &tx).Context(ctx).ExternalTransactionId(*externalTxID).Do()
+			// The parent resource name format is: applications/{packageName}
+			parent := fmt.Sprintf("applications/%s", pkg)
+			resp, err := service.API.Externaltransactions.Createexternaltransaction(parent, &tx).Context(ctx).ExternalTransactionId(*externalTxID).Do()
 			if err != nil {
 				return err
 			}

--- a/internal/cli/externaltx/externaltx_test.go
+++ b/internal/cli/externaltx/externaltx_test.go
@@ -1,0 +1,94 @@
+package externaltx
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/tamtom/play-console-cli/internal/playclient"
+)
+
+// mockService points the generated client at a local server and records the
+// request path, so the test asserts the exact official URL.
+func mockService(t *testing.T, record func(*http.Request)) context.Context {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		record(r)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	t.Cleanup(server.Close)
+	return playclient.ContextWithServiceFactory(context.Background(),
+		func(ctx context.Context) (*playclient.Service, error) {
+			return playclient.NewServiceWithClient(ctx, server.Client(), server.URL+"/")
+		})
+}
+
+// The official createexternaltransaction method requires the parent in the
+// form applications/{packageName}. A bare package name produces a URL the
+// API rejects.
+func TestCreate_UsesOfficialApplicationsParent(t *testing.T) {
+	var gotPath string
+	ctx := mockService(t, func(r *http.Request) { gotPath = r.URL.Path })
+
+	cmd := CreateCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--package", "com.example.app",
+		"--external-transaction-id", "tx-1",
+		"--json", `{"originalPreTaxAmount":{"priceMicros":"9990000","currency":"EUR"}}`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Exec(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "/androidpublisher/v3/applications/com.example.app/externalTransactions"
+	if gotPath != want {
+		t.Fatalf("request path = %q, want %q", gotPath, want)
+	}
+}
+
+func TestGet_UsesOfficialResourceName(t *testing.T) {
+	var gotPath string
+	ctx := mockService(t, func(r *http.Request) { gotPath = r.URL.Path })
+
+	cmd := GetCommand()
+	if err := cmd.FlagSet.Parse([]string{"--package", "com.example.app", "--external-transaction-id", "tx-1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Exec(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "/androidpublisher/v3/applications/com.example.app/externalTransactions/tx-1"
+	if gotPath != want {
+		t.Fatalf("request path = %q, want %q", gotPath, want)
+	}
+}
+
+func TestRefund_UsesOfficialResourceName(t *testing.T) {
+	var gotPath string
+	ctx := mockService(t, func(r *http.Request) { gotPath = r.URL.Path })
+
+	cmd := RefundCommand()
+	if err := cmd.FlagSet.Parse([]string{
+		"--package", "com.example.app",
+		"--external-transaction-id", "tx-1",
+		"--json", `{"refundTime":"2026-08-24T00:00:00Z"}`,
+		"--confirm",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Exec(ctx, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "/androidpublisher/v3/applications/com.example.app/externalTransactions/tx-1:refund"
+	if !strings.HasPrefix(gotPath, want) {
+		t.Fatalf("request path = %q, want prefix %q", gotPath, want)
+	}
+}


### PR DESCRIPTION
## Summary
`gplay external-transactions create` could never succeed. It sent a malformed parent, so every call went to the wrong URL.

Found during a full audit of CLI coverage against the official Android Publisher REST API.

## Why
The official `androidpublisher.externaltransactions.createexternaltransaction` method requires `parent` to match `^applications/[^/]+$`. The URL template is `androidpublisher/v3/{+parent}/externalTransactions`.

The command passed the bare package name (`internal/cli/externaltx/externaltx.go:115`), so the request went to:
```
/androidpublisher/v3/com.example.app/externalTransactions          (wrong)
/androidpublisher/v3/applications/com.example.app/externalTransactions   (correct)
```

The sibling `get` and `refund` commands already built the name correctly. Only `create` was wrong.

## What Changed
- `create` now builds `applications/{packageName}` as the parent.
- The package had **no test file at all**, which is why nothing caught this. Added request-path tests for `create`, `get`, and `refund` that assert the exact official URL against a local test server.

## Validation
- [x] Wrote the test first. It failed with the exact wrong path: `request path = "/androidpublisher/v3/com.example.app/externalTransactions"`.
- [x] All three tests pass after the fix.
- [x] `make dev` passes (format, lint, tests, build).
- [x] No live API call was needed or made; the tests use a local httptest server.