### PR TITLE
fix: restrict GPLAY_API_BASE_URL to loopback hosts

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -124,6 +124,7 @@ gplay auth doctor --fix --confirm
 | `GPLAY_MAX_RETRIES` | Max retries for failed requests (default: 3) |
 | `GPLAY_RETRY_DELAY` | Base delay between retries (default: `1s`) |
 | `GPLAY_DEFAULT_OUTPUT` | Default output format (`json`, `table`, `markdown`) |
+| `GPLAY_API_BASE_URL` | Test only. Points the API client at a local sandbox server. Loopback hosts only; any other host is refused because the client attaches the OAuth token to the request. |
 
 ## Config File
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > Release notes for **0.5.0 – 0.7.1** were auto-generated and live in
 > [GitHub Releases](https://github.com/tamtom/play-console-cli/releases).
 
+## [0.9.2] - 2026-08-25
+
+### Security
+
+- `GPLAY_API_BASE_URL` now accepts loopback hosts only. The API client attaches
+  the OAuth bearer token to every request, so a non-loopback value made the CLI
+  send a live Google access token to that host. Any other value is now refused
+  with an error instead of being ignored. The command fails closed, because a
+  silent fallback would let a hermetic test reach the real Play API. The
+  variable is for local testing only and is documented as such.
+
+### Fixed
+
+- `gplay external-transactions create` now sends the parent in the official
+  `applications/{packageName}` format. The command sent a bare package name, so
+  every call went to the wrong URL and failed. The `get` and `refund`
+  subcommands were already correct.
+
+### Testing
+
+- Verified all 218 official Google Play API methods against the live discovery
+  documents and confirmed each one is reachable from a command.
+- Added request-path tests for the three `external-transactions` subcommands.
+  The package had no tests before.
+- Expanded the live smoke suite from 10 to 20 commands and added a hermetic
+  sandbox for black-box tests of the compiled binary.
+
 ## [0.9.1] - 2026-08-24
 
 ### Fixed

--- a/internal/playclient/baseurl_test.go
+++ b/internal/playclient/baseurl_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/tamtom/play-console-cli/internal/testutil"
@@ -41,6 +42,56 @@ func TestNewService_HonorsBaseURLOverride(t *testing.T) {
 	}
 	if gotPath == "" {
 		t.Fatal("the request did not reach the sandbox server")
+	}
+}
+
+// The override attaches the OAuth bearer token to every request it sends.
+// A non-loopback host would therefore receive a live Google access token,
+// so NewService must refuse it. It must fail closed: silently falling back
+// to the real API would let a "hermetic" test hit production instead.
+func TestNewService_RefusesNonLoopbackBaseURL(t *testing.T) {
+	for _, base := range []string{
+		"https://evil.example.com",
+		"http://10.0.0.5:8080",
+		"https://androidpublisher.googleapis.com.evil.example",
+		"not-a-url",
+		"file:///etc/passwd",
+	} {
+		t.Run(base, func(t *testing.T) {
+			t.Setenv("GPLAY_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+			t.Setenv("GPLAY_SERVICE_ACCOUNT_JSON", testutil.SandboxServiceAccount(t, "https://oauth2.googleapis.com/token"))
+			t.Setenv("GPLAY_API_BASE_URL", base)
+
+			_, err := NewService(context.Background())
+			if err == nil {
+				t.Fatalf("base URL %q must be refused", base)
+			}
+			if !strings.Contains(err.Error(), "GPLAY_API_BASE_URL") {
+				t.Fatalf("error must name the variable, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewService_AcceptsLoopbackBaseURL(t *testing.T) {
+	for _, base := range []string{
+		"http://127.0.0.1:8080",
+		"http://localhost:9999",
+		"http://[::1]:8080",
+	} {
+		t.Run(base, func(t *testing.T) {
+			t.Setenv("GPLAY_CONFIG_PATH", filepath.Join(t.TempDir(), "config.json"))
+			t.Setenv("GPLAY_SERVICE_ACCOUNT_JSON", testutil.SandboxServiceAccount(t, "https://oauth2.googleapis.com/token"))
+			t.Setenv("GPLAY_API_BASE_URL", base)
+
+			service, err := NewService(context.Background())
+			if err != nil {
+				t.Fatalf("loopback base URL %q must be accepted: %v", base, err)
+			}
+			if service.API.BasePath != base+"/" {
+				t.Fatalf("BasePath = %q, want %q", service.API.BasePath, base+"/")
+			}
+		})
 	}
 }
 

--- a/internal/playclient/service.go
+++ b/internal/playclient/service.go
@@ -3,7 +3,10 @@ package playclient
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -51,7 +54,11 @@ func NewService(ctx context.Context) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	if base := sandboxBaseURL(); base != "" {
+	base, err := sandboxBaseURL()
+	if err != nil {
+		return nil, err
+	}
+	if base != "" {
 		api.BasePath = base
 	}
 	return &Service{API: api, Cfg: cfg}, nil
@@ -60,15 +67,35 @@ func NewService(ctx context.Context) (*Service, error) {
 // sandboxBaseURL returns the GPLAY_API_BASE_URL override, normalized to end
 // with a slash. The override points the client at a local sandbox server for
 // hermetic black-box tests. It is not a supported production setting.
-func sandboxBaseURL() string {
+//
+// The client attaches the OAuth bearer token to every request it sends, so a
+// non-loopback host would receive a live Google access token. Only loopback
+// hosts are accepted. An invalid value is an error rather than a silent
+// fallback: a hermetic test must fail instead of reaching the real API.
+func sandboxBaseURL() (string, error) {
 	base := strings.TrimSpace(os.Getenv("GPLAY_API_BASE_URL"))
 	if base == "" {
-		return ""
+		return "", nil
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		return "", fmt.Errorf("GPLAY_API_BASE_URL must be an http or https URL on a loopback host, got %q", base)
+	}
+	if !isLoopbackHost(parsed.Hostname()) {
+		return "", fmt.Errorf("GPLAY_API_BASE_URL must point at a loopback host; %q would receive the OAuth access token", base)
 	}
 	if !strings.HasSuffix(base, "/") {
 		base += "/"
 	}
-	return base
+	return base, nil
+}
+
+func isLoopbackHost(host string) bool {
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
 }
 
 // NewAuthenticatedClient returns an HTTP client authenticated with the


### PR DESCRIPTION
## Summary
`GPLAY_API_BASE_URL` shipped in v0.9.1+ code with no restriction on the destination host. The API client attaches the OAuth bearer token to every request, so setting that variable to any host made the CLI send a **live Google access token** to it.

Found while reviewing what has landed since v0.9.1, before cutting a release.

## Why this matters
`NewService` builds the HTTP client with `oauth2.NewClient`, which attaches the token unconditionally, and only then overrides `api.BasePath`. The destination changes; the credential does not.

I verified it rather than assuming. A test pointed the override at a local server and recorded the inbound request:
```
destination host: 127.0.0.1:49626
Authorization header sent: "Bearer SECRET-TOKEN"
```
With a real service account that is a real Google token going to whatever host the variable names. This directly contradicts the project's own "no developer credentials leaked" rule.

Threat model: an attacker needs to set an environment variable — CI env injection, a compromised workflow, or a shared machine. It is a credential-exfiltration amplifier, not a remote exploit, but it should not ship.

## What Changed
- `NewService` accepts **loopback hosts only** (`127.0.0.1`, `::1`, `localhost`).
- Any other value is refused **with an error**, not ignored. This fails closed on purpose: a silent fallback would let a supposedly hermetic test quietly hit the real Play API.
- Non-http/https schemes and unparseable values are refused too.
- Documented the variable in Agents.md as test only.

## Validation
- [x] Wrote the tests first; all five hostile values (`https://evil.example.com`, `http://10.0.0.5:8080`, a suffix-confusion host, `not-a-url`, `file:///etc/passwd`) were accepted before the fix and are refused after.
- [x] Loopback values still work, including `[::1]`.
- [x] The hermetic sandbox black-box suite (`internal/cmdtest`, `internal/sandbox`) still passes, so testing is unaffected.
- [x] `make dev` passes.

## Release note
This is a prerequisite for the next release. It should go out together with the `external-transactions create` fix (#270).