### PR TITLE
fix: suggest GitHub star after metadata push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- A one-time GitHub star suggestion after a successful edit commit or release,
+- A one-time GitHub star suggestion after a successful metadata push, edit commit, or release,
   shown on stderr only when `gh` is installed. Agents must obtain an explicit
   yes before running the suggested command. The CLI never waits for input or
   stars automatically; set `GPLAY_NO_STAR_PROMPT=1` to suppress the suggestion.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ irm https://raw.githubusercontent.com/tamtom/play-console-cli/main/install.ps1 |
 
 **Update:** `gplay update` self-updates in place. It also checks for new versions on startup (disable with `GPLAY_NO_UPDATE=1`).
 
-After your first successful edit commit or release with `gh` installed, gplay
+After your first successful metadata push, edit commit, or release with `gh` installed, gplay
 prints an optional star suggestion to stderr. It never waits for input or
 stars automatically: agents must ask you first. Set `GPLAY_NO_STAR_PROMPT=1`
 to suppress the suggestion. See [configuration](docs/configuration.md).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ gplay init --package com.example.app --service-account /path/to/sa.json
 
 ## Output formats
 
-After a successful `edits commit`, `release`, or `publish track`, gplay prints
+After a successful `metadata push`, `edits commit`, `release`, or `publish track`, gplay prints
 a one-time GitHub star suggestion to stderr if `gh` is on PATH. Metadata
 updates qualify when their edit is committed. The CLI never waits for input,
 runs `gh`, or stars a repository automatically; JSON stdout is unchanged.

--- a/internal/cli/metadata/push.go
+++ b/internal/cli/metadata/push.go
@@ -99,7 +99,13 @@ Examples:
 				"dryRun":  *dryRun,
 				"status":  "pushed",
 			}
-			return shared.PrintOutputContext(ctx, result, *outputFlag, *pretty)
+			if err := shared.PrintOutputContext(ctx, result, *outputFlag, *pretty); err != nil {
+				return err
+			}
+			if !*dryRun {
+				shared.SuggestGitHubStar(ctx)
+			}
+			return nil
 		},
 	}
 }

--- a/internal/cmdtest/star_suggestion_test.go
+++ b/internal/cmdtest/star_suggestion_test.go
@@ -80,6 +80,32 @@ func TestStarSuggestion_ReleaseSharesOneTimeStateWithCommit(t *testing.T) {
 	}
 }
 
+func TestStarSuggestion_MetadataPushSuggestsOnceAfterRealSubmission(t *testing.T) {
+	setupStarSuggestion(t)
+	dir := t.TempDir()
+	localeDir := filepath.Join(dir, "en-US")
+	if err := os.Mkdir(localeDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(localeDir, "title.txt"), []byte("Updated title"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, attempt := range []string{"dry run", "first push", "second push"} {
+		args := []string{"metadata", "push", "--package", sandbox.Package, "--dir", dir, "--confirm"}
+		if attempt == "dry run" {
+			args = append(args, "--dry-run")
+		}
+		result := cmdtest.Run(t, args...)
+		if result.ExitCode != 0 || !json.Valid([]byte(result.Stdout)) {
+			t.Fatalf("%s failed or stdout is not JSON: %+v", attempt, result)
+		}
+		wantSuggestion := attempt == "first push"
+		if got := strings.Contains(result.Stderr, "Would you like to star"); got != wantSuggestion {
+			t.Errorf("%s suggestion = %t, want %t: %q", attempt, got, wantSuggestion, result.Stderr)
+		}
+	}
+}
+
 func TestStarSuggestion_SkippedAttemptsDoNotConsumeSuggestion(t *testing.T) {
 	for _, scenario := range []string{"no gh", "dry run", "failure", "read", "opt out"} {
 		t.Run(scenario, func(t *testing.T) {


### PR DESCRIPTION
`metadata push --confirm` commits its edit directly, so it did not show the new one-time GitHub star suggestion. Show the shared suggestion after a successful push and output, and preserve it during local `--dry-run` previews.

The compiled CLI regression covers a preview followed by two successful pushes, asserting valid JSON and exactly one suggestion. The test failed before the fix and passes afterward. Full race-enabled tests, formatting, generated docs, and lint pass.
